### PR TITLE
run npm prune during the deploy path

### DIFF
--- a/src/cloud-cli/applications/deploy-app-code.ts
+++ b/src/cloud-cli/applications/deploy-app-code.ts
@@ -34,6 +34,7 @@ export async function deployAppCode(appName: string, host: string, port: string)
       return 1;
     }
 
+    execSync(`npm prune --production node_modules/* `);
     execSync(`zip -ry ${deployDirectoryName}/${appName}.zip ./* -x ${deployDirectoryName}/* ${dbosConfigFilePath} > /dev/null`);
     execSync(`zip -j ${deployDirectoryName}/${appName}.zip ${deployDirectoryName}/${dbosConfigFilePath} > /dev/null`);
 


### PR DESCRIPTION
[npm prune](https://docs.npmjs.com/cli/v8/commands/npm-prune/):

> This command removes "extraneous" packages. If a package name is provided, then only packages matching one of the supplied names are removed.
> 
> Extraneous packages are those present in the node_modules folder that are not listed as any package's dependency list.
> 
> If the --production flag is specified or the NODE_ENV environment variable is set to production, this command will remove the packages specified in your devDependencies. 

For example on the examples/hello app:
<img width="1426" alt="Screenshot 2023-12-01 at 23 41 53" src="https://github.com/dbos-inc/dbos-ts/assets/3437048/31ff01c8-c9d0-40c3-980a-50f8dc52588b">

Tested with our demo app in DBOS cloud (deploy from the main CLI or this PR's CLI)
![Screenshot 2023-12-03 at 11 11 16](https://github.com/dbos-inc/dbos-ts/assets/3437048/c0c485cb-e36f-46c3-acbe-294cfa717d02)

Unzipped (this should be a good proxy of  the application disk image's size)
![Screenshot 2023-12-03 at 11 12 18](https://github.com/dbos-inc/dbos-ts/assets/3437048/0774e00b-587d-4d0d-a5cd-6a54a5f2beed)


✅ Passes integration tests in DBOS cloud