### PR TITLE
always load Operon schema at init

### DIFF
--- a/src/operon.ts
+++ b/src/operon.ts
@@ -116,9 +116,9 @@ export class Operon {
       if (dbExists.rows.length === 0) {
         // Create the Operon system database
         await this.pgSystemClient.query(`CREATE DATABASE ${databaseName}`);
-        // Load the Operon system schema
-        await this.pool.query(operonSystemDbSchema);
       }
+      // Load the Operon system schema
+      await this.pool.query(operonSystemDbSchema);
     } finally {
       // We want to close the client no matter what
       await this.pgSystemClient.end();


### PR DESCRIPTION
Small PR to make sure we always attempt to load the Operon system schema. Previously we would only be doing it if the database did not exists.

Tested within https://github.com/dbos-inc/operon-demo-apps/pull/7