### PR TITLE
Devhawk/ESM

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   testRegex: '((\\.|/)(test|spec))\\.ts?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
@@ -12,4 +12,17 @@ module.exports = {
   setupFiles: [
     './jest.setup.ts'
   ],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@prisma/client": "^5.1.1",
+        "@tsconfig/node18": "^18.2.1",
         "@types/jest": "^29.5.3",
         "@types/lodash": "^4.14.197",
         "@types/pg": "^8.10.2",
@@ -1450,6 +1451,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.1.tgz",
+      "integrity": "sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Operon",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "build-fdb": "tsc --project tsconfig.build-fdb.json",
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@prisma/client": "^5.1.1",
+    "@tsconfig/node18": "^18.2.1",
     "@types/jest": "^29.5.3",
     "@types/lodash": "^4.14.197",
     "@types/pg": "^8.10.2",

--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -1,7 +1,7 @@
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { Logger } from "./telemetry";
-import { WorkflowContext } from "./workflow";
-import { OperonContext } from "./context";
+import { Logger } from "./telemetry/index.js";
+import { WorkflowContext } from "./workflow.js";
+import { OperonContext } from "./context.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type OperonCommunicator<T extends any[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -20,11 +20,11 @@
 import "reflect-metadata";
 
 import * as crypto from "crypto";
-import { TransactionConfig, TransactionContext } from "./transaction";
-import { WorkflowConfig, WorkflowContext } from "./workflow";
-import { CommunicatorContext } from "./communicator";
-import { OperonContext } from "./context";
-import { OperonDataValidationError } from "./error";
+import { TransactionConfig, TransactionContext } from "./transaction.js";
+import { WorkflowConfig, WorkflowContext } from "./workflow.js";
+import { CommunicatorContext } from "./communicator.js";
+import { OperonContext } from "./context.js";
+import { OperonDataValidationError } from "./error.js";
 
 /**
  * Any column type column can be.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 export {
   Operon,
   OperonConfig,
-} from './operon';
+} from './operon.js';
 
 export {
   OperonContext,
-} from './context';
+} from './context.js';
 
 export {
   TransactionContext,
   TransactionConfig,
   OperonTransaction as OperonTransactionFunction,
-} from './transaction';
+} from './transaction.js';
 
 export {
   WorkflowContext,
@@ -20,11 +20,11 @@ export {
   WorkflowHandle,
   StatusString,
   OperonWorkflow as OperonWorkflowFunction,
-} from './workflow';
+} from './workflow.js';
 
 export {
   CommunicatorContext
-} from './communicator';
+} from './communicator.js';
 
 export {
   OperonError,
@@ -32,7 +32,7 @@ export {
   OperonTopicPermissionDeniedError,
   OperonWorkflowPermissionDeniedError,
   OperonDataValidationError,
-} from './error';
+} from './error.js';
 
 export {
   OperonFieldType,
@@ -61,4 +61,4 @@ export {
   OperonWorkflow,
 
   forEachMethod,
-} from "./decorators";
+} from "./decorators.js";

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -5,7 +5,7 @@ import {
   OperonInitializationError,
   OperonWorkflowConflictUUIDError,
   OperonNotRegisteredError,
-} from './error';
+} from './error.js';
 import {
   InvokedHandle,
   OperonWorkflow,
@@ -14,11 +14,11 @@ import {
   WorkflowHandle,
   WorkflowParams,
   RetrievedHandle,
-} from './workflow';
+} from './workflow.js';
 
-import { OperonTransaction, TransactionConfig } from './transaction';
-import { CommunicatorConfig, OperonCommunicator } from './communicator';
-import { readFileSync } from './utils';
+import { OperonTransaction, TransactionConfig } from './transaction.js';
+import { CommunicatorConfig, OperonCommunicator } from './communicator.js';
+import { readFileSync } from './utils.js';
 
 import {
   TelemetryCollector,
@@ -30,14 +30,14 @@ import {
   JaegerExporter,
   Logger,
   Tracer,
-} from './telemetry';
+} from './telemetry/index.js';
 import { PoolConfig } from 'pg';
-import { transaction_outputs } from '../schemas/user_db_schema';
-import { SystemDatabase, PostgresSystemDatabase } from './system_database';
+import { transaction_outputs } from '../schemas/user_db_schema.js';
+import { SystemDatabase, PostgresSystemDatabase } from './system_database.js';
 import { v4 as uuidv4 } from 'uuid';
 import YAML from 'yaml';
-import { PGNodeUserDatabase, PrismaClient, PrismaUserDatabase, UserDatabase, TypeOrmDatabase } from './user_database';
-import { forEachMethod } from './decorators';
+import { PGNodeUserDatabase, PrismaClient, PrismaUserDatabase, UserDatabase, TypeOrmDatabase } from './user_database.js';
+import { forEachMethod } from './decorators.js';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { DataSource } from "typeorm"
 

--- a/src/provenance/provenance_daemon.ts
+++ b/src/provenance/provenance_daemon.ts
@@ -5,9 +5,9 @@ import {
   POSTGRES_EXPORTER,
   PostgresExporter,
   TelemetryCollector
-} from "../telemetry";
-import { OperonConfig } from "src/operon";
-import { ProvenanceSignal } from "src/telemetry/signals";
+} from "../telemetry/index.js";
+import { OperonConfig } from "../operon.js";
+import { ProvenanceSignal } from "../telemetry/signals.js";
 
 interface wal2jsonRow {
   xid: string;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { deserializeError, serializeError } from "serialize-error";
-import { operonNull, OperonNull } from "./operon";
+import { operonNull, OperonNull } from "./operon.js";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from "pg";
-import { OperonWorkflowConflictUUIDError } from "./error";
-import { StatusString, WorkflowStatus } from "./workflow";
-import { systemDBSchema, notifications, operation_outputs, workflow_status } from "../schemas/system_db_schema";
-import { sleep } from "./utils";
+import { OperonWorkflowConflictUUIDError } from "./error.js";
+import { StatusString, WorkflowStatus } from "./workflow.js";
+import { systemDBSchema, notifications, operation_outputs, workflow_status } from "../schemas/system_db_schema.js";
+import { sleep } from "./utils.js";
 
 export interface SystemDatabase {
   init(): Promise<void>;

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -1,5 +1,5 @@
-import { ITelemetryExporter } from "./exporters";
-import { OperonSignal } from "./signals";
+import { ITelemetryExporter } from "./exporters.js";
+import { OperonSignal } from "./signals.js";
 
 class SignalsQueue {
   data: OperonSignal[] = [];

--- a/src/telemetry/exporters.ts
+++ b/src/telemetry/exporters.ts
@@ -1,12 +1,12 @@
 import { Client, QueryConfig, QueryArrayResult, PoolConfig } from "pg";
 import { groupBy } from "lodash";
-import { forEachMethod, LogMasks, OperonDataType, OperonMethodRegistrationBase } from "./../decorators";
-import { OperonPostgresExporterError, OperonJaegerExporterError } from "./../error";
-import { OperonSignal, ProvenanceSignal, TelemetrySignal } from "./signals";
+import { forEachMethod, LogMasks, OperonDataType, OperonMethodRegistrationBase } from "../decorators.js";
+import { OperonPostgresExporterError, OperonJaegerExporterError } from "../error.js";
+import { OperonSignal, ProvenanceSignal, TelemetrySignal } from "./signals.js";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
-import { spanToString } from "./traces";
+import { spanToString } from "./traces.js";
 
 export interface ITelemetryExporter<T, U> {
   export(signal: OperonSignal[]): Promise<T>;

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,4 +1,4 @@
-export { Tracer } from "./traces";
-export { Logger } from "./logs";
-export { TelemetryCollector } from "./collector";
-export { POSTGRES_EXPORTER, PostgresExporter, CONSOLE_EXPORTER, ConsoleExporter, JAEGER_EXPORTER, JaegerExporter } from "./exporters";
+export { Tracer } from "./traces.js";
+export { Logger } from "./logs.js";
+export { TelemetryCollector } from "./collector.js";
+export { POSTGRES_EXPORTER, PostgresExporter, CONSOLE_EXPORTER, ConsoleExporter, JAEGER_EXPORTER, JaegerExporter } from "./exporters.js";

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -1,8 +1,8 @@
-import { WorkflowContext } from "./../workflow";
-import { TelemetryCollector } from "./collector";
-import { TelemetrySignal } from "./signals";
-import { TransactionContext } from "./../transaction";
-import { CommunicatorContext } from "src/communicator";
+import { WorkflowContext } from "../workflow.js";
+import { TelemetryCollector } from "./collector.js";
+import { TelemetrySignal } from "./signals.js";
+import { TransactionContext } from "../transaction.js";
+import { CommunicatorContext } from "../communicator.js";
 
 interface ILogger {
   log(context: WorkflowContext | TransactionContext, severity: string, message: string): void;

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -3,8 +3,8 @@ import { Resource } from "@opentelemetry/resources";
 import opentelemetry from "@opentelemetry/api";
 import { hrTimeToMicroseconds } from "@opentelemetry/core";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
-import { TelemetryCollector } from "./collector";
-import { TelemetrySignal } from "./signals";
+import { TelemetryCollector } from "./collector.js";
+import { TelemetrySignal } from "./signals.js";
 
 export function spanToString(span: ReadableSpan): string {
   return JSON.stringify({

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { PoolClient } from "pg";
-import { PrismaClient, UserDatabaseName, UserDatabaseClient } from "./user_database";
-import { Logger } from "./telemetry";
-import { ValuesOf } from "./utils";
-import { WorkflowContext } from "./workflow";
+import { PrismaClient, UserDatabaseName, UserDatabaseClient } from "./user_database.js";
+import { Logger } from "./telemetry/index.js";
+import { ValuesOf } from "./utils.js";
+import { WorkflowContext } from "./workflow.js";
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { OperonContext } from './context';
+import { OperonContext } from './context.js';
 import { EntityManager } from "typeorm";
 
 // Can we call it OperonTransactionFunction

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Pool, PoolConfig, PoolClient, DatabaseError as PGDatabaseError } from "pg";
-import { createUserDBSchema, userDBSchema } from "../schemas/user_db_schema";
-import { IsolationLevel, TransactionConfig } from "./transaction";
-import { ValuesOf } from "./utils";
+import { createUserDBSchema, userDBSchema } from "../schemas/user_db_schema.js";
+import { IsolationLevel, TransactionConfig } from "./transaction.js";
+import { ValuesOf } from "./utils.js";
 import { DataSource as TypeORMDataSource, EntityManager as TypeORMEntityManager, QueryFailedError } from "typeorm";
 
 export interface UserDatabase {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Operon, OperonNull, operonNull } from "./operon";
-import { transaction_outputs } from "../schemas/user_db_schema";
-import { OperonTransaction, TransactionContext } from "./transaction";
-import { OperonCommunicator, CommunicatorContext } from "./communicator";
-import { OperonError, OperonNotRegisteredError, OperonTopicPermissionDeniedError, OperonWorkflowConflictUUIDError } from "./error";
+import { Operon, OperonNull, operonNull } from "./operon.js";
+import { transaction_outputs } from "../schemas/user_db_schema.js";
+import { OperonTransaction, TransactionContext } from "./transaction.js";
+import { OperonCommunicator, CommunicatorContext } from "./communicator.js";
+import { OperonError, OperonNotRegisteredError, OperonTopicPermissionDeniedError, OperonWorkflowConflictUUIDError } from "./error.js";
 import { serializeError, deserializeError } from "serialize-error";
-import { sleep } from "./utils";
-import { SystemDatabase } from "./system_database";
-import { UserDatabaseClient } from "./user_database";
+import { sleep } from "./utils.js";
+import { SystemDatabase } from "./system_database.js";
+import { UserDatabaseClient } from "./user_database.js";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { OperonContext } from './context';
+import { OperonContext } from './context.js';
 
 const defaultRecvTimeoutSec = 60;
 

--- a/tests/authorization.test.ts
+++ b/tests/authorization.test.ts
@@ -6,8 +6,8 @@ import {
   WorkflowContext,
   WorkflowConfig,
   WorkflowParams,
-} from "src/";
-import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
+} from "../src/index.js";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers.js";
 
 describe("authorization", () => {
   let operon: Operon;

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -4,10 +4,10 @@ import {
   OperonConfig,
   TransactionContext,
   WorkflowContext,
-} from "src/";
+} from "../src/index.js";
 import { v1 as uuidv1 } from "uuid";
-import { sleep } from "src/utils";
-import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
+import { sleep } from "../src/utils.js";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers.js";
 
 describe("concurrency-tests", () => {
   let operon: Operon;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
-import { Operon, OperonConfig, OperonInitializationError } from "src/";
-import { generateOperonTestConfig } from "./helpers";
-import * as utils from "../src/utils";
+import { Operon, OperonConfig, OperonInitializationError } from "../src/index.js";
+import { generateOperonTestConfig } from "./helpers.js";
+import * as utils from "../src/utils.js";
 import { PoolConfig } from "pg";
 
 describe("operon-config", () => {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -5,17 +5,17 @@ import {
   TransactionContext,
   OperonError,
   CommunicatorContext,
-} from "src/";
+} from "../src/index.js";
 import {
   generateOperonTestConfig,
   setupOperonTestDb,
   TestKvTable,
-} from "./helpers";
+} from "./helpers.js";
 import { DatabaseError } from "pg";
 import { v1 as uuidv1 } from "uuid";
-import { sleep } from "src/utils";
-import { StatusString } from "src/workflow";
-import { OperonNotRegisteredError } from "src/error";
+import { sleep } from "../src/utils.js";
+import { StatusString } from "../src/workflow.js";
+import { OperonNotRegisteredError } from "../src/error.js";
 
 describe("failures-tests", () => {
   let operon: Operon;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { OperonConfig } from "src";
+import { OperonConfig } from "../src/index.js";
 import { Client } from "pg";
 
 /* DB management helpers */

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -7,7 +7,7 @@ import {
   ArgName,
   SkipLogging,
   LogMask,
-} from "src/decorators";
+} from "../src/decorators.js";
 
 class TestFunctions {
   @Traced

--- a/tests/operon.test.ts
+++ b/tests/operon.test.ts
@@ -6,16 +6,16 @@ import {
   CommunicatorContext,
   WorkflowParams,
   WorkflowHandle,
-} from "src/";
+} from "../src/index.js";
 import {
   generateOperonTestConfig,
   setupOperonTestDb,
   TestKvTable,
-} from "./helpers";
+} from "./helpers.js";
 import { v1 as uuidv1 } from "uuid";
-import { sleep } from "src/utils";
-import { WorkflowConfig, StatusString } from "src/workflow";
-import { CONSOLE_EXPORTER } from "src/telemetry";
+import { sleep } from "../src/utils.js";
+import { WorkflowConfig, StatusString } from "../src/workflow.js";
+import { CONSOLE_EXPORTER } from "../src/telemetry/index.js";
 
 describe("operon-tests", () => {
   const testTableName = "operon_test_kv";

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -1,8 +1,8 @@
 import { PrismaClient, testkv } from "@prisma/client";
-import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
-import { Operon, OperonConfig, TransactionContext } from "src";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers.js";
+import { Operon, OperonConfig, TransactionContext } from "../src/index.js";
 import { v1 as uuidv1 } from "uuid";
-import { sleep } from "src/utils";
+import { sleep } from "../src/utils.js";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 interface PrismaPGError {

--- a/tests/provenance/provenance.test.ts
+++ b/tests/provenance/provenance.test.ts
@@ -1,9 +1,9 @@
-import { generateOperonTestConfig, setupOperonTestDb } from "../helpers";
-import { ProvenanceDaemon } from "../../src/provenance/provenance_daemon";
-import { POSTGRES_EXPORTER, PostgresExporter } from "../../src/telemetry";
-import { OperonTransaction, OperonWorkflow } from "../../src/decorators";
-import { Operon, OperonConfig, TransactionContext, WorkflowContext } from "../../src";
-import { PgTransactionId } from "../../src/workflow";
+import { generateOperonTestConfig, setupOperonTestDb } from "../helpers.js";
+import { ProvenanceDaemon } from "../../src/provenance/provenance_daemon.js";
+import { POSTGRES_EXPORTER, PostgresExporter } from "../../src/telemetry/index.js";
+import { OperonTransaction, OperonWorkflow } from "../../src/decorators.js";
+import { Operon, OperonConfig, TransactionContext, WorkflowContext } from "../../src/index.js";
+import { PgTransactionId } from "../../src/workflow.js";
 
 describe("operon-provenance", () => {
   const testTableName = "operon_test_kv";

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -4,13 +4,13 @@ import {
   POSTGRES_EXPORTER,
   TelemetryCollector,
   CONSOLE_EXPORTER,
-} from "../src/telemetry";
-import { TelemetrySignal } from "../src/telemetry/signals";
-import { Operon, OperonConfig } from "../src/operon";
-import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
-import { Traced, OperonTransaction, OperonWorkflow } from "../src/decorators";
-import { TransactionContext, WorkflowContext, WorkflowParams } from "src";
-import { WorkflowHandle } from "src/workflow";
+} from "../src/telemetry/index.js";
+import { TelemetrySignal } from "../src/telemetry/signals.js";
+import { Operon, OperonConfig } from "../src/operon.js";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers.js";
+import { Traced, OperonTransaction, OperonWorkflow } from "../src/decorators.js";
+import { TransactionContext, WorkflowContext, WorkflowParams } from "../src/index.js";
+import { WorkflowHandle } from "../src/workflow.js";
 
 type TelemetrySignalDbFields = {
   workflow_uuid: string;

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -1,9 +1,9 @@
 // import { PrismaClient, testkv } from "@prisma/client";
 import { DataSource, EntityManager, Entity, PrimaryColumn, Column} from "typeorm";
-import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
-import { Operon, OperonConfig, TransactionContext } from "src";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers.js";
+import { Operon, OperonConfig, TransactionContext } from "../src/index.js";
 import { v1 as uuidv1 } from "uuid";
-import { sleep } from "src/utils";
+import { sleep } from "../src/utils.js";
 
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,109 +1,11 @@
 {
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "esnext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    "experimentalDecorators": true,                      /* Enable experimental support for legacy experimental decorators. */
-    "emitDecoratorMetadata": true,                       /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    "newLine": "lf",                                     /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "outDir": "./dist",
+    "sourceMap": true,
+    // TODO: move to new TS 5.0 Decorators
+    // https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
   }
 }


### PR DESCRIPTION
as I was working on the shop demo, I wanted to use top level await. However, to do so requires using ECMAScript Modules (ESM). This draft PR update operon to use ESM across the board.

It also updates tsconfig for more modern defaults, leveraging the @tsconfig/node18 package.

tests all pass locally on my machine, but I see there's a failure on the GH check. Will investigate.