### PR TITLE
Update some import paths to be relative to their files.

### DIFF
--- a/src/operon.ts
+++ b/src/operon.ts
@@ -18,11 +18,10 @@ import {
   POSTGRES_EXPORTER,
 } from './telemetry';
 import { Pool, PoolConfig, Client } from 'pg';
-import { userDBSchema, transaction_outputs } from 'schemas/user_db_schema';
-import { SystemDatabase, PostgresSystemDatabase } from 'src/system_database';
+import { userDBSchema, transaction_outputs } from '../schemas/user_db_schema';
+import { SystemDatabase, PostgresSystemDatabase } from './system_database';
 import { v4 as uuidv4 } from 'uuid';
 import YAML from 'yaml';
-
 
 export interface OperonNull {}
 export const operonNull: OperonNull = {};

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -5,7 +5,7 @@ import { operonNull, OperonNull } from "./operon";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from 'pg';
 import { OperonWorkflowConflictUUIDError } from "./error";
 import { StatusString, WorkflowStatus } from "./workflow";
-import { systemDBSchema, notifications, operation_outputs, workflow_status } from 'schemas/system_db_schema';
+import { systemDBSchema, notifications, operation_outputs, workflow_status } from '../schemas/system_db_schema';
 import { sleep } from "./utils";
 
 export interface SystemDatabase {


### PR DESCRIPTION
Import paths in the Operon project have to be relative to the file, rather than to `package.json`
This is because, when operon is imported as a npm package, paths will all be relative to the *parent* project, importing operon.

