### PR TITLE
Revert "change destroy methods to asyncDisposable (#64)"

### DIFF
--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -60,7 +60,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   async init(): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  async [Symbol.asyncDispose](): Promise<void> {
+  async destroy(): Promise<void> {
     this.dbRoot.close();
   }
 

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -84,7 +84,7 @@ interface WorkflowInput<T extends any[]> {
   input: T;
 }
 
-export class Operon implements AsyncDisposable {
+export class Operon {
   initialized: boolean;
   readonly config: OperonConfig;
   // User Database
@@ -235,16 +235,12 @@ export class Operon implements AsyncDisposable {
     this.initialized = true;
   }
 
-  async dispose() {
+  async destroy() {
     clearInterval(this.flushBufferID);
     await this.flushWorkflowStatusBuffer();
-    await this.systemDatabase[Symbol.asyncDispose]();
-    await this.userDatabase[Symbol.asyncDispose]();
-    await this.telemetryCollector[Symbol.asyncDispose]();
-  }
-
-  async [Symbol.asyncDispose]() {
-    return this.dispose();
+    await this.systemDatabase.destroy();
+    await this.userDatabase.destroy();
+    await this.telemetryCollector.destroy();
   }
 
   generateOperonConfig(): OperonConfig {

--- a/src/provenance/provenance_daemon.ts
+++ b/src/provenance/provenance_daemon.ts
@@ -40,7 +40,7 @@ interface wal2jsonChange {
  * Because the daemon depends on Postgres logical replication, it can only export information on updates and deletes in tables
  * whose rows are uniquely identifiable, either because the table has a primary key or a replica identity.
  */
-export class ProvenanceDaemon implements AsyncDisposable {
+export class ProvenanceDaemon {
   readonly client;
   readonly daemonID;
   readonly recordProvenanceIntervalMs = 1000;
@@ -66,7 +66,7 @@ export class ProvenanceDaemon implements AsyncDisposable {
         }
       }
     }
-
+    
     this.telemetryCollector = new TelemetryCollector(telemetryExporters);
   }
 
@@ -109,9 +109,9 @@ export class ProvenanceDaemon implements AsyncDisposable {
     }
   }
 
-  async [Symbol.asyncDispose]() {
+  async stop() {
     clearInterval(this.daemonID);
     await this.client.end();
-    await this.telemetryCollector[Symbol.asyncDispose]();
+    await this.telemetryCollector.destroy();
   }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -8,8 +8,9 @@ import { StatusString, WorkflowStatus } from "./workflow";
 import { systemDBSchema, notifications, operation_outputs, workflow_status, workflow_events } from "../schemas/system_db_schema";
 import { sleep } from "./utils";
 
-export interface SystemDatabase extends AsyncDisposable{
+export interface SystemDatabase {
   init(): Promise<void>;
+  destroy(): Promise<void>;
 
   checkWorkflowOutput<R>(workflowUUID: string): Promise<OperonNull | R>;
   bufferWorkflowStatus(workflowUUID: string): void;
@@ -61,7 +62,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     await pgSystemClient.end();
   }
 
-  async [Symbol.asyncDispose]() {
+  async destroy() {
     if (this.notificationsClient) {
       this.notificationsClient.removeAllListeners();
       this.notificationsClient.release();

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -19,7 +19,7 @@ class SignalsQueue {
 }
 
 // TODO: Handle temporary workflows properly.
-export class TelemetryCollector implements AsyncDisposable {
+export class TelemetryCollector {
   // Signals buffer management
   private readonly signals: SignalsQueue = new SignalsQueue();
   private readonly signalBufferID: NodeJS.Timeout;
@@ -41,11 +41,13 @@ export class TelemetryCollector implements AsyncDisposable {
     }
   }
 
-  async [Symbol.asyncDispose]() {
+  async destroy() {
     clearInterval(this.signalBufferID);
     await this.processAndExportSignals();
     for (const exporter of this.exporters) {
-      await exporter[Symbol.asyncDispose]();
+      if (exporter.destroy) {
+        await exporter.destroy();
+      }
     }
   }
 

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -4,8 +4,9 @@ import { createUserDBSchema, userDBSchema } from "../schemas/user_db_schema";
 import { IsolationLevel, TransactionConfig } from "./transaction";
 import { ValuesOf } from "./utils";
 
-export interface UserDatabase extends AsyncDisposable {
+export interface UserDatabase {
   init(): Promise<void>;
+  destroy(): Promise<void>;
 
   getName(): UserDatabaseName;
 
@@ -43,7 +44,7 @@ export class PGNodeUserDatabase implements UserDatabase {
     await this.pool.query(userDBSchema);
   }
 
-  async [Symbol.asyncDispose](): Promise<void> {
+  async destroy(): Promise<void> {
     await this.pool.end();
   }
 
@@ -137,7 +138,7 @@ export class PrismaUserDatabase implements UserDatabase {
     await this.prisma.$queryRawUnsafe(userDBSchema);
   }
 
-  async [Symbol.asyncDispose](): Promise<void> {
+  async destroy(): Promise<void> {
     await this.prisma.$disconnect();
   }
 
@@ -192,7 +193,6 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 }
 
-// Note: TypeORMDataSource has to be compatible w/ TypeORM's DataSource class, which uses destroy instead of AsyncDisposable
 export interface TypeORMDataSource {
 
   readonly isInitialized: boolean;
@@ -231,7 +231,7 @@ export class TypeORMDatabase implements UserDatabase {
     await this.dataSource.query(userDBSchema);
   }
 
-  async [Symbol.asyncDispose](): Promise<void> {
+  async destroy(): Promise<void> {
     if (this.dataSource.isInitialized) {
       await this.dataSource.destroy();
     }

--- a/tests/authorization.test.ts
+++ b/tests/authorization.test.ts
@@ -23,7 +23,7 @@ describe("authorization", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   describe("workflow authorization", () => {

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -31,7 +31,7 @@ describe("concurrency-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("duplicate-transaction", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,7 +23,6 @@ describe("operon-config", () => {
       .mockReturnValueOnce(mockOperonConfigYamlString);
     jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
 
-    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon: Operon = new Operon();
     operon.useNodePostgres();
     expect(operon.initialized).toBe(false);
@@ -37,21 +36,19 @@ describe("operon-config", () => {
     expect(poolConfig.password).toBe(process.env.PGPASSWORD);
     expect(poolConfig.connectionTimeoutMillis).toBe(3000);
     expect(poolConfig.database).toBe("some DB");
-
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("Custom config is parsed as expected", async () => {
     // We use readFileSync as a proxy for checking the config was not read from the default location
     const readFileSpy = jest.spyOn(utils, "readFileSync");
     const config: OperonConfig = generateOperonTestConfig();
-    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(config);
     operon.useNodePostgres();
     expect(operon.initialized).toBe(false);
     expect(operon.config).toBe(config);
     expect(readFileSpy).toHaveBeenCalledTimes(0);
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("fails to read config file", () => {

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -83,7 +83,7 @@ describe("decorator-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("simple-communicator-decorator", async () => {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -39,7 +39,7 @@ describe("failures-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("operon-error", async () => {

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -33,7 +33,7 @@ describe("foundationdb-operon", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("fdb-operon", async () => {

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -82,7 +82,7 @@ describe("httpserver-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("get-hello", async () => {

--- a/tests/operon.test.ts
+++ b/tests/operon.test.ts
@@ -41,7 +41,7 @@ describe("operon-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("simple-function", async () => {

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -61,7 +61,7 @@ describe("prisma-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("simple-prisma", async () => {

--- a/tests/provenance/provenance.test.ts
+++ b/tests/provenance/provenance.test.ts
@@ -30,8 +30,8 @@ describe("operon-provenance", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
-    await provDaemon[Symbol.asyncDispose]();
+    await operon.destroy();
+    await provDaemon.stop();
   });
 
   class TestFunctions {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -75,16 +75,14 @@ describe("operon-telemetry", () => {
       CONSOLE_EXPORTER,
       POSTGRES_EXPORTER,
     ]);
-    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(operonConfig);
     operon.useNodePostgres();
     await operon.init();
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("collector handles errors gracefully", async () => {
     const operonConfig = generateOperonTestConfig([POSTGRES_EXPORTER]);
-    // TODO: Move to using await when ts-jest is updated to support TS 5.2
     const operon = new Operon(operonConfig);
     operon.useNodePostgres();
     await operon.init(TestClass);
@@ -101,7 +99,7 @@ describe("operon-telemetry", () => {
       operon.telemetryCollector.processAndExportSignals()
     ).resolves.not.toThrow();
 
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   describe("Console exporter", () => {
@@ -115,8 +113,8 @@ describe("operon-telemetry", () => {
     });
 
     afterEach(async () => {
-      await collector[Symbol.asyncDispose]();
-      await operon[Symbol.asyncDispose]();
+      await collector.destroy();
+      await operon.destroy();
     });
 
     test("console.log is called with the correct messages", async () => {
@@ -168,7 +166,7 @@ describe("operon-telemetry", () => {
     });
 
     afterAll(async () => {
-      await operon[Symbol.asyncDispose]();
+      await operon.destroy();
       // This attempts to clear all our DBs, including the observability one
       await setupOperonTestDb(operonConfig);
     });

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -72,7 +72,7 @@ describe("typeorm-tests", () => {
   });
 
   afterEach(async () => {
-    await operon[Symbol.asyncDispose]();
+    await operon.destroy();
   });
 
   test("simple-typeorm", async () => {


### PR DESCRIPTION
This reverts commit 9a1d79b460944b72ce42bf96b0f5596d208f1fbb.

Node LTS doesn't define Symbol.asyncDisposable and it's not clear how to correctly polyfill it. THe TS 5.2 annoncement blog post suggested you could simply `Symbol.asyncDispose ??= Symbol("Symbol.asyncDispose")`...which isn't legal typescript. I was able to polyfill by casting Symbol to any, but when I added the polyfill to index.ts, the tests started failing. Given the dev exp issues Chuck raised + the runtime support issue, I think we're better off reverting this change. We can re-assess *adding* AsyncDisposable support when the underlying runtime includes it.

