### PR TITLE
TypeORM is not TypeOrm in their docs

### DIFF
--- a/src/operon.ts
+++ b/src/operon.ts
@@ -36,7 +36,8 @@ import { transaction_outputs } from '../schemas/user_db_schema';
 import { SystemDatabase, PostgresSystemDatabase } from './system_database';
 import { v4 as uuidv4 } from 'uuid';
 import YAML from 'yaml';
-import { PGNodeUserDatabase, PrismaClient, PrismaUserDatabase, UserDatabase, TypeOrmDatabase } from './user_database';
+import { PGNodeUserDatabase, PrismaClient, PrismaUserDatabase,
+         UserDatabase, TypeORMDatabase, } from './user_database';
 import { forEachMethod } from './decorators';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { DataSource } from "typeorm"
@@ -184,13 +185,13 @@ export class Operon {
   }
 
   // TODO: Create an interface for ds that has the high level things we expect from typeorm
-  useTypeOrm(ds: unknown) {
+  useTypeORM(ds: unknown) {
     if (this.userDatabase) {
       throw new OperonInitializationError("Data source already initialized!");
     }
 
     if (ds) {
-      this.userDatabase = new TypeOrmDatabase(ds as DataSource);
+      this.userDatabase = new TypeORMDatabase(ds as DataSource);
       return;
     }
   }

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -195,9 +195,9 @@ export class PrismaUserDatabase implements UserDatabase {
 }
 
 /**
- * TypeOrm user data access interface
+ * TypeORM user data access interface
  */
-export class TypeOrmDatabase implements UserDatabase {
+export class TypeORMDatabase implements UserDatabase {
   readonly dataSource: TypeORMDataSource;
 
   constructor(readonly ds: TypeORMDataSource) {

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -63,7 +63,7 @@ describe("typeorm-tests", () => {
   beforeEach(async () => {
     globalCnt = 0;
     operon = new Operon(config);
-    operon.useTypeOrm(typeormDs);
+    operon.useTypeORM(typeormDs);
     await operon.init();
     await operon.userDatabase.query(`DROP TABLE IF EXISTS ${testTableName};`);
     await operon.userDatabase.query(


### PR DESCRIPTION
I noticed Manoj is spelling it TypeORM in the new PR.  As this is consistent with their docs, let us get rid of the use of "TypeOrm" which is not consistent with the other two.