### PR TITLE
Basic SSL Support

### DIFF
--- a/src/operon.ts
+++ b/src/operon.ts
@@ -61,7 +61,7 @@ interface ConfigFile {
     connectionTimeoutMillis: number;
     user_database: string;
     system_database: string;
-    ssl?: string;
+    ssl_ca?: string;
   };
   telemetryExporters?: string[];
 }
@@ -237,8 +237,8 @@ export class Operon {
       connectionTimeoutMillis: config.database.connectionTimeoutMillis,
       database: config.database.user_database,
     };
-    if (config.database.ssl) {
-      poolConfig.ssl = { ca: [readFileSync(config.database.ssl)], rejectUnauthorized: true };
+    if (config.database.ssl_ca) {
+      poolConfig.ssl = { ca: [readFileSync(config.database.ssl_ca)], rejectUnauthorized: true };
     }
     return {
       poolConfig: poolConfig,


### PR DESCRIPTION
Small PR allowing specification of an SSL root certificate to securely connect to a database using SSL/TLS.  This is required to connect to an RDS instance.

To specify a root certificate, set the `ssl_ca` parameter in `operon_config.yaml` to a path to the certificate file in PEM format.

This is equivalent to running `psql sslrootcert=/path/to/rootcert/pem/file`

Documentation on SSL for RDS Postgres for reference: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html