### PR TITLE
Fix OAOO bug for workflow getStatus()

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -124,7 +124,6 @@ export class DBOSExecutor {
     this.telemetryCollector = new TelemetryCollector(telemetryExporters);
     this.tracer = new Tracer(this.telemetryCollector);
     this.initialized = false;
-    this.initialEpochTimeMs = Date.now();
   }
 
   configureDbClient() {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -239,7 +239,6 @@ export class DBOSExecutor {
         this.logger.debug("Executing init method: " + m.name);
         await m.origFunction(new InitContext(this));
       }
-
     }
 
     this.logger.info("Workflow executor initialized");
@@ -285,9 +284,6 @@ export class DBOSExecutor {
   }
 
   async workflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
-    if (this.debugMode) {
-      return this.debugWorkflow(wf, params, undefined, undefined, ...args);
-    }
     return this.internalWorkflow(wf, params, undefined, undefined, ...args);
   }
 
@@ -359,14 +355,6 @@ export class DBOSExecutor {
 
     // Return the normal handle that doesn't capture errors.
     return new InvokedHandle(this.systemDatabase, workflowPromise, workflowUUID, wf.name, callerUUID, callerFunctionID);
-  }
-
-  /**
-   * DEBUG MODE
-   */
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async debugWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
-    throw new DBOSError("NOT IMPLEMENTED!");
   }
 
   async transaction<T extends any[], R>(txn: Transaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -215,13 +215,14 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   /**
    * Invoke another workflow as its child workflow and return a workflow handle.
    * The child workflow is guaranteed to be executed exactly once, even if the workflow is retried with the same UUID.
-   * We pass in itself as a parent context adn assign the child workflow with a derministic UUID "this.workflowUUID-functionID", which appends a function ID to its own UUID.
+   * We pass in itself as a parent context adn assign the child workflow with a deterministic UUID "this.workflowUUID-functionID", which appends a function ID to its own UUID.
+   * We also pass in its own workflowUUID and function ID so the invoked handle is deterministic.
    */
   async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
-    return this.#wfe.workflow(wf, { parentCtx: this, workflowUUID: childUUID }, ...args);
+    return this.#wfe.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 
   /**

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -1,0 +1,104 @@
+import { WorkflowContext, Workflow, TestingRuntime } from "../../src/";
+import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
+import { DBOSConfig } from "../../src/dbos-executor";
+import { TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import { v1 as uuidv1 } from "uuid";
+import { createInternalTestFDB } from "./fdb_helpers";
+
+describe("foundationdb-oaoo", () => {
+  let config: DBOSConfig;
+  let testRuntime: TestingRuntime;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    const systemDB = await createInternalTestFDB();
+    testRuntime = await createInternalTestRuntime([EventStatusOAOO], config, systemDB);
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  /**
+   * GetEvent/Status OAOO tests.
+   */
+  class EventStatusOAOO {
+    static wfCnt: number = 0;
+    static resolve: () => void;
+    static promise = new Promise<void>((r) => {
+      EventStatusOAOO.resolve = r;
+    });
+
+    @Workflow()
+    static async setEventWorkflow(ctxt: WorkflowContext) {
+      await ctxt.setEvent("key1", "value1");
+      await ctxt.setEvent("key2", "value2");
+      await EventStatusOAOO.promise;
+      throw Error("Failed workflow");
+    }
+
+    @Workflow()
+    static async getEventRetrieveWorkflow(ctxt: WorkflowContext, targetUUID: string): Promise<string> {
+      let res = "";
+      const getValue = await ctxt.getEvent<string>(targetUUID, "key1", 0);
+      EventStatusOAOO.wfCnt++;
+      if (getValue === null) {
+        res = "valueNull";
+      } else {
+        res = getValue;
+      }
+  
+      const handle = ctxt.retrieveWorkflow(targetUUID);
+      const status = await handle.getStatus();
+      EventStatusOAOO.wfCnt++;
+      if (status === null) {
+        res += "-statusNull";
+      } else {
+        res += "-" + status.status;
+      }
+  
+      // Note: the targetUUID must match the child workflow UUID.
+      const invokedHandle = await ctxt.childWorkflow(EventStatusOAOO.setEventWorkflow);
+      try {
+        if (EventStatusOAOO.wfCnt > 2) {
+          await invokedHandle.getResult();
+        }
+      } catch(e) {
+        // Ignore error.
+        ctxt.logger.error(e);
+      }
+
+      const ires = await invokedHandle.getStatus();
+      res += "-" + ires?.status;
+      return res;
+    }
+  }
+
+  test("workflow-getevent-retrieve", async() => {
+    // Execute a workflow (w/ getUUID) to get an event and retrieve a workflow that doesn't exist, then invoke the setEvent workflow as a child workflow.
+    // If we execute the get workflow without UUID, both getEvent and retrieveWorkflow should return values.
+    // But if we run the get workflow again with getUUID, getEvent/retrieveWorkflow should still return null.
+    const wfe = (testRuntime as TestingRuntimeImpl).getDBOSExec();
+    clearInterval(wfe.flushBufferID); // Don't flush the output buffer.
+
+    const getUUID = uuidv1();
+    const setUUID = getUUID + "-2";
+
+    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
+    expect(EventStatusOAOO.wfCnt).toBe(2);
+    await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
+
+    EventStatusOAOO.resolve();
+    // Run without UUID, should get the new result.
+    await expect(testRuntime.invoke(EventStatusOAOO).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("value1-ERROR-ERROR");
+
+    // Test OAOO for getEvent and getWorkflowStatus.
+    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
+    expect(EventStatusOAOO.wfCnt).toBe(6);  // Should re-execute the workflow because we're not flushing the result buffer.
+  });
+
+});

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -51,7 +51,7 @@ describe("foundationdb-oaoo", () => {
       } else {
         res = getValue;
       }
-  
+
       const handle = ctxt.retrieveWorkflow(targetUUID);
       const status = await handle.getStatus();
       EventStatusOAOO.wfCnt++;
@@ -60,14 +60,14 @@ describe("foundationdb-oaoo", () => {
       } else {
         res += "-" + status.status;
       }
-  
+
       // Note: the targetUUID must match the child workflow UUID.
       const invokedHandle = await ctxt.childWorkflow(EventStatusOAOO.setEventWorkflow);
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();
         }
-      } catch(e) {
+      } catch (e) {
         // Ignore error.
         ctxt.logger.error(e);
       }
@@ -78,7 +78,7 @@ describe("foundationdb-oaoo", () => {
     }
   }
 
-  test("workflow-getevent-retrieve", async() => {
+  test("workflow-getevent-retrieve", async () => {
     // Execute a workflow (w/ getUUID) to get an event and retrieve a workflow that doesn't exist, then invoke the setEvent workflow as a child workflow.
     // If we execute the get workflow without UUID, both getEvent and retrieveWorkflow should return values.
     // But if we run the get workflow again with getUUID, getEvent/retrieveWorkflow should still return null.
@@ -88,17 +88,31 @@ describe("foundationdb-oaoo", () => {
     const getUUID = uuidv1();
     const setUUID = getUUID + "-2";
 
-    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
+    await expect(
+      testRuntime
+        .invoke(EventStatusOAOO, getUUID)
+        .getEventRetrieveWorkflow(setUUID)
+        .then((x) => x.getResult())
+    ).resolves.toBe("valueNull-statusNull-PENDING");
     expect(EventStatusOAOO.wfCnt).toBe(2);
     await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
 
     EventStatusOAOO.resolve();
     // Run without UUID, should get the new result.
-    await expect(testRuntime.invoke(EventStatusOAOO).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("value1-ERROR-ERROR");
+    await expect(
+      testRuntime
+        .invoke(EventStatusOAOO)
+        .getEventRetrieveWorkflow(setUUID)
+        .then((x) => x.getResult())
+    ).resolves.toBe("value1-ERROR-ERROR");
 
     // Test OAOO for getEvent and getWorkflowStatus.
-    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
-    expect(EventStatusOAOO.wfCnt).toBe(6);  // Should re-execute the workflow because we're not flushing the result buffer.
+    await expect(
+      testRuntime
+        .invoke(EventStatusOAOO, getUUID)
+        .getEventRetrieveWorkflow(setUUID)
+        .then((x) => x.getResult())
+    ).resolves.toBe("valueNull-statusNull-PENDING");
+    expect(EventStatusOAOO.wfCnt).toBe(6); // Should re-execute the workflow because we're not flushing the result buffer.
   });
-
 });


### PR DESCRIPTION
This PR fixes a bug in `childWorkflow()` where we didn't correctly pass its own UUID and funcID to the invokedHandle. Therefore, the `getStatus()` method in the invokedHandle wasn't actually OAOO.

This PR also updates the OAOO tests for this potential buggy scenario.