### PR TITLE
Simplify getting started setup

### DIFF
--- a/examples/hello/package.json
+++ b/examples/hello/package.json
@@ -2,6 +2,7 @@
   "name": "operon-hello",
   "version": "0.0.1",
   "scripts": {
+    "operon-quickstart-setup": "PGPASSWORD=dbos ./start_postgres_docker.sh && knex migrate:latest && tsc",
     "build": "tsc",
     "test": "jest --runInBand"
   },


### PR DESCRIPTION
Add an npm command to:
- start postgres container
- perform knex migration
- run TSC

So the getting started guide can simply say `npm run operon-quickstart-setup` and briefly explain what it does.