### PR TITLE
Implement Debug Methods

### DIFF
--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -2,6 +2,7 @@ import { Span } from "@opentelemetry/sdk-trace-base";
 import { WinstonLogger as Logger } from "./telemetry/logs";
 import { WorkflowContextImpl } from "./workflow";
 import { DBOSContext, DBOSContextImpl } from "./context";
+import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type Communicator<T extends any[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;
@@ -19,8 +20,7 @@ export interface CommunicatorContext extends DBOSContext {
   readonly maxAttempts: number;
 }
 
-export class CommunicatorContextImpl extends DBOSContextImpl implements CommunicatorContext
-{
+export class CommunicatorContextImpl extends DBOSContextImpl implements CommunicatorContext {
   readonly functionID: number;
   readonly retriesAllowed: boolean;
   readonly intervalSeconds: number;
@@ -28,7 +28,7 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
   readonly backoffRate: number;
 
   // TODO: Validate the parameters.
-  constructor(workflowContext: WorkflowContextImpl, functionID: number, span: Span, logger: Logger, params: CommunicatorConfig, commName: string) {
+  constructor(workflowContext: WorkflowContextImpl | WorkflowContextDebug, functionID: number, span: Span, logger: Logger, params: CommunicatorConfig, commName: string) {
     super(commName, span, logger, workflowContext);
     this.functionID = functionID;
     this.retriesAllowed = params.retriesAllowed ?? true;
@@ -37,7 +37,7 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
     this.backoffRate = params.backoffRate ?? 2;
     if (workflowContext.applicationConfig) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-       this.applicationConfig = workflowContext.applicationConfig;
+      this.applicationConfig = workflowContext.applicationConfig;
     }
   }
 }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -255,6 +255,8 @@ export class DBOSExecutor {
       if (err instanceof Error) {
         this.logger.error(`failed to initialize workflow executor: ${err.message}`, err, err.stack);
         throw new DBOSInitializationError(err.message);
+      } else {
+        throw err;
       }
     }
     this.initialized = true;

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -1,18 +1,16 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DBOSExecutor, DBOSNull, dbosNull } from "../dbos-executor";
 import { transaction_outputs } from "../../schemas/user_db_schema";
-import { IsolationLevel, Transaction, TransactionContext, TransactionContextImpl } from "../transaction";
-import { Communicator, CommunicatorContext, CommunicatorContextImpl } from "../communicator";
-import { DBOSDebuggerError, DBOSError, DBOSNotRegisteredError, DBOSWorkflowConflictUUIDError } from "../error";
-import { serializeError, deserializeError } from "serialize-error";
+import { Transaction, TransactionContextImpl } from "../transaction";
+import { Communicator } from "../communicator";
+import { DBOSDebuggerError} from "../error";
+import { deserializeError } from "serialize-error";
 import { SystemDatabase } from "../system_database";
 import { UserDatabaseClient } from "../user_database";
-import { SpanStatusCode } from "@opentelemetry/api";
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { HTTPRequest, DBOSContext, DBOSContextImpl } from '../context';
+import { DBOSContextImpl } from "../context";
 import { getRegisteredOperations } from "../decorators";
-import { WFInvokeFuncs, Workflow, WorkflowConfig, WorkflowContext, WorkflowHandle } from "../workflow";
+import { WFInvokeFuncs, Workflow, WorkflowConfig, WorkflowContext, WorkflowHandle, WorkflowStatus } from "../workflow";
 
 interface RecordedResult<R> {
   output: R;
@@ -51,11 +49,11 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     for (const op of ops) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       proxy[op.name] = op.txnConfig
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ? (...args: any[]) => this.transaction(op.registeredFunction as Transaction<any[], any>, ...args)
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          (...args: any[]) => this.transaction(op.registeredFunction as Transaction<any[], any>, ...args)
         : op.commConfig
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        ? (...args: any[]) => this.external(op.registeredFunction as Communicator<any[], any>, ...args)
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          (...args: any[]) => this.external(op.registeredFunction as Communicator<any[], any>, ...args)
         : undefined;
     }
     return proxy as WFInvokeFuncs<T>;
@@ -65,12 +63,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     // Note: we read the recorded snapshot and transaction ID!
     const query = "SELECT output, error, txn_snapshot, txn_id FROM dbos.transaction_outputs WHERE workflow_uuid=$1 AND function_id=$2";
 
-    const rows = await this.#wfe.userDatabase.queryWithClient<transaction_outputs>(
-      client,
-      query,
-      this.workflowUUID,
-      funcID
-    );
+    const rows = await this.#wfe.userDatabase.queryWithClient<transaction_outputs>(client, query, this.workflowUUID, funcID);
 
     if (rows.length === 0 || rows.length > 1) {
       this.logger.error("Unexpected! This should never happen during debug. Returned rows: " + rows.toString());
@@ -85,7 +78,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
       output: JSON.parse(rows[0].output) as R,
       txn_snapshot: rows[0].txn_snapshot,
       txn_id: rows[0].txn_id,
-    }
+    };
 
     // Send a signal to the debug proxy.
     // TODO: use the real command once the proxy is fully implemented.
@@ -110,8 +103,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
     const wrappedTransaction = async (client: UserDatabaseClient): Promise<R> => {
       // Original result must exist during replay.
-      const tCtxt = new TransactionContextImpl(this.#wfe.userDatabase.getName(), client, this,
-      span, this.#wfe.logger, funcID, txn.name);
+      const tCtxt = new TransactionContextImpl(this.#wfe.userDatabase.getName(), client, this, span, this.#wfe.logger, funcID, txn.name);
       check = await this.checkExecution<R>(client, funcID);
 
       // Execute the user's transaction.
@@ -127,7 +119,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check!.output; // Always return the recorded result.
   }
 
-  async external<T extends any[], R>(commFn: Communicator<T, R>, ...args: T): Promise<R> {
+  async external<T extends any[], R>(commFn: Communicator<T, R>, ..._args: T): Promise<R> {
     const commConfig = this.#wfe.communicatorConfigMap.get(commFn.name);
     if (commConfig === undefined) {
       throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
@@ -174,13 +166,55 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check as T | null;
   }
 
-  setEvent<T extends NonNullable<any>>(key: string, value: T): Promise<void> {
-    throw new Error("Method not implemented.");
+  async setEvent<T extends NonNullable<any>>(_key: string, _value: T): Promise<void> {
+    const functionID: number = this.functionIDGetIncrement();
+    // Original result must exist during replay.
+    const check: undefined | DBOSNull = await this.#wfe.systemDatabase.checkOperationOutput<undefined>(this.workflowUUID, functionID);
+    if (check === dbosNull) {
+      throw new DBOSDebuggerError(`Cannot find recorded setEvent. Shouldn't happen in debug mode!`);
+    }
+    this.logger.debug("Use recorded setEvent output.");
   }
-  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number | undefined): Promise<T | null> {
-    throw new Error("Method not implemented.");
+
+  async getEvent<T extends NonNullable<any>>(_workflowUUID: string, _key: string, _timeoutSeconds?: number | undefined): Promise<T | null> {
+    const functionID: number = this.functionIDGetIncrement();
+
+    // Original result must exist during replay.
+    const check: T | null | DBOSNull = await this.#wfe.systemDatabase.checkOperationOutput<T | null>(this.workflowUUID, functionID);
+    if (check === dbosNull) {
+      throw new DBOSDebuggerError(`Cannot find recorded getEvent. Shouldn't happen in debug mode!`);
+    }
+    this.logger.debug("Use recorded getEvent output.");
+    return check as T | null;
   }
-  retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R> {
-    throw new Error("Method not implemented.");
+
+  retrieveWorkflow<R>(targetUUID: string): WorkflowHandle<R> {
+    // TODO: write a proper test for this.
+    const functionID: number = this.functionIDGetIncrement();
+    return new RetrievedHandleDebug(this.#wfe.systemDatabase, targetUUID, this.workflowUUID, functionID);
+  }
+}
+
+/**
+ * The handle returned when retrieving a workflow with Debug workflow's retrieve
+ */
+class RetrievedHandleDebug<R> implements WorkflowHandle<R> {
+  constructor(readonly systemDatabase: SystemDatabase, readonly workflowUUID: string, readonly callerUUID: string, readonly callerFunctionID: number) {}
+
+  getWorkflowUUID(): string {
+    return this.workflowUUID;
+  }
+
+  async getStatus(): Promise<WorkflowStatus | null> {
+    // Must use original result.
+    const check: WorkflowStatus | null | DBOSNull = await this.systemDatabase.checkOperationOutput<WorkflowStatus | null>(this.callerUUID, this.callerFunctionID);
+    if (check === dbosNull) {
+      throw new DBOSDebuggerError(`Cannot find recorded workflow status. Shouldn't happen in debug mode!`);
+    }
+    return check as WorkflowStatus | null;
+  }
+
+  async getResult(): Promise<R> {
+    return await this.systemDatabase.getWorkflowResult<R>(this.workflowUUID);
   }
 }

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -78,6 +78,7 @@ export async function createInternalTestRuntime(userClasses: object[], testConfi
 export class TestingRuntimeImpl implements TestingRuntime {
   #server: DBOSHttpServer | null = null;
   #applicationConfig: unknown = undefined;
+  #isInitialized = false;
 
   /**
    * Initialize the testing runtime by loading user functions specified in classes and using the specified config.
@@ -89,13 +90,18 @@ export class TestingRuntimeImpl implements TestingRuntime {
     await dbosExec.init(...userClasses);
     this.#server = new DBOSHttpServer(dbosExec);
     this.#applicationConfig = dbosExec.config.application;
+    this.#isInitialized = true;
   }
 
   /**
    * Release resources after tests.
    */
   async destroy() {
-    await this.#server?.dbosExec.destroy();
+    // Only release once.
+    if (this.#isInitialized) {
+      await this.#server?.dbosExec.destroy();
+      this.#isInitialized = false;
+    }
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -119,7 +119,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     // Note: we read the current snapshot, not the recorded one!
     const rows = await this.#wfe.userDatabase.queryWithClient<transaction_outputs & { recorded: boolean }>(
       client,
-      "(SELECT output, error, pg_current_snapshot()::text as txn_snapshot, true as recorded FROM dbos.transaction_outputs WHERE workflow_uuid=$1 AND function_id=$2 UNION ALL SELECT null as output, null as error, pg_current_snapshot()::text as txn_snapshot, false as recorded) ORDER BY recorded",
+      "(SELECT output, error, txn_snapshot, true as recorded FROM dbos.transaction_outputs WHERE workflow_uuid=$1 AND function_id=$2 UNION ALL SELECT null as output, null as error, pg_current_snapshot()::text as txn_snapshot, false as recorded) ORDER BY recorded",
       this.workflowUUID,
       funcID
     );

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -98,6 +98,11 @@ describe("foundationdb-oaoo", () => {
     await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
 
     EventStatusOAOO.resolve();
+
+    // Wait for the child workflow to finish.
+    const handle = testRuntime.retrieveWorkflow(setUUID);
+    await expect(handle.getResult()).rejects.toThrow("Failed workflow");
+
     // Run without UUID, should get the new result.
     await expect(
       testRuntime

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -261,6 +261,11 @@ describe("oaoo-tests", () => {
     await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
 
     EventStatusOAOO.resolve();
+
+    // Wait for the child workflow to finish.
+    const handle = testRuntime.retrieveWorkflow(setUUID);
+    await expect(handle.getResult()).rejects.toThrow("Failed workflow");
+
     // Run without UUID, should get the new result.
     await expect(testRuntime.invoke(EventStatusOAOO).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("value1-ERROR-ERROR");
 

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator } from "../../src/";
+import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator, Debug } from "../../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers";
 import { v1 as uuidv1 } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";
@@ -11,12 +11,26 @@ const testTableName = "debugger_test_kv";
 describe("debugger-test", () => {
   let username: string;
   let config: DBOSConfig;
+  let debugConfig: DBOSConfig;
   let testRuntime: TestingRuntime;
+  let debugRuntime: TestingRuntime;
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
+    debugConfig = generateDBOSTestConfig(undefined, "http://127.0.0.1:5432");
     username = config.poolConfig.user || "postgres";
     await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    // TODO: connect to the real proxy.
+    debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
+    testRuntime = await createInternalTestRuntime([DebuggerTest], config);
+  });
+
+  afterEach(async () => {
+    await debugRuntime.destroy();
+    await testRuntime.destroy();
   });
 
   class DebuggerTest {
@@ -45,16 +59,28 @@ describe("debugger-test", () => {
     static async testCommunicator(_ctxt: CommunicatorContext) {
       return ++DebuggerTest.cnt;
     }
+
+    @Workflow()
+    static async receiveWorkflow(ctxt: WorkflowContext, debug?: boolean) {
+      const message1 = await ctxt.recv<string>();
+      const message2 = await ctxt.recv<string>();
+      const fail = await ctxt.recv("fail", 0);
+      if (debug) {
+        await ctxt.recv("shouldn't happen", 0);
+      }
+      return message1 === "message1" && message2 === "message2" && fail === null;
+    }
+
+    @Workflow()
+    static async sendWorkflow(ctxt: WorkflowContext, destinationUUID: string) {
+      await ctxt.send(destinationUUID, "message1");
+      await ctxt.send(destinationUUID, "message2");
+    }
   }
 
   test("debug-workflow", async () => {
-    // TODO: connect to the real proxy.
-    const debugConfig = generateDBOSTestConfig(undefined, "http://127.0.0.1:5432");
-    const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
-
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    testRuntime = await createInternalTestRuntime([DebuggerTest], config);
     const res = await testRuntime
       .invoke(DebuggerTest, wfUUID)
       .testWorkflow(username)
@@ -76,18 +102,11 @@ describe("debugger-test", () => {
 
     // Execute a workflow without specifying the UUID should fail.
     await expect(debugRuntime.invoke(DebuggerTest).testWorkflow(username)).rejects.toThrow("Workflow UUID not found!");
-
-    await debugRuntime.destroy();
   });
 
   test("debug-transaction", async () => {
-    // TODO: connect to the real proxy.
-    const debugConfig = generateDBOSTestConfig(undefined, "http://127.0.0.1:5432");
-    const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
-
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    testRuntime = await createInternalTestRuntime([DebuggerTest], config);
     await expect(testRuntime.invoke(DebuggerTest, wfUUID).testFunction(username)).resolves.toBe(1);
     await testRuntime.destroy();
 
@@ -100,18 +119,11 @@ describe("debugger-test", () => {
 
     // Execute a workflow without specifying the UUID should fail.
     await expect(debugRuntime.invoke(DebuggerTest).testFunction(username)).rejects.toThrow("Workflow UUID not found!");
-
-    await debugRuntime.destroy();
   });
 
   test("debug-communicator", async () => {
-    // TODO: connect to the real proxy.
-    const debugConfig = generateDBOSTestConfig(undefined, "http://127.0.0.1:5432");
-    const debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
-
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    testRuntime = await createInternalTestRuntime([DebuggerTest], config);
     await expect(testRuntime.invoke(DebuggerTest, wfUUID).testCommunicator()).resolves.toBe(1);
     await testRuntime.destroy();
 
@@ -124,7 +136,24 @@ describe("debugger-test", () => {
 
     // Execute a workflow without specifying the UUID should fail.
     await expect(debugRuntime.invoke(DebuggerTest).testCommunicator()).rejects.toThrow("Workflow UUID not found!");
+  });
 
-    await debugRuntime.destroy();
+  test("debug-workflow-notifications", async() => {
+    const recvUUID = uuidv1();
+    const sendUUID = uuidv1();
+    // Execute the workflow and destroy the runtime
+    const handle = await testRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow(false);
+    await expect(testRuntime.invoke(DebuggerTest, sendUUID).sendWorkflow(recvUUID).then((x) => x.getResult())).resolves.toBeFalsy(); // return void.
+    expect(await handle.getResult()).toBe(true);
+    await testRuntime.destroy();
+
+    // Execute again in debug mode.
+    await expect(debugRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow(false).then((x) => x.getResult())).resolves.toBe(true);
+    await expect(debugRuntime.invoke(DebuggerTest, sendUUID).sendWorkflow(recvUUID).then((x) => x.getResult())).resolves.toBeFalsy();
+
+    // Execute a non-exist UUID should fail.
+    const wfUUID2 = uuidv1();
+    await expect(debugRuntime.send(recvUUID, "testmsg", "testtopic", wfUUID2)).rejects.toThrow("Cannot find recorded send");
+    await expect(debugRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow(true).then((x) => x.getResult())).rejects.toThrow("Cannot find recorded recv");
   });
 });


### PR DESCRIPTION
This PR implements the rest of the methods (other than transaction and childWorkflow) in `debug_workflow.ts`, and adds corresponding tests for them. All methods should be read-only, checking recorded output from the system database.

This PR also fixes a minor flaky OAOO test, by waiting for the workflow to finish before retrieving its status.