### PR TITLE
Store serialized request in workflow status

### DIFF
--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -7,6 +7,7 @@ export interface workflow_status {
   error: string;
   assumed_role: string;
   authenticated_roles: string;  // Serialized list of roles.
+  request: string;  // Serialized HTTPRequest
 }
 
 export interface notifications {
@@ -54,6 +55,7 @@ export const systemDBSchema = `
     authenticated_user TEXT,
     assumed_role TEXT,
     authenticated_roles TEXT,
+    request TEXT,
     output TEXT,
     error TEXT
   );

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,16 +6,16 @@ import { IncomingHttpHeaders } from "http";
 import { ParsedUrlQuery } from "querystring";
 
 // Operon request includes useful information from http.IncomingMessage and parsed body, URL parameters, and parsed query string.
-interface HTTPRequest {
-  headers: IncomingHttpHeaders;  // HTTP headers.
-  rawHeaders: string[];
-  params: unknown; // Parsed argument from URL.
+export interface HTTPRequest {
+  headers?: IncomingHttpHeaders;  // HTTP headers.
+  rawHeaders?: string[];
+  params?: unknown; // Parsed argument from URL.
   body?: unknown;  // parsed HTTP body as an object.
-  rawBody: string; // unparsed raw HTTP body string.
-  query: ParsedUrlQuery; // parsed query string.
-  querystring: string; // unparsed query string.
-  url: string; // request url.
-  ip: string; // request remote address.
+  rawBody?: string; // unparsed raw HTTP body string.
+  query?: ParsedUrlQuery; // parsed query string.
+  querystring?: string; // unparsed query string.
+  url?: string; // request url.
+  ip?: string; // request remote address.
 }
 
 export interface OperonContext {

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -14,6 +14,7 @@ import {
   WorkflowParams,
   RetrievedHandle,
   WorkflowContextImpl,
+  WorkflowStatus,
 } from './workflow';
 
 import { OperonTransaction, TransactionConfig } from './transaction';
@@ -43,6 +44,7 @@ import {
 import { OperonMethodRegistrationBase, getRegisteredOperations, getOrCreateOperonClassRegistration } from './decorators';
 import { SpanStatusCode } from '@opentelemetry/api';
 import knex, { Knex } from 'knex';
+import { OperonContextImpl } from './context';
 
 export interface OperonNull { }
 export const operonNull: OperonNull = {};
@@ -283,7 +285,7 @@ export class Operon {
 
     // Synchronously set the workflow's status to PENDING and record workflow inputs.  Not needed for temporary workflows.
     if (!wCtxt.isTempWorkflow) {
-      args = await this.systemDatabase.initWorkflowStatus(workflowUUID, wf.name, wCtxt.authenticatedUser, wCtxt.assumedRole, wCtxt.authenticatedRoles, args);
+      args = await this.systemDatabase.initWorkflowStatus(workflowUUID, wf.name, wCtxt.authenticatedUser, wCtxt.assumedRole, wCtxt.authenticatedRoles, wCtxt.request ?? null, args);
     }
     const runWorkflow = async () => {
       // Check if the workflow previously ran.
@@ -381,13 +383,13 @@ export class Operon {
       try {
         const wfStatus = await this.systemDatabase.getWorkflowStatus(workflowUUID);
         const inputs = await this.systemDatabase.getWorkflowInputs(workflowUUID);
-        if (!inputs) {
+        if (!inputs || !wfStatus) {
           console.error("Failed to find inputs during recover, workflow UUID: " + workflowUUID);
           continue;
         }
-        const wfInfo: WorkflowInfo<any, any> | undefined = this.workflowInfoMap.get(wfStatus!.workflowName);
+        const wfInfo: WorkflowInfo<any, any> | undefined = this.workflowInfoMap.get(wfStatus.workflowName);
 
-        const parentCtx = await this.systemDatabase.getRecoveryContext(this, workflowUUID);
+        const parentCtx = this.#getRecoveryContext(workflowUUID, wfStatus);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         handlerArray.push(await this.workflow(wfInfo!.workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined }, ...inputs))
       } catch (e) {
@@ -395,6 +397,20 @@ export class Operon {
       }
     }
     await Promise.allSettled(handlerArray.map((i) => i.getResult()));
+  }
+
+  #getRecoveryContext(workflowUUID: string, status: WorkflowStatus): OperonContextImpl {
+    const span = this.tracer.startSpan(status.workflowName);
+    span.setAttributes({
+      operationName: status.workflowName,
+    });
+    const oc = new OperonContextImpl(status.workflowName, span, this.logger);
+    oc.request = status.request ?? undefined;
+    oc.authenticatedUser = status.authenticatedUser;
+    oc.authenticatedRoles = status.authenticatedRoles;
+    oc.assumedRole = status.assumedRole;
+    oc.workflowUUID = workflowUUID;
+    return oc;
   }
 
   /* BACKGROUND PROCESSES */

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1,27 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { deserializeError, serializeError } from "serialize-error";
-import { Operon, operonNull, OperonNull } from "./operon";
+import { operonNull, OperonNull } from "./operon";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from "pg";
 import { OperonDuplicateWorkflowEventError, OperonWorkflowConflictUUIDError } from "./error";
 import { StatusString, WorkflowStatus } from "./workflow";
 import { systemDBSchema, notifications, operation_outputs, workflow_status, workflow_events, workflow_inputs } from "../schemas/system_db_schema";
 import { sleep } from "./utils";
-import { OperonContextImpl } from "./context";
+import { HTTPRequest } from "./context";
 
 export interface SystemDatabase {
   init(): Promise<void>;
   destroy(): Promise<void>;
 
   checkWorkflowOutput<R>(workflowUUID: string): Promise<OperonNull | R>;
-  initWorkflowStatus<T extends any[]>(workflowUUID: string, name: string, authenticatedUser: string, assumedRole: string, authenticatedRoles: string[], args: T): Promise<T>;
+  initWorkflowStatus<T extends any[]>(workflowUUID: string, name: string, authenticatedUser: string, assumedRole: string, authenticatedRoles: string[], request: HTTPRequest | null, args: T): Promise<T>;
   bufferWorkflowOutput<R>(workflowUUID: string, output: R): void;
   flushWorkflowStatusBuffer(): Promise<Array<string>>;
   recordWorkflowError(workflowUUID: string, error: Error): Promise<void>;
 
   getPendingWorkflows(): Promise<Array<string>>;
   getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null>;
-  getRecoveryContext(operon: Operon, workflowUUID: string): Promise<OperonContextImpl | null>;
 
   checkCommunicatorOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R>;
   recordCommunicatorOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void>;
@@ -86,10 +85,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async initWorkflowStatus<T extends any[]>(workflowUUID: string, name: string, authenticatedUser: string, assumedRole: string, authenticatedRoles: string[], args: T): Promise<T> {
+  async initWorkflowStatus<T extends any[]>(workflowUUID: string, name: string, authenticatedUser: string, assumedRole: string, authenticatedRoles: string[], request: HTTPRequest | null, args: T): Promise<T> {
     await this.pool.query(
-      `INSERT INTO workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, output) VALUES($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (workflow_uuid) DO NOTHING`,
-      [workflowUUID, StatusString.PENDING, name, authenticatedUser, assumedRole, JSON.stringify(authenticatedRoles), null]
+      `INSERT INTO workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output) VALUES($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (workflow_uuid) DO NOTHING`,
+      [workflowUUID, StatusString.PENDING, name, authenticatedUser, assumedRole, JSON.stringify(authenticatedRoles), JSON.stringify(request), null]
     );
     const { rows } = await this.pool.query<workflow_inputs>(
       `INSERT INTO workflow_inputs (workflow_uuid, inputs) VALUES($1, $2) ON CONFLICT (workflow_uuid) DO UPDATE SET workflow_uuid = excluded.workflow_uuid  RETURNING inputs`,
@@ -148,25 +147,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
       return null
     }
     return JSON.parse(rows[0].inputs) as T;
-  }
-
-  async getRecoveryContext(operon: Operon, workflowUUID: string): Promise<OperonContextImpl | null> {
-    const status = await this.getWorkflowStatus(workflowUUID);
-    if (!status) {
-      return null;
-    }
-    const span = operon.tracer.startSpan(status.workflowName);
-    span.setAttributes({
-      operationName: status.workflowName,
-    });
-    const oc = new OperonContextImpl(status.workflowName, span, operon.logger);
-    // FIXME: pass in the original request. IncomingMessage is not serializable.
-    oc.request = undefined;
-    oc.authenticatedUser = status.authenticatedUser;
-    oc.authenticatedRoles = status.authenticatedRoles;
-    oc.assumedRole = status.assumedRole;
-    oc.workflowUUID = workflowUUID;
-    return oc;
   }
 
   async checkCommunicatorOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R> {
@@ -367,11 +347,12 @@ export class PostgresSystemDatabase implements SystemDatabase {
   }
 
   async getWorkflowStatus(workflowUUID: string): Promise<WorkflowStatus | null> {
-    const { rows } = await this.pool.query<workflow_status>("SELECT status, name, authenticated_user, assumed_role, authenticated_roles FROM workflow_status WHERE workflow_uuid=$1", [workflowUUID]);
+    const { rows } = await this.pool.query<workflow_status>("SELECT status, name, authenticated_user, assumed_role, authenticated_roles, request FROM workflow_status WHERE workflow_uuid=$1", [workflowUUID]);
     if (rows.length === 0) {
       return null;
     }
-    return { status: rows[0].status, workflowName: rows[0].name, authenticatedUser: rows[0].authenticated_user, assumedRole: rows[0].assumed_role, authenticatedRoles: JSON.parse(rows[0].authenticated_roles) as string[] };
+    return { status: rows[0].status, workflowName: rows[0].name, authenticatedUser: rows[0].authenticated_user, assumedRole: rows[0].assumed_role, authenticatedRoles: JSON.parse(rows[0].authenticated_roles) as string[],
+    request: JSON.parse(rows[0].request) as HTTPRequest };
   }
 
   async getWorkflowResult<R>(workflowUUID: string): Promise<R> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -10,7 +10,7 @@ import { SystemDatabase } from "./system_database";
 import { UserDatabaseClient } from "./user_database";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { OperonContext, OperonContextImpl } from './context';
+import { HTTPRequest, OperonContext, OperonContextImpl } from './context';
 import { getRegisteredOperations } from "./decorators";
 
 export type OperonWorkflow<T extends any[], R> = (ctxt: WorkflowContext, ...args: T) => Promise<R>;
@@ -42,6 +42,7 @@ export interface WorkflowStatus {
   authenticatedUser: string;
   assumedRole: string;
   authenticatedRoles: string[];
+  request: HTTPRequest;
 }
 
 export interface PgTransactionId {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -127,10 +127,11 @@ describe("failures-tests", () => {
     // Run a workflow until pending and start recovery.
     clearInterval(operon.flushBufferID); // Don't flush the output buffer.
 
-    // Create an Operon context to pass authenticated user to the workflow.
+    // Create an Operon context to pass authenticated user and a URL to the workflow.
     const span = operon.tracer.startSpan("test");
     const oc = new OperonContextImpl("testRecovery", span, operon.logger);
     oc.authenticatedUser = "test_recovery_user";
+    oc.request = { url: "test-recovery-url" };
 
     const handle = await operon.workflow(FailureTestClass.testRecoveryWorkflow, { parentCtx: oc }, 5);
 
@@ -235,7 +236,7 @@ class FailureTestClass {
 
   @OperonWorkflow()
   static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
-    if (ctxt.authenticatedUser === "test_recovery_user") {
+    if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request?.url === "test-recovery-url") {
       FailureTestClass.cnt += input;
     }
     await FailureTestClass.promise1;

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -169,6 +169,7 @@ describe("httpserver-tests", () => {
     await expect(retrievedHandle.getResult()).resolves.toBe("hello 1");
     await expect(retrievedHandle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
+      request: { url: "/workflow?name=bob" },
     });
   });
 
@@ -184,6 +185,7 @@ describe("httpserver-tests", () => {
     await expect(retrievedHandle.getResult()).resolves.toBe("hello 1");
     await expect(retrievedHandle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
+      request: { url: "/handler/bob" },
     });
   });
 


### PR DESCRIPTION
This PR stores and retrieves the workflow's HTTP request (if any) to/from workflow status for failure recovery.

Previously we passed in `request=undefined` during recovery. Now our failure recovery is fully working.