### PR TITLE
Unified Notification Listener

### DIFF
--- a/src/operon.ts
+++ b/src/operon.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Pool, PoolConfig, Notification, Client, PoolClient } from 'pg';
+import { Pool, PoolConfig, Notification, PoolClient } from 'pg';
 import { OperonWorkflow, WorkflowContext, WorkflowParams } from './workflow';
 import { v1 as uuidv1 } from 'uuid';
 import { OperonTransaction } from './transaction';

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /*eslint-disable no-constant-condition */
 import { operon__FunctionOutputs, operon__Notifications } from './operon';
-import { Pool, PoolClient, Notification, DatabaseError } from 'pg';
+import { Pool, PoolClient, DatabaseError } from 'pg';
 import { OperonTransaction, TransactionContext } from './transaction';
 import { OperonCommunicator, CommunicatorContext, CommunicatorParams } from './communicator';
 import { OperonError } from './error';
@@ -172,11 +172,11 @@ export class WorkflowContext {
     const { rows }  = await client.query(`INSERT INTO operon__Notifications (key, message) VALUES ($1, $2) ON CONFLICT (key) DO NOTHING RETURNING 'Success';`,
       [key, JSON.stringify(message)])
     // Return true if successful, false if key already exists.
-    const success: boolean = rows.length === 0;
+    const success: boolean = (rows.length !== 0);
     await this.recordExecution<boolean>(client, functionID, success, null);
     await client.query("COMMIT");
     client.release();
-    return rows.length !== 0;
+    return success;
   }
 
   async recv<T extends NonNullable<any>>(key: string, timeoutSeconds: number) : Promise<T | null> {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -29,6 +29,27 @@ describe('concurrency-tests', () => {
     await operon.destroy();
   });
 
+  test('operon-error', async() => {
+    const testCommunicator = async (ctxt: CommunicatorContext, code?: number) => {
+      void ctxt;
+      await sleep(1);
+      if (code) {
+        throw new OperonError("test operon error with code.", code);
+      } else {
+        throw new OperonError("test operon error without code");
+      }
+    };
+
+    const testWorkflow = async (ctxt: WorkflowContext, code?: number) => {
+      return await ctxt.external(testCommunicator, {retriesAllowed: false}, code);
+    };
+
+    await expect(operon.workflow(testWorkflow, {}, 11)).rejects.toThrowError(new OperonError("test operon error with code.", 11));
+
+    // Test without code.
+    await expect(operon.workflow(testWorkflow, {})).rejects.toThrowError(new OperonError("test operon error without code"));
+  });
+
   test('simple-keyconflict', async() => {
     let counter: number = 0;
     let succeedUUID: string = '';

--- a/tests/operon.test.ts
+++ b/tests/operon.test.ts
@@ -238,13 +238,38 @@ describe('operon-tests', () => {
   });
 
   test('simple-operon-notifications', async() => {
-    const workflowUUID = uuidv1();
-    const promise = operon.recv({workflowUUID: workflowUUID}, "test", 2);
+    // Send and have a receiver waiting.
+    const promise = operon.recv({}, "test", 2);
     const send = await operon.send({}, "test", 123);
     expect(send).toBe(true);
     expect(await promise).toBe(123);
-    const retry = await operon.recv({workflowUUID: workflowUUID}, "test", 2);
-    expect(retry).toBe(123);
+
+    // Send and then receive.
+    await expect(operon.send({}, "test2", 456)).resolves.toBe(true);
+    await sleep(10);
+    await expect(operon.recv({}, "test2", 1)).resolves.toBe(456);
+  });
+
+  test('notification-oaoo',async () => {
+    const sendWorkflowUUID = uuidv1();
+    const recvWorkflowUUID = uuidv1();
+    const promise = operon.recv({workflowUUID: recvWorkflowUUID}, "test", 1);
+    const send = await operon.send({workflowUUID: sendWorkflowUUID}, "test", 123);
+    expect(send).toBe(true);
+
+    expect(await promise).toBe(123);
+
+    // Send again with the same UUID but different input.
+    // Even we sent it twice, it should still be 123.
+    await expect(operon.send({workflowUUID: sendWorkflowUUID}, "test", 123)).resolves.toBe(true);
+
+    await expect(operon.recv({workflowUUID: recvWorkflowUUID}, "test", 1)).resolves.toBe(123);
+
+    // Receive again with the same workflowUUID, should get the same result.
+    await expect(operon.recv({workflowUUID: recvWorkflowUUID}, "test", 1)).resolves.toBe(123);
+
+    // Receive again with the different workflowUUID.
+    await expect(operon.recv({}, "test", 2)).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
Use a single global listener for Postgres notifications and communicate with `recv` calls via Promises.  Avoids an issue where every `recv` requires its own client, quickly exhausting the pool of clients.