### PR TITLE
Always Record Inputs

### DIFF
--- a/src/cloud-cli/userdb.ts
+++ b/src/cloud-cli/userdb.ts
@@ -154,7 +154,7 @@ export function migrate() {
 
   if (create_db) {
     logger.info(`Creating database ${userdbname}`);
-    let cmd = `createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userdbname} -U ${configFile.database.username} -w ${configFile.database.password} -e`;
+    const cmd = `createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userdbname} -U ${configFile.database.username} -w ${configFile.database.password} -e`;
     logger.info(cmd);
     try {
       execSync(cmd);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -89,7 +89,7 @@ export class DBOSExecutor {
   readonly communicatorConfigMap: Map<string, CommunicatorConfig> = new Map();
   readonly registeredOperations: Array<MethodRegistrationBase> = [];
   readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to workflow promise
-  readonly pendingAsyncWrites: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to result buffer flush promise
+  readonly pendingAsyncWrites: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to asynchronous write promise
 
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -89,7 +89,7 @@ export class DBOSExecutor {
   readonly communicatorConfigMap: Map<string, CommunicatorConfig> = new Map();
   readonly registeredOperations: Array<MethodRegistrationBase> = [];
   readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to workflow promise
-  readonly pendingBufferFlushes: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to result buffer flush promise
+  readonly pendingAsyncWrites: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to result buffer flush promise
 
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;
@@ -280,9 +280,9 @@ export class DBOSExecutor {
       this.logger.info("Waiting for pending workflows to finish.");
       await Promise.allSettled(this.pendingWorkflowMap.values());
     }
-    if (this.pendingBufferFlushes.size > 0) {
+    if (this.pendingAsyncWrites.size > 0) {
       this.logger.info("Waiting for pending buffer flushes to finish");
-      await Promise.allSettled(this.pendingBufferFlushes.values());
+      await Promise.allSettled(this.pendingAsyncWrites.values());
     }
     clearInterval(this.flushBufferID);
     await this.flushWorkflowStatusBuffer();
@@ -339,9 +339,15 @@ export class DBOSExecutor {
     const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name, presetUUID);
     wCtxt.span.setAttributes({ args: JSON.stringify(args) }); // TODO enforce skipLogging & request for hashing
 
-    // Synchronously set the workflow's status to PENDING and record workflow inputs.  Not needed for temporary workflows.
+    // Synchronously set the workflow's status to PENDING and record workflow inputs.
     if (!wCtxt.isTempWorkflow) {
       args = await this.systemDatabase.initWorkflowStatus(workflowUUID, wf.name, wCtxt.authenticatedUser, wCtxt.assumedRole, wCtxt.authenticatedRoles, wCtxt.request, args);
+    } else {
+      // For temporary workflows, instead asynchronously record inputs.
+      const setWorkflowInputs: Promise<void> = this.systemDatabase.setWorkflowInputs<T>(workflowUUID, args)
+        .catch(error => { this.logger.error('Error asynchronously setting workflow inputs', error) })
+        .finally(() => { this.pendingAsyncWrites.delete(workflowUUID) })
+      this.pendingAsyncWrites.set(workflowUUID, setWorkflowInputs);
     }
     const runWorkflow = async () => {
       let result: R;
@@ -376,8 +382,8 @@ export class DBOSExecutor {
         }
       }, { isolationLevel: IsolationLevel.ReadCommitted })
         .catch(error => { this.logger.error('Error asynchronously flushing result buffer', error) })
-        .finally(() => { this.pendingBufferFlushes.delete(workflowUUID) })
-      this.pendingBufferFlushes.set(workflowUUID, resultBufferFlush);
+        .finally(() => { this.pendingAsyncWrites.delete(workflowUUID) })
+      this.pendingAsyncWrites.set(workflowUUID, resultBufferFlush);
       return result;
     };
     const workflowPromise: Promise<R> = runWorkflow();

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -170,7 +170,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
 
   async setWorkflowInputs<T extends any[]>(workflowUUID: string, args: T): Promise<void> {
-    this.dbRoot.doTransaction(async (txn) => {
+    await this.dbRoot.doTransaction(async (txn) => {
       const inputsDB = txn.at(this.workflowInputsDB);
       const inputs = await inputsDB.get(workflowUUID);
       if (inputs === undefined) {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -169,6 +169,16 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     return workflows.filter((i) => i[1].status === StatusString.PENDING && i[1].executorID === executorID).map((i) => i[0]);
   }
 
+  async setWorkflowInputs<T extends any[]>(workflowUUID: string, args: T): Promise<void> {
+    this.dbRoot.doTransaction(async (txn) => {
+      const inputsDB = txn.at(this.workflowInputsDB);
+      const inputs = await inputsDB.get(workflowUUID);
+      if (inputs === undefined) {
+        inputsDB.set(workflowUUID, args);
+      }
+    });
+  }
+
   async getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null> {
     return ((await this.workflowInputsDB.get(workflowUUID)) as T) ?? null;
   }


### PR DESCRIPTION
This PR asynchronously records inputs of temporary workflows so they can easily be replayed by the debugger.