### PR TITLE
support default param for WFContext.invoke

### DIFF
--- a/examples/hello/src/userFunctions.ts
+++ b/examples/hello/src/userFunctions.ts
@@ -25,11 +25,11 @@ export class Hello {
 
   @OperonWorkflow()
   @GetApi('/greeting/:name')
-  static async helloWorkflow(wfCtxt: WorkflowContext, name: string) {
+  static async helloWorkflow(wfCtxt: WorkflowContext<typeof Hello>, name: string) {
     wfCtxt.log("Hello, workflow!");
     const encodedName = btoa(name);
-    const decodedName = await wfCtxt.invoke(Hello).helloExternal(encodedName);
-    return await wfCtxt.invoke(Hello).helloFunction(decodedName);
+    const decodedName = await wfCtxt.invoke().helloExternal(encodedName);
+    return await wfCtxt.invoke().helloFunction(decodedName);
   }
 }
 


### PR DESCRIPTION
As discussed in #75, this *draft* PR adds support default parameter support for `WorkflowContext.invoke`. Not clear folks will think it's worth it, but I wrote the code so I figured we should review before deciding.

The runtime part of this change is pretty easy - `Operon.#registerClass` already has the class instance so we just need to save it in the `WorkflowInfo` so we can pass it to the `WorkflowContext` when it gets created.

The dev time part of this change is a little fiddly. We have to make WorkflowContext generic on the type it's contained within. Also, we have to use `typeof OperationClass` since the tx/comm methods are static.

The biggest problem I see here is that we depend on the developer using the correct generic type on `WorkflowContext`. Forget the `typeof`? Stops working. Use a different class? Throws an error. 

Anyway, here's what the code would look like

```ts
static async helloWorkflow(wfCtxt: WorkflowContext<typeof Hello>, name: string) {
  wfCtxt.log("Hello, workflow!");
  const encodedName = btoa(name);
  const decodedName = await wfCtxt.invoke().helloExternal(encodedName);
  return await wfCtxt.invoke().helloFunction(decodedName);
}
```