### PR TITLE
Improve Transaction Execution

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -345,14 +345,6 @@ export class DBOSExecutor {
       args = await this.systemDatabase.initWorkflowStatus(workflowUUID, wf.name, wCtxt.authenticatedUser, wCtxt.assumedRole, wCtxt.authenticatedRoles, wCtxt.request, args);
     }
     const runWorkflow = async () => {
-      // Check if the workflow previously ran.
-      const previousOutput = await this.systemDatabase.checkWorkflowOutput(workflowUUID);
-      if (previousOutput !== dbosNull) {
-        wCtxt.span.setAttribute("cached", true);
-        wCtxt.span.setStatus({ code: SpanStatusCode.OK });
-        this.tracer.endSpan(wCtxt.span);
-        return previousOutput as R;
-      }
       let result: R;
       // Execute the workflow.
       try {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -330,6 +330,7 @@ export class DBOSExecutor {
   // If callerUUID and functionID are set, it means the workflow is invoked from within a workflow.
   async internalWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     const workflowUUID: string = params.workflowUUID ? params.workflowUUID : this.#generateUUID();
+    const presetUUID = params.workflowUUID !== undefined;
 
     const wInfo = this.workflowInfoMap.get(wf.name);
     if (wInfo === undefined) {
@@ -337,7 +338,7 @@ export class DBOSExecutor {
     }
     const wConfig = wInfo.config;
 
-    const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name);
+    const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name, presetUUID);
     wCtxt.span.setAttributes({ args: JSON.stringify(args) }); // TODO enforce skipLogging & request for hashing
 
     // Synchronously set the workflow's status to PENDING and record workflow inputs.  Not needed for temporary workflows.

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -18,7 +18,7 @@ import {
   WorkflowStatus,
 } from './workflow';
 
-import { Transaction, TransactionConfig } from './transaction';
+import { IsolationLevel, Transaction, TransactionConfig } from './transaction';
 import { CommunicatorConfig, Communicator } from './communicator';
 import { JaegerExporter } from './telemetry/exporters';
 import { TelemetryCollector } from './telemetry/collector';
@@ -35,6 +35,7 @@ import {
   TypeORMDatabase,
   UserDatabaseName,
   KnexUserDatabase,
+  UserDatabaseClient,
 } from './user_database';
 import { MethodRegistrationBase, getRegisteredOperations, getOrCreateClassRegistration, MethodRegistration } from './decorators';
 import { SpanStatusCode } from '@opentelemetry/api';
@@ -372,6 +373,11 @@ export class DBOSExecutor {
       } finally {
         this.tracer.endSpan(wCtxt.span);
       }
+      // // Asynchronously flush the result buffer.
+      // this.userDatabase.transaction(async (client: UserDatabaseClient) => {
+      //   await wCtxt.flushResultBuffer(client);
+      // }, { isolationLevel: IsolationLevel.ReadCommitted })
+      // .catch(error => { this.logger.error('Error asynchronously flushing result buffer', error)})
       return result;
     };
     const workflowPromise: Promise<R> = runWorkflow();

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -83,7 +83,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     parentCtx: DBOSContextImpl | undefined,
     workflowUUID: string,
     readonly workflowConfig: WorkflowConfig,
-    workflowName: string
+    workflowName: string,
+    readonly presetUUID: boolean,
   ) {
     const span = dbosExec.tracer.startSpan(
       workflowName,

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -35,7 +35,7 @@ describe("concurrency-tests", () => {
     // Run two transactions concurrently with the same UUID.
     // Both should return the correct result but only one should execute.
     const workflowUUID = uuidv1();
-    let results = await Promise.allSettled([
+    const results = await Promise.allSettled([
       testRuntime.invoke(ConcurrTestClass, workflowUUID).testReadWriteFunction(10),
       testRuntime.invoke(ConcurrTestClass, workflowUUID).testReadWriteFunction(10),
     ]);

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -42,18 +42,6 @@ describe("concurrency-tests", () => {
     expect((results[0] as PromiseFulfilledResult<number>).value).toBe(10);
     expect((results[1] as PromiseFulfilledResult<number>).value).toBe(10);
     expect(ConcurrTestClass.cnt).toBe(1);
-
-    // Read-only transactions would execute twice.
-    ConcurrTestClass.cnt = 0;
-
-    const readUUID = uuidv1();
-    results = await Promise.allSettled([
-      testRuntime.invoke(ConcurrTestClass, readUUID).testReadOnlyFunction(12),
-      testRuntime.invoke(ConcurrTestClass, readUUID).testReadOnlyFunction(12),
-    ]);
-    expect((results[0] as PromiseFulfilledResult<number>).value).toBe(12);
-    expect((results[1] as PromiseFulfilledResult<number>).value).toBe(12);
-    expect(ConcurrTestClass.cnt).toBe(2);
   });
 
   test("concurrent-workflow", async () => {
@@ -130,13 +118,6 @@ class ConcurrTestClass {
   @Transaction()
   static async testReadWriteFunction(_txnCtxt: TestTransactionContext, id: number) {
     ConcurrTestClass.cnt++;
-    return id;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/require-await
-  @Transaction({ readOnly: true })
-  static async testReadOnlyFunction(_txnCtxt: TestTransactionContext, id: number) {
-    ConcurrTestClass.cnt += 1;
     return id;
   }
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -112,7 +112,7 @@ describe("dbos-config", () => {
     test("getConfig returns the expected values", async () => {
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const dbosExec = new DBOSExecutor(dbosConfig);
-      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext");
+      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext", true);
       // Config key exists
       expect(ctx.getConfig("payments_url")).toBe("http://somedomain.com/payment");
       // Config key does not exist, no default value
@@ -138,7 +138,7 @@ describe("dbos-config", () => {
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const dbosExec = new DBOSExecutor(dbosConfig);
-      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext");
+      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext", true);
       expect(ctx.getConfig<string>("payments_url", "default")).toBe("default");
       // We didn't init, so do some manual cleanup only
       clearInterval(dbosExec.flushBufferID);
@@ -148,7 +148,7 @@ describe("dbos-config", () => {
     test("getConfig throws when it finds a value of different type than the default", async () => {
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const dbosExec = new DBOSExecutor(dbosConfig);
-      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext");
+      const ctx: WorkflowContextImpl = new WorkflowContextImpl(dbosExec, undefined, "testUUID", {}, "testContext", true);
       expect(() => ctx.getConfig<number>("payments_url", 1234)).toThrow(DBOSConfigKeyTypeError);
       // We didn't init, so do some manual cleanup only
       clearInterval(dbosExec.flushBufferID);

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -44,7 +44,7 @@ describe("oaoo-tests", () => {
     static async testCommunicator(_commCtxt: CommunicatorContext) {
       return CommunicatorOAOO.#counter++;
     }
-  
+
     @Workflow()
     static async testCommWorkflow(workflowCtxt: WorkflowContext) {
       const funcResult = await workflowCtxt.invoke(CommunicatorOAOO).testCommunicator();
@@ -85,7 +85,7 @@ describe("oaoo-tests", () => {
       const { rows } = await txnCtxt.client.query<TestKvTable>(`INSERT INTO ${testTableName}(value) VALUES ($1) RETURNING id`, [name]);
       return Number(rows[0].id);
     }
-  
+
     @Transaction({ readOnly: true })
     static async testReadTx(txnCtxt: TestTransactionContext, id: number) {
       const { rows } = await txnCtxt.client.query<TestKvTable>(`SELECT id FROM ${testTableName} WHERE id=$1`, [id]);
@@ -96,7 +96,7 @@ describe("oaoo-tests", () => {
         return -1;
       }
     }
-  
+
     @Workflow()
     static async testTxWorkflow(wfCtxt: WorkflowContext, name: string) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -105,7 +105,7 @@ describe("oaoo-tests", () => {
       const checkResult: number = await wfCtxt.invoke(WorkflowOAOO).testReadTx(funcResult);
       return checkResult;
     }
-  
+
     // eslint-disable-next-line @typescript-eslint/require-await
     @Workflow()
     static async nestedWorkflow(wfCtxt: WorkflowContext, name: string) {
@@ -118,12 +118,12 @@ describe("oaoo-tests", () => {
     const uuidArray: string[] = [];
 
     for (let i = 0; i < 10; i++) {
-      const workflowUUID: string = uuidv1();
+      const workflowHandle = await testRuntime
+        .invoke(WorkflowOAOO)
+        .testTxWorkflow(username);
+      const workflowUUID: string = workflowHandle.getWorkflowUUID()
       uuidArray.push(workflowUUID);
-      workflowResult = await testRuntime
-        .invoke(WorkflowOAOO, workflowUUID)
-        .testTxWorkflow(username)
-        .then((x) => x.getResult());
+      workflowResult = await workflowHandle.getResult();
       expect(workflowResult).toEqual(i + 1);
     }
 
@@ -219,7 +219,7 @@ describe("oaoo-tests", () => {
       } else {
         res = getValue;
       }
-  
+
       const handle = ctxt.retrieveWorkflow(targetUUID);
       const status = await handle.getStatus();
       EventStatusOAOO.wfCnt++;
@@ -228,7 +228,7 @@ describe("oaoo-tests", () => {
       } else {
         res += "-" + status.status;
       }
-  
+
       // Note: the targetUUID must match the child workflow UUID.
       const invokedHandle = await ctxt.childWorkflow(EventStatusOAOO.setEventWorkflow);
       try {

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -43,6 +43,12 @@ describe("debugger-test", () => {
     }
 
     @Transaction()
+    static async testReadOnlyFunction(txnCtxt: TestTransactionContext, number: number) {
+      const { rows } = await txnCtxt.client.query<{one: number}>(`SELECT 1 AS one`);
+      return Number(rows[0].one) + number;
+    }
+
+    @Transaction()
     static async testFunction(txnCtxt: TestTransactionContext, name: string) {
       const { rows } = await txnCtxt.client.query<TestKvTable>(`INSERT INTO ${testTableName}(value) VALUES ($1) RETURNING id`, [name]);
       return Number(rows[0].id);
@@ -143,6 +149,24 @@ describe("debugger-test", () => {
     // Execute a workflow without specifying the UUID should fail.
     await expect(debugRuntime.invoke(DebuggerTest).testFunction(username)).rejects.toThrow("Workflow UUID not found!");
   });
+
+  test("debug-read-only-transaction", async () => {
+    const wfUUID = uuidv1();
+    // Execute the workflow and destroy the runtime
+    await expect(testRuntime.invoke(DebuggerTest, wfUUID).testReadOnlyFunction(1)).resolves.toBe(2);
+    await testRuntime.destroy();
+
+    // Execute again in debug mode.
+    await expect(debugRuntime.invoke(DebuggerTest, wfUUID).testReadOnlyFunction(1)).resolves.toBe(2);
+
+    // Execute a non-exist UUID should fail.
+    const wfUUID2 = uuidv1();
+    await expect(debugRuntime.invoke(DebuggerTest, wfUUID2).testReadOnlyFunction(1)).rejects.toThrow("This should never happen during debug.");
+
+    // Execute a workflow without specifying the UUID should fail.
+    await expect(debugRuntime.invoke(DebuggerTest).testReadOnlyFunction(1)).rejects.toThrow("Workflow UUID not found!");
+  });
+
 
   test("debug-communicator", async () => {
     const wfUUID = uuidv1();

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -42,7 +42,7 @@ describe("debugger-test", () => {
       await ctx.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id SERIAL PRIMARY KEY, value TEXT);`);
     }
 
-    @Transaction()
+    @Transaction({readOnly: true})
     static async testReadOnlyFunction(txnCtxt: TestTransactionContext, number: number) {
       const { rows } = await txnCtxt.client.query<{one: number}>(`SELECT 1 AS one`);
       return Number(rows[0].one) + number;


### PR DESCRIPTION
This PR makes two major changes: 

1.  Fix an issue where transaction snapshot information was sometimes not recorded for read-only transactions because the transaction results buffer is only flushed by write transactions.  Thus, snapshot information for a read-only transaction is only recorded if its workflow contains a subsequent write. The transaction results buffer is now flushed asynchronously at the end of a workflow.

2.  Only check if a transaction previously executed if the workflow UUID is preset. Otherwise, the UUID is newly generated within the SDK, so simultaneous executions with the same UUID should be impossible.