### PR TITLE
Fix Github Action wal2json issue

### DIFF
--- a/.github/workflows/operon-test.yml
+++ b/.github/workflows/operon-test.yml
@@ -19,7 +19,7 @@ jobs:
     services:
       # Label used to access the service container.
       postgres:
-        image: postgres
+        image: postgres:15.4
         env:
           # Specify the password for Postgres superuser.
           POSTGRES_PASSWORD: dbos


### PR DESCRIPTION
The failure was caused by incompatible versions: the default `postgres` container was recently upgraded to version 16, but we installed wal2json-15. The solution is to specify a Postgres version to use (`postgres:15.4`). 