### PR TITLE
Export Postgres transaction ID

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -210,7 +210,6 @@ export class WorkflowContext extends OperonContext {
           await this.recordGuardedOutput<R>(client, funcId, result);
 
           // Obtain the transaction ID.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           const pg_txn_id = (await this.#operon.userDatabase.queryWithClient<PgTransactionId>(client, "select CAST(pg_current_xact_id() AS TEXT) as txid;"))[0].txid;
           tCtxt.span.setAttribute("postgres_transaction_id", pg_txn_id);
           this.resultBuffer.clear();


### PR DESCRIPTION
This is a small PR that obtains the transaction ID of non read-only transactions and adds it as an attribute to the tracing span. This information will be useful to our provenance system where we can link each transaction back to its workflowUUID and function ID.

To see the effect, you need to enable `JAEGER_EXPORTER` in Operon config, start a Jaeger server, and run some tests. Then, you'll be able to see `postgres_transaction_id` for transactions that are not marked as read-only.