### PR TITLE
Do not maintain null vs undefined

### DIFF
--- a/src/data_validation.ts
+++ b/src/data_validation.ts
@@ -32,6 +32,14 @@ export function validateOperonMethodArgs<Args extends unknown[]>(methReg: Operon
         }
 
         let argValue = args[idx];
+
+        // So... there is such a thing as "undefined", and another thing called "null"
+        // We will fold this to "undefined" for our APIs.  It's just a rule of ours.
+        if (argValue === null) {
+          argValue = undefined;
+          args[idx] = undefined;
+        }
+
         if (argValue === undefined && (argDescriptor.required === ArgRequiredOptions.REQUIRED ||
           (argDescriptor.required === ArgRequiredOptions.DEFAULT && methReg.defaults?.defaultArgRequired === ArgRequiredOptions.REQUIRED)))
         {

--- a/tests/httpServer/validation.test.ts
+++ b/tests/httpServer/validation.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { GetApi, PostApi, ArgVarchar, ArgDate, DefaultArgRequired, DefaultArgOptional, Debug, ArgRequired, ArgOptional, OperonTestingRuntime } from "../../src";
+import { GetApi, PostApi, ArgVarchar, ArgDate, DefaultArgRequired, DefaultArgOptional, Debug, ArgRequired, ArgOptional, OperonTestingRuntime, OperonWorkflow } from "../../src";
 import { generateOperonTestConfig, setupOperonTestDb } from "../helpers";
 import request from "supertest";
 import { HandlerContext } from "../../src/httpServer/handler";
 import { OperonConfig } from "../../src/operon";
+import { WorkflowContext } from "../../src";
 import { createInternalTestRuntime } from "../../src/testing/testing_runtime";
 
 describe("httpserver-datavalidation-tests", () => {
@@ -60,6 +61,12 @@ describe("httpserver-datavalidation-tests", () => {
   test("string post not a number", async () => {
     const response = await request(testRuntime.getHandlersCallback()).post("/string").send({ v: 1234 });
     expect(response.statusCode).toBe(400);
+  });
+
+  // No string to optional arg -- in a workflow
+  test("no string to workflow w optional arg", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).post("/doworkflow").send({});
+    expect(response.statusCode).toBe(200);
   });
 
   // Varchar(10)
@@ -561,6 +568,20 @@ describe("httpserver-datavalidation-tests", () => {
     @Debug()
     static async checkDefValueD(_ctx: HandlerContext, v?: string) {
       return { message: `Got string ${v}` };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    @OperonWorkflow()
+    static async opworkflow(_ctx: WorkflowContext, @ArgOptional v?: string)
+    {
+      return {message: v};
+    }
+    
+    @PostApi("/doworkflow")
+    static async doWorkflow(ctx: HandlerContext, @ArgOptional v?: string)
+    {
+      const wh = await ctx.invoke(DefaultArgToDefault).opworkflow(v);
+      return await wh.getResult();
     }
   }
 });


### PR DESCRIPTION
Convert 'null's to 'undefined's for methods defined for Operon.

It's sort of silly to have both.  It's much easier to work with serialization and databases if you only support one thing.

undefined is easier to work with because of ?: and other constructs.  Let's go with that for now.