### PR TITLE
Initial Debugger

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -141,11 +141,15 @@ export class DBOSExecutor {
     const userDbClient = this.config.userDbclient;
     const localConfig = JSON.parse(JSON.stringify(this.config.poolConfig)) as PoolConfig; // Deep copy
     if (this.debugMode) {
-      // TODO: we currently use a single hostname:port string. Need to find a better way to configure the debug mode.
-      const parts = this.config.debugProxy!.split(':');
-      localConfig.host = parts[0];
-      localConfig.port = parseInt(parts[1], 10);
-      this.logger.info("Debugging mode proxy: " + this.config.debugProxy);
+      try {
+        const url = new URL(this.config.debugProxy!);
+        localConfig.host = url.hostname;
+        localConfig.port = parseInt(url.port, 10);
+        this.logger.info(`Debugging mode proxy: ${localConfig.host}:${localConfig.port}`);
+      } catch (err) {
+        this.logger.error(err);
+        return;
+      }
     }
     if (userDbClient === UserDatabaseName.PRISMA) {
       // TODO: make Prisma work with debugger proxy.

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -41,6 +41,7 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import knex, { Knex } from 'knex';
 import { DBOSContextImpl, InitContext } from './context';
 import { HandlerRegistration } from './httpServer/handler';
+import { WorkflowContextDebug } from './debugger/debug_workflow';
 
 export interface DBOSNull { }
 export const dbosNull: DBOSNull = {};
@@ -400,7 +401,7 @@ export class DBOSExecutor {
     }
     const wConfig = wInfo.config;
 
-    const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name);
+    const wCtxt = new WorkflowContextDebug(this, params.parentCtx, workflowUUID, wConfig, wf.name);
 
     // TODO: maybe also check the input args against the recorded ones.
     const runWorkflow = async () => {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -139,13 +139,13 @@ export class DBOSExecutor {
 
   configureDbClient() {
     const userDbClient = this.config.userDbclient;
-    const localConfig = JSON.parse(JSON.stringify(this.config.poolConfig)) as PoolConfig; // Deep copy
+    const userDBConfig = JSON.parse(JSON.stringify(this.config.poolConfig)) as PoolConfig; // Deep copy
     if (this.debugMode) {
       try {
         const url = new URL(this.config.debugProxy!);
-        localConfig.host = url.hostname;
-        localConfig.port = parseInt(url.port, 10);
-        this.logger.info(`Debugging mode proxy: ${localConfig.host}:${localConfig.port}`);
+        userDBConfig.host = url.hostname;
+        userDBConfig.port = parseInt(url.port, 10);
+        this.logger.info(`Debugging mode proxy: ${userDBConfig.host}:${userDBConfig.port}`);
       } catch (err) {
         this.logger.error(err);
         return;
@@ -165,11 +165,11 @@ export class DBOSExecutor {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         this.userDatabase = new TypeORMDatabase(new DataSourceExports.DataSource({
           type: "postgres", // perhaps should move to config file
-          host: localConfig.host,
-          port: localConfig.port,
-          username: localConfig.user,
-          password: localConfig.password,
-          database: localConfig.database,
+          host: userDBConfig.host,
+          port: userDBConfig.port,
+          username: userDBConfig.user,
+          password: userDBConfig.password,
+          database: userDBConfig.database,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           entities: this.entities
         }))
@@ -181,18 +181,18 @@ export class DBOSExecutor {
       const knexConfig: Knex.Config = {
         client: "postgres",
         connection: {
-          host: localConfig.host,
-          port: localConfig.port,
-          user: localConfig.user,
-          password: localConfig.password,
-          database: localConfig.database,
-          ssl: localConfig.ssl,
+          host: userDBConfig.host,
+          port: userDBConfig.port,
+          user: userDBConfig.user,
+          password: userDBConfig.password,
+          database: userDBConfig.database,
+          ssl: userDBConfig.ssl,
         }
       }
       this.userDatabase = new KnexUserDatabase(knex(knexConfig));
       this.logger.debug("Loaded Knex user database");
     } else {
-      this.userDatabase = new PGNodeUserDatabase(localConfig);
+      this.userDatabase = new PGNodeUserDatabase(userDBConfig);
       this.logger.debug("Loaded Postgres user database");
     }
   }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -85,11 +85,7 @@ export class DBOSExecutor {
   readonly transactionConfigMap: Map<string, TransactionConfig> = new Map();
   readonly communicatorConfigMap: Map<string, CommunicatorConfig> = new Map();
   readonly registeredOperations: Array<MethodRegistrationBase> = [];
-<<<<<<< HEAD
   readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to workflow promise.
-=======
-  readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map();  // Map from workflowUUID to workflow promise.
->>>>>>> e6b2d26 (clean up code, add debug mode)
 
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -21,6 +21,7 @@ export interface DBOSCLIStartOptions {
   loglevel?: string,
   configfile?: string,
   entrypoint?: string,
+  debug?: string,
 }
 
 program
@@ -42,6 +43,7 @@ program
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
   .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
+  .option('-d, --debug <string>', 'Specify the debugger proxy URL')
   .action(async (options: DBOSCLIStartOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -128,6 +128,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions): [DBOSConfig, 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       entities: configFile.dbClientMetadata?.entities,
     },
+    debugProxy: cliOptions?.debug || undefined,
   };
 
   /*************************************/

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DBOSExecutor, DBOSNull, dbosNull } from "../dbos-executor";
+import { transaction_outputs } from "../../schemas/user_db_schema";
+import { IsolationLevel, Transaction, TransactionContext, TransactionContextImpl } from "../transaction";
+import { Communicator, CommunicatorContext, CommunicatorContextImpl } from "../communicator";
+import { DBOSError, DBOSNotRegisteredError, DBOSWorkflowConflictUUIDError } from "../error";
+import { serializeError, deserializeError } from "serialize-error";
+import { SystemDatabase } from "../system_database";
+import { UserDatabaseClient } from "../user_database";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { Span } from "@opentelemetry/sdk-trace-base";
+import { HTTPRequest, DBOSContext, DBOSContextImpl } from '../context';
+import { getRegisteredOperations } from "../decorators";
+import { WFInvokeFuncs, Workflow, WorkflowConfig, WorkflowContext, WorkflowHandle } from "../workflow";
+
+/**
+ * Context used for debugging a workflow
+ */
+export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowContext {
+  functionID: number = 0;
+  readonly #wfe;
+  readonly isTempWorkflow: boolean;
+
+  constructor(wfe: DBOSExecutor, parentCtx: DBOSContextImpl | undefined, workflowUUID: string, readonly workflowConfig: WorkflowConfig, workflowName: string) {
+    const span = wfe.tracer.startSpan(workflowName, { workflowUUID: workflowUUID }, parentCtx?.span);
+    super(workflowName, span, wfe.logger, parentCtx);
+    this.workflowUUID = workflowUUID;
+    this.#wfe = wfe;
+    this.isTempWorkflow = wfe.tempWorkflowName === workflowName;
+    if (wfe.config.application) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      this.applicationConfig = wfe.config.application;
+    }
+  }
+
+  functionIDGetIncrement(): number {
+    return this.functionID++;
+  }
+
+  invoke<T extends object>(object: T): WFInvokeFuncs<T> {
+    const ops = getRegisteredOperations(object);
+
+    const proxy: any = {};
+    for (const op of ops) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      proxy[op.name] = op.txnConfig
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        ? (...args: any[]) => this.transaction(op.registeredFunction as Transaction<any[], any>, ...args)
+        : op.commConfig
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        ? (...args: any[]) => this.external(op.registeredFunction as Communicator<any[], any>, ...args)
+        : undefined;
+    }
+    return proxy as WFInvokeFuncs<T>;
+  }
+
+  async transaction<T extends any[], R>(txn: Transaction<T, R>, ...args: T): Promise<R> {
+    throw new Error("Method not implemented");
+  }
+
+  external<T extends any[], R>(commFn: Communicator<T, R>, ...args: T): Promise<R> {
+    throw new Error("Method not implemented");
+  }
+
+  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+    const funcId = this.functionIDGetIncrement();
+    const childUUID: string = this.workflowUUID + "-" + funcId;
+    return this.#wfe.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
+  }
+
+  send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string | undefined): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  recv<T extends NonNullable<any>>(topic?: string | undefined, timeoutSeconds?: number | undefined): Promise<T | null> {
+    throw new Error("Method not implemented.");
+  }
+  setEvent<T extends NonNullable<any>>(key: string, value: T): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number | undefined): Promise<T | null> {
+    throw new Error("Method not implemented.");
+  }
+  retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -154,3 +154,9 @@ export class DBOSConfigKeyTypeError extends DBOSError {
   }
 }
 
+const DebuggerError = 15;
+export class DBOSDebuggerError extends DBOSError {
+  constructor(msg: string) {
+    super("DEBUGGER: " + msg, DebuggerError);
+  }
+}

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -5,6 +5,7 @@ import { Span } from "@opentelemetry/sdk-trace-base";
 import { DBOSContext, DBOSContextImpl } from "./context";
 import { ValuesOf } from "./utils";
 import { WinstonLogger as Logger } from "./telemetry/logs";
+import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
 // Can we call it TransactionFunction
 export type Transaction<T extends any[], R> = (ctxt: TransactionContext<any>, ...args: T) => Promise<R>;
@@ -30,7 +31,7 @@ export class TransactionContextImpl<T extends UserDatabaseClient> extends DBOSCo
   constructor(
     readonly clientKind: UserDatabaseName,
     readonly client: T,
-    workflowContext: WorkflowContextImpl,
+    workflowContext: WorkflowContextImpl | WorkflowContextDebug,
     span: Span,
     logger: Logger,
     readonly functionID: number,

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -254,6 +254,9 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
+    if (this.#wfe.debugMode) {
+      return this.#wfe.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
+    }
     return this.#wfe.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -254,9 +254,6 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
-    if (this.#wfe.debugMode) {
-      return this.#wfe.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
-    }
     return this.#wfe.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -23,8 +23,6 @@ describe("dbos-tests", () => {
 
   beforeEach(async () => {
     testRuntime = await createInternalTestRuntime([DBOSTestClass, ReadRecording, RetrieveWorkflowStatus], config);
-    // await testRuntime.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
-    // await testRuntime.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id SERIAL PRIMARY KEY, value TEXT);`);
     DBOSTestClass.cnt = 0;
   });
 
@@ -227,7 +225,6 @@ class DBOSTestClass {
   static initialized = false;
   static cnt: number = 0;
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @DBOSInitializer()
   static async init(_ctx: InitContext) { 
     DBOSTestClass.initialized = true;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,7 @@ import { UserDatabaseName } from "../src/user_database";
 import { setApplicationVersion } from "../src/dbos-runtime/applicationVersion";
 
 /* DB management helpers */
-export function generateDBOSTestConfig(dbClient?: UserDatabaseName): DBOSConfig {
+export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugProxy?: string): DBOSConfig {
   const dbPassword: string | undefined = process.env.DB_PASSWORD || process.env.PGPASSWORD;
   if (!dbPassword) {
     throw new Error("DB_PASSWORD or PGPASSWORD environment variable not set");
@@ -41,6 +41,7 @@ export function generateDBOSTestConfig(dbClient?: UserDatabaseName): DBOSConfig 
     dbClientMetadata: {
       entities: ["KV"],
     },
+    debugProxy: debugProxy,
   };
 
   return dbosTestConfig;

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,11 +1,9 @@
-import { WorkflowContext, TransactionContext, CommunicatorContext, WorkflowHandle, Transaction, Workflow, Communicator, DBOSInitializer, InitContext } from "../../src/";
+import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext } from "../../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers";
 import { v1 as uuidv1 } from "uuid";
-import { StatusString } from "../../src/workflow";
 import { DBOSConfig } from "../../src/dbos-executor";
 import { PoolClient } from "pg";
-import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
-import { DBOSDebuggerError } from "../../src/error";
+import { TestingRuntime, createInternalTestRuntime } from "../../src/testing/testing_runtime";
 
 type TestTransactionContext = TransactionContext<PoolClient>;
 const testTableName = "debugger_test_kv";

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,0 +1,75 @@
+import { WorkflowContext, TransactionContext, CommunicatorContext, WorkflowHandle, Transaction, Workflow, Communicator, DBOSInitializer, InitContext } from "../../src/";
+import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers";
+import { v1 as uuidv1 } from "uuid";
+import { StatusString } from "../../src/workflow";
+import { DBOSConfig } from "../../src/dbos-executor";
+import { PoolClient } from "pg";
+import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import { DBOSDebuggerError } from "../../src/error";
+
+type TestTransactionContext = TransactionContext<PoolClient>;
+
+describe("debugger-test", () => {
+  let username: string;
+  let config: DBOSConfig;
+  let testRuntime: TestingRuntime;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    username = config.poolConfig.user || "postgres";
+    await setUpDBOSTestDb(config);
+  });
+
+  class DebuggerTest {
+    @Transaction()
+    static async testFunction(txnCtxt: TestTransactionContext, name: string) {
+      const { rows } = await txnCtxt.client.query(`select current_user from current_user where current_user=$1;`, [name]);
+      txnCtxt.logger.debug("Name: " + name);
+      return JSON.stringify(rows[0]);
+    }
+
+    @Workflow()
+    static async testWorkflow(ctxt: WorkflowContext, name: string) {
+      const funcResult = await ctxt.invoke(DebuggerTest).testFunction(name);
+      return funcResult;
+    }
+  }
+
+  test("debug-workflow", async () => {
+    process.env["SILENCE_LOGS"] = "false";
+    const debugConfig = generateDBOSTestConfig(undefined, "127.0.0.1:5432");
+    const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
+
+    const wfUUID = uuidv1();
+    // Execute the workflow and destroy the runtime
+    testRuntime = await createInternalTestRuntime([DebuggerTest], config);
+    const res = await testRuntime
+      .invoke(DebuggerTest, wfUUID)
+      .testWorkflow(username)
+      .then((x) => x.getResult());
+    expect(JSON.parse(res)).toEqual({ current_user: username });
+    await testRuntime.destroy();
+
+    // Execute again in debug mode.
+    // TODO: test with a real proxy.
+    const debugRes = await debugRuntime
+      .invoke(DebuggerTest, wfUUID)
+      .testWorkflow(username)
+      .then((x) => x.getResult());
+    expect(JSON.parse(debugRes)).toEqual({ current_user: username });
+
+    // Execute a non-exist UUID should fail.
+    const wfUUID2 = uuidv1();
+    const nonExist = await debugRuntime
+    .invoke(DebuggerTest, wfUUID2)
+    .testWorkflow(username);
+    await expect(nonExist.getResult()).rejects.toThrow("Workflow status not found!");
+
+    // Execute a workflow without specifying the UUID should fail.
+    await expect(debugRuntime
+      .invoke(DebuggerTest)
+      .testWorkflow(username)).rejects.toThrow("Workflow UUID not found!");
+
+    await debugRuntime.destroy();
+  });
+});

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -42,6 +42,7 @@ describe("debugger-test", () => {
   }
 
   test("debug-workflow", async () => {
+    // TODO: connect to the real proxy.
     const debugConfig = generateDBOSTestConfig(undefined, "127.0.0.1:5432");
     const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
 
@@ -56,7 +57,6 @@ describe("debugger-test", () => {
     await testRuntime.destroy();
 
     // Execute again in debug mode.
-    // TODO: test with a real proxy.
     const debugRes = await debugRuntime
       .invoke(DebuggerTest, wfUUID)
       .testWorkflow(username)

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -41,7 +41,7 @@ describe("debugger-test", () => {
 
   test("debug-workflow", async () => {
     // TODO: connect to the real proxy.
-    const debugConfig = generateDBOSTestConfig(undefined, "127.0.0.1:5432");
+    const debugConfig = generateDBOSTestConfig(undefined, "http://127.0.0.1:5432");
     const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
 
     const wfUUID = uuidv1();


### PR DESCRIPTION
This PR adds initial support for the debug mode. The main goal is to faithfully replay past workflow executions. Under debug mode, everything should be read-only: we skip initialization steps in the database and don't record for OAOO. Instead of connecting to the actual user DB, we connect to a debugger proxy which transforms queries to perform time traveling.

Details:
- Add a CLI option for `npx dbos-sdk start`: `-d, --debug` with the URL of the debug proxy.
- We can only execute a workflow in debug if we can find recorded workflow status and transaction output. Otherwise, we throw an error.
- Create a new workflow context called `WorkflowContextDebug`, which implements debugger specific methods. We currently only support executing transaction functions or child workflows. Will implement more in the future.
- Add a debugger test. We currently connect to the actual user DB in debug mode, but once the proxy is ready, we can test with it.
