### PR TITLE
Middleware Module

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -172,11 +172,6 @@ export class OperonParameter {
   }
 }
 
-export interface OperonRegistrationMetadata {
-  name: string;
-  requiredRole: string [];
-}
-
 export interface OperonMethodRegistrationBase {
   name: string;
   traceLevel: TraceLevels;

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -1,0 +1,25 @@
+import Koa from "koa";
+
+// Middleware context does not extend Operon context because it runs before actual Operon operations.
+export class MiddlewareContext {
+  constructor(
+    readonly koaContext: Koa.Context,
+    readonly name: string, // Method (handler, transaction, workflow) name
+    readonly requiredRole: string[]
+  ) {}
+}
+
+/**
+ * Authentication middleware that executes before a request reaches a function.
+ * This is expected to:
+ *   - Validate the request found in the handler context and extract auth information from the request.
+ *   - Map the HTTP request to the user identity and roles defined in Operon app.
+ * If this succeeds, return the current authenticated user and a list of roles.
+ * If any step fails, throw an error.
+ */
+export type OperonHttpAuthMiddleware = (ctx: MiddlewareContext) => Promise<OperonHttpAuthReturn | void>;
+
+export interface OperonHttpAuthReturn {
+  authenticatedUser: string;
+  authenticatedRoles: string[];
+}

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -18,23 +18,7 @@ import {
 } from "../error";
 import { Operon } from "../operon";
 import { serializeError } from 'serialize-error';
-import { OperonRegistrationMetadata } from 'src/decorators';
-
-/**
- * Authentication middleware that executes before a request reaches a function.
- * This is expected to:
- *   - Validate the request found in the handler context and extract auth information from the request.
- *   - Map the HTTP request to the user identity and roles defined in Operon app.
- * If this succeeds, return the current authenticated user and a list of roles.
- * If any step fails, throw an error.
- */
-// TODO: should we expose HandlerContext here or define a new context, or directly use Koa.Context? It currently contains methods to invoke transactions and other fields.
-export type OperonHttpAuthMiddleware = (metadata: OperonRegistrationMetadata, ctx: HandlerContext) => Promise<OperonHttpAuthReturn | void>;
-
-export interface OperonHttpAuthReturn {
-  authenticatedUser: string;
-  authenticatedRoles: string[];
-}
+import { OperonHttpAuthMiddleware } from './middleware';
 
 export class OperonHttpServer {
   readonly app: Koa;
@@ -98,7 +82,7 @@ export class OperonHttpServer {
           // Check for auth first
           if (middlewares && middlewares.auth) {
             try {
-              const res = await middlewares.auth({name: ro.name, requiredRole: ro.requiredRole}, oc);
+              const res = await middlewares.auth({name: ro.name, requiredRole: ro.requiredRole, koaContext: koaCtxt});
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;
                 oc.authenticatedRoles = res.authenticatedRoles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,6 @@ export {
 export {
   OperonFieldType,
   OperonDataType,
-  OperonRegistrationMetadata,
   OperonMethodRegistrationBase,
   TraceLevels,
   LogMasks,
@@ -74,3 +73,9 @@ export {
 export {
   OperonHttpServer,
 } from "./httpServer/server";
+
+export {
+  OperonHttpAuthMiddleware,
+  OperonHttpAuthReturn,
+  MiddlewareContext,
+} from "./httpServer/middleware";

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -8,7 +8,7 @@ import {
   OperonResponseError,
   OperonTransaction,
   OperonWorkflow,
-  OperonRegistrationMetadata,
+  MiddlewareContext,
   PostApi,
   RequiredRole,
   TransactionContext,
@@ -47,12 +47,8 @@ describe("httpserver-tests", () => {
     httpServer = new OperonHttpServer(operon,
       {
         // eslint-disable-next-line @typescript-eslint/require-await
-        authMiddleware: async (handler: OperonRegistrationMetadata, ctx: HandlerContext) => {
-            if (handler.requiredRole.length > 0) {
-              if (!ctx.request) {
-                throw new Error("No request");
-              }
-
+        authMiddleware: async (ctx: MiddlewareContext) => {
+            if (ctx.requiredRole.length > 0) {
               const { userid } = ctx.koaContext.request.query
               const uid = userid?.toString();
 


### PR DESCRIPTION
This PR refactors HTTP middleware related interfaces and moves them a separate `middleware.ts` file. The goal is to explicitly define the input and output types of the HTTP Auth middleware. An HTTP authenticate middleware takes in a `MiddlewareContext` which contains the raw Koa context and required roles to run a target endpoint, and returns an object which contains the authenticated user and roles.