### PR TITLE
Fix Handler Context Bug

### DIFF
--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -113,6 +113,7 @@ export class HandlerContextImpl extends OperonContextImpl implements HandlerCont
 
   // TODO: Make private
   async transaction<T extends any[], R>(txn: OperonTransaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+    params.parentCtx = this;
     return this.#operon.transaction(txn, params, ...args);
   }
 }

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -120,11 +120,11 @@ export class Operon {
           telemetryExporters.push(new PostgresExporter(this.config.poolConfig, this.config.observability_database));
         } else if (exporter === JAEGER_EXPORTER) {
           telemetryExporters.push(new JaegerExporter());
-        } else {
-          // If nothing is configured, enable console exporter by default.
-          telemetryExporters.push(new ConsoleExporter());
         }
       }
+    } else {
+      // If nothing is configured, enable console exporter by default.
+      telemetryExporters.push(new ConsoleExporter());
     }
     this.telemetryCollector = new TelemetryCollector(telemetryExporters);
     this.logger = new Logger(this.telemetryCollector);


### PR DESCRIPTION
This PR fixes a bug in handler context: it didn't pass the handler context as a parent context to invoked transactions. Added a test to make sure that child workflows and transactions can get the correct auth information from parentCtx.

It also fixes an issue in a previous PR merge that disabled the console exporter. We should always have a default console exporter unless specify something else.