### PR TITLE
Debug mode CLI

### DIFF
--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -131,7 +131,6 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions): [DBOSConfig, 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       entities: configFile.dbClientMetadata?.entities,
     },
-    debugProxy: cliOptions?.debug || undefined,
   };
 
   /*************************************/

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,6 +1,18 @@
-import { DBOSConfig } from "../dbos-executor";
-import { DBOSRuntimeConfig } from "./runtime";
+import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
+import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
 export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
+  dbosConfig = {...dbosConfig, debugProxy: proxy};
 
+  // Load classes
+  const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);
+  const dbosExec = new DBOSExecutor(dbosConfig);
+  await dbosExec.init(...classes);
+
+  // Invoke the workflow in debug mode.
+  const handle = await dbosExec.executeWorkflowUUID(workflowUUID);
+  await handle.getResult();
+
+  // Destroy testing runtime.
+  await dbosExec.destroy();
 }

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,0 +1,6 @@
+import { DBOSConfig } from "../dbos-executor";
+import { DBOSRuntimeConfig } from "./runtime";
+
+export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
+
+}

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -54,7 +54,6 @@ export class DBOSRuntime {
     for (const key in exports) {
       if (isObject(exports[key])) {
         classes.push(exports[key] as object);
-        console.log(`Registering class ${key}`);
       }
     }
     return classes;

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -73,7 +73,7 @@ export async function createInternalTestRuntime(userClasses: object[], testConfi
 }
 
 /**
- * This class provides a runtime to test Opeorn functions in unit tests.
+ * This class provides a runtime to test DBOS functions in unit tests.
  */
 export class TestingRuntimeImpl implements TestingRuntime {
   #server: DBOSHttpServer | null = null;


### PR DESCRIPTION
This PR refactors the debug mode CLI. Instead of adding an option in `npx dbos-sdk start`, this PR implements a new CLI command `npx debug`. The idea is to initiate a very simple DBOSExecutor in debug mode and execute the workflow given its UUID, and wait for its result. We can attach a debugger (I tested with the VSCode debugger) to single step through the execution.

```
Usage: dbos-sdk debug [options]

Debug a workflow

Options:
  -x, --proxy <string>       Specify the debugger proxy URL [Required]
  -u, --uuid <string>        Specify the workflow UUID to debug [Required]
  -l, --loglevel <string>    Specify log level
  -c, --configfile <string>  Specify the config file path (default: "dbos-config.yaml")
  -e, --entrypoint <string>  Specify the entrypoint file path
  -h, --help                 display help for command
```

This command simply accepts a proxy URL and a workflow UUID to be replayed. I manually tested with our extended hello workflow and it works well. The catch is that we currently don't remember the name of transactions/communicators, so we cannot replay temporary workflows that only contain a transaction or a communicator. Will fix it in the next PR.

Example output from replaying the helloWorklfow with a given UUID (not connected to a real proxy, so we see the error):
```
qianli@Qians-MacBook-Pro ~/D/d/e/hello (qian/debug-cli) [SIGINT]> npx dbos-sdk debug -x http://127.0.0.1:5432 -u c2972552-e0c6-477a-a2d1-17d6b88d3886
2023-12-08 01:08:01 [version 1.0] [info]: Running in debug mode!
2023-12-08 01:08:01 [version 1.0] [info]: Debugging mode proxy: 127.0.0.1:5432
2023-12-08 01:08:01 [version 1.0] [info]: Workflow executor initialized
2023-12-08 01:08:01 [version 1.0] [error]: Detected different transaction output than the original one!
 Expected: "Hello, qian! You have been greeted 4 times.\n"
 Received: "Hello, qian! You have been greeted 1 times.\n"
   ...

qianli@Qians-MacBook-Pro ~/D/d/e/hello (qian/debug-cli)> npx dbos-sdk debug -x http://127.0.0.1:5432 -u 5bfae982-a2d9-458b-a241-a35310c46c74
2023-12-08 01:08:15 [version 1.0] [info]: Running in debug mode!
2023-12-08 01:08:15 [version 1.0] [info]: Debugging mode proxy: 127.0.0.1:5432
2023-12-08 01:08:15 [version 1.0] [info]: Workflow executor initialized
2023-12-08 01:08:16 [version 1.0] [error]: Detected different transaction output than the original one!
 Expected: "Hello, qian! You have been greeted 5 times.\n"
 Received: "Hello, qian! You have been greeted 3 times.\n"
 ...
```