### PR TITLE
change destroy methods to asyncDisposable

### DIFF
--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -60,7 +60,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   async init(): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  async destroy(): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     this.dbRoot.close();
   }
 

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -84,7 +84,7 @@ interface WorkflowInput<T extends any[]> {
   input: T;
 }
 
-export class Operon {
+export class Operon implements AsyncDisposable {
   initialized: boolean;
   readonly config: OperonConfig;
   // User Database
@@ -232,12 +232,12 @@ export class Operon {
     this.initialized = true;
   }
 
-  async destroy() {
+  async [Symbol.asyncDispose]() {
     clearInterval(this.flushBufferID);
     await this.flushWorkflowStatusBuffer();
-    await this.systemDatabase.destroy();
-    await this.userDatabase.destroy();
-    await this.telemetryCollector.destroy();
+    await this.systemDatabase[Symbol.asyncDispose]();
+    await this.userDatabase[Symbol.asyncDispose]();
+    await this.telemetryCollector[Symbol.asyncDispose]();
   }
 
   generateOperonConfig(): OperonConfig {

--- a/src/provenance/provenance_daemon.ts
+++ b/src/provenance/provenance_daemon.ts
@@ -40,7 +40,7 @@ interface wal2jsonChange {
  * Because the daemon depends on Postgres logical replication, it can only export information on updates and deletes in tables
  * whose rows are uniquely identifiable, either because the table has a primary key or a replica identity.
  */
-export class ProvenanceDaemon {
+export class ProvenanceDaemon implements AsyncDisposable {
   readonly client;
   readonly daemonID;
   readonly recordProvenanceIntervalMs = 1000;
@@ -66,7 +66,7 @@ export class ProvenanceDaemon {
         }
       }
     }
-    
+
     this.telemetryCollector = new TelemetryCollector(telemetryExporters);
   }
 
@@ -109,9 +109,9 @@ export class ProvenanceDaemon {
     }
   }
 
-  async stop() {
+  async [Symbol.asyncDispose]() {
     clearInterval(this.daemonID);
     await this.client.end();
-    await this.telemetryCollector.destroy();
+    await this.telemetryCollector[Symbol.asyncDispose]();
   }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -8,9 +8,8 @@ import { StatusString, WorkflowStatus } from "./workflow";
 import { systemDBSchema, notifications, operation_outputs, workflow_status, workflow_events } from "../schemas/system_db_schema";
 import { sleep } from "./utils";
 
-export interface SystemDatabase {
+export interface SystemDatabase extends AsyncDisposable{
   init(): Promise<void>;
-  destroy(): Promise<void>;
 
   checkWorkflowOutput<R>(workflowUUID: string): Promise<OperonNull | R>;
   bufferWorkflowStatus(workflowUUID: string): void;
@@ -62,7 +61,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     await pgSystemClient.end();
   }
 
-  async destroy() {
+  async [Symbol.asyncDispose]() {
     if (this.notificationsClient) {
       this.notificationsClient.removeAllListeners();
       this.notificationsClient.release();

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -19,7 +19,7 @@ class SignalsQueue {
 }
 
 // TODO: Handle temporary workflows properly.
-export class TelemetryCollector {
+export class TelemetryCollector implements AsyncDisposable {
   // Signals buffer management
   private readonly signals: SignalsQueue = new SignalsQueue();
   private readonly signalBufferID: NodeJS.Timeout;
@@ -41,13 +41,11 @@ export class TelemetryCollector {
     }
   }
 
-  async destroy() {
+  async [Symbol.asyncDispose]() {
     clearInterval(this.signalBufferID);
     await this.processAndExportSignals();
     for (const exporter of this.exporters) {
-      if (exporter.destroy) {
-        await exporter.destroy();
-      }
+      await exporter[Symbol.asyncDispose]();
     }
   }
 

--- a/tests/authorization.test.ts
+++ b/tests/authorization.test.ts
@@ -23,7 +23,7 @@ describe("authorization", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   describe("workflow authorization", () => {

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -31,7 +31,7 @@ describe("concurrency-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("duplicate-transaction", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,6 +23,7 @@ describe("operon-config", () => {
       .mockReturnValueOnce(mockOperonConfigYamlString);
     jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
 
+    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon: Operon = new Operon();
     operon.useNodePostgres();
     expect(operon.initialized).toBe(false);
@@ -36,19 +37,21 @@ describe("operon-config", () => {
     expect(poolConfig.password).toBe(process.env.PGPASSWORD);
     expect(poolConfig.connectionTimeoutMillis).toBe(3000);
     expect(poolConfig.database).toBe("some DB");
-    await operon.destroy();
+
+    await operon[Symbol.asyncDispose]();
   });
 
   test("Custom config is parsed as expected", async () => {
     // We use readFileSync as a proxy for checking the config was not read from the default location
     const readFileSpy = jest.spyOn(utils, "readFileSync");
     const config: OperonConfig = generateOperonTestConfig();
+    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(config);
     operon.useNodePostgres();
     expect(operon.initialized).toBe(false);
     expect(operon.config).toBe(config);
     expect(readFileSpy).toHaveBeenCalledTimes(0);
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("fails to read config file", () => {

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -83,7 +83,7 @@ describe("decorator-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("simple-communicator-decorator", async () => {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -39,7 +39,7 @@ describe("failures-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("operon-error", async () => {

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -33,7 +33,7 @@ describe("foundationdb-operon", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("fdb-operon", async () => {

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -48,7 +48,7 @@ describe("httpserver-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("get-hello", async () => {

--- a/tests/operon.test.ts
+++ b/tests/operon.test.ts
@@ -41,7 +41,7 @@ describe("operon-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("simple-function", async () => {

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -61,7 +61,7 @@ describe("prisma-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("simple-prisma", async () => {

--- a/tests/provenance/provenance.test.ts
+++ b/tests/provenance/provenance.test.ts
@@ -30,8 +30,8 @@ describe("operon-provenance", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
-    await provDaemon.stop();
+    await operon[Symbol.asyncDispose]();
+    await provDaemon[Symbol.asyncDispose]();
   });
 
   class TestFunctions {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -75,14 +75,16 @@ describe("operon-telemetry", () => {
       CONSOLE_EXPORTER,
       POSTGRES_EXPORTER,
     ]);
+    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(operonConfig);
     operon.useNodePostgres();
     await operon.init();
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("collector handles errors gracefully", async () => {
     const operonConfig = generateOperonTestConfig([POSTGRES_EXPORTER]);
+    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(operonConfig);
     operon.useNodePostgres();
     await operon.init(TestClass);
@@ -99,7 +101,7 @@ describe("operon-telemetry", () => {
       operon.telemetryCollector.processAndExportSignals()
     ).resolves.not.toThrow();
 
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   describe("Console exporter", () => {
@@ -113,8 +115,8 @@ describe("operon-telemetry", () => {
     });
 
     afterEach(async () => {
-      await collector.destroy();
-      await operon.destroy();
+      await collector[Symbol.asyncDispose]();
+      await operon[Symbol.asyncDispose]();
     });
 
     test("console.log is called with the correct messages", async () => {
@@ -166,7 +168,7 @@ describe("operon-telemetry", () => {
     });
 
     afterAll(async () => {
-      await operon.destroy();
+      await operon[Symbol.asyncDispose]();
       // This attempts to clear all our DBs, including the observability one
       await setupOperonTestDb(operonConfig);
     });

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -72,7 +72,7 @@ describe("typeorm-tests", () => {
   });
 
   afterEach(async () => {
-    await operon.destroy();
+    await operon[Symbol.asyncDispose]();
   });
 
   test("simple-typeorm", async () => {


### PR DESCRIPTION
A few caveats:

* the TypeORMDataSource interface is modeled to work with TypeORM's DataSource class. That class implements destroy so TypeORMDataSource was not switched over to AsyncDisposable
* ts-jest has not be updated to TS 5.2, so we can't use `await using` in our tests yet. Added TODOs to change add `await using` where possible in our tests once ts-jest is updated