### PR TITLE
Support Replay Temporary Workflows

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -179,8 +179,8 @@ export class DBOSExecutor {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
       const DataSourceExports = require("typeorm");
       try {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         this.userDatabase = new TypeORMDatabase(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           new DataSourceExports.DataSource({
             type: "postgres", // perhaps should move to config file
             host: userDBConfig.host,

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -31,7 +31,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     super(workflowName, span, dbosExec.logger, parentCtx);
     this.workflowUUID = workflowUUID;
     this.#dbosExec = dbosExec;
-    this.isTempWorkflow = dbosExec.tempWorkflowName === workflowName;
+    this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
     if (dbosExec.config.application) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.applicationConfig = dbosExec.config.application;

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -92,8 +92,8 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
    * It connects to a debug proxy and everything should be read-only.
    */
   async transaction<T extends any[], R>(txn: Transaction<T, R>, ...args: T): Promise<R> {
-    const config = this.#dbosExec.transactionConfigMap.get(txn.name);
-    if (config === undefined) {
+    const txnInfo = this.#dbosExec.transactionInfoMap.get(txn.name);
+    if (txnInfo === undefined) {
       throw new DBOSDebuggerError(`Transaction ${txn.name} not registered!`);
     }
     // const readOnly = true; // TODO: eventually, this transaction must be read-only.
@@ -111,7 +111,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
       return result;
     };
 
-    const result = await this.#dbosExec.userDatabase.transaction(wrappedTransaction, config);
+    const result = await this.#dbosExec.userDatabase.transaction(wrappedTransaction, txnInfo.config);
 
     if (JSON.stringify(check!.output) !== JSON.stringify(result)) {
       this.logger.error(`Detected different transaction output than the original one!\n Expected: ${JSON.stringify(result)}\n Received: ${JSON.stringify(check!.output)}`);
@@ -120,7 +120,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
   }
 
   async external<T extends any[], R>(commFn: Communicator<T, R>, ..._args: T): Promise<R> {
-    const commConfig = this.#dbosExec.communicatorConfigMap.get(commFn.name);
+    const commConfig = this.#dbosExec.communicatorInfoMap.get(commFn.name);
     if (commConfig === undefined) {
       throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
     }

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -2,24 +2,11 @@
 
 import { deserializeError, serializeError } from "serialize-error";
 import { DBOSExecutor, DBOSNull, dbosNull } from "../dbos-executor";
-import { DBOSExecutorIDHeader, SystemDatabase } from "../system_database";
+import { BufferedStatus, SystemDatabase } from "../system_database";
 import { StatusString, WorkflowStatus } from "../workflow";
 import * as fdb from "foundationdb";
 import { DuplicateWorkflowEventError, DBOSWorkflowConflictUUIDError } from "../error";
 import { NativeValue } from "foundationdb/dist/lib/native";
-import { HTTPRequest } from "../context";
-
-interface WorkflowOutput<R> {
-  status: string;
-  error: string;
-  output: R;
-  name: string;
-  authenticatedUser: string;
-  authenticatedRoles: Array<string>;
-  assumedRole: string;
-  request: HTTPRequest;
-  executorID: string; // Set to "local" for local deployment, set to microVM ID for cloud deployment.
-}
 
 interface OperationOutput<R> {
   output: R;
@@ -42,7 +29,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   workflowEventsDB: fdb.Database<fdb.TupleItem, fdb.TupleItem, unknown, unknown>;
   workflowInputsDB: fdb.Database<string, string, unknown, unknown>;
 
-  readonly workflowStatusBuffer: Map<string, unknown> = new Map();
+  readonly workflowStatusBuffer: Map<string, BufferedStatus> = new Map();
 
   constructor() {
     fdb.setAPIVersion(710, 710);
@@ -77,60 +64,48 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
 
   async checkWorkflowOutput<R>(workflowUUID: string): Promise<R | DBOSNull> {
-    const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<R> | undefined;
+    const output = (await this.workflowStatusDB.get(workflowUUID)) as BufferedStatus | undefined;
     if (output === undefined || output.status === StatusString.PENDING) {
       return dbosNull;
     } else if (output.status === StatusString.ERROR) {
       throw deserializeError(JSON.parse(output.error));
     } else {
-      return output.output;
+      return output.output as R;
     }
   }
 
-  async initWorkflowStatus<T extends any[]>(
-    workflowUUID: string,
-    name: string,
-    authenticatedUser: string,
-    assumedRole: string,
-    authenticatedRoles: string[],
-    request: HTTPRequest | null,
-    args: T
-  ): Promise<T> {
+  async initWorkflowStatus<T extends any[]>(bufStatus: BufferedStatus, args: T): Promise<T> {
     return this.dbRoot.doTransaction(async (txn) => {
       const statusDB = txn.at(this.workflowStatusDB);
       const inputsDB = txn.at(this.workflowInputsDB);
-
-      let executorID: string = "local";
-      if (request && request.headers && request.headers[DBOSExecutorIDHeader]) {
-        executorID = request.headers[DBOSExecutorIDHeader] as string;
-      }
-
-      const present = await statusDB.get(workflowUUID);
+      const present = await statusDB.get(bufStatus.workflowUUID);
       if (present === undefined) {
-        statusDB.set(workflowUUID, {
-          status: StatusString.PENDING,
+        statusDB.set(bufStatus.workflowUUID, {
+          status: bufStatus.status,
           error: null,
           output: null,
-          name: name,
-          authenticatedUser: authenticatedUser,
-          assumedRole: assumedRole,
-          authenticatedRoles: authenticatedRoles,
-          request: request,
-          executorID: executorID,
+          name: bufStatus.name,
+          authenticatedUser: bufStatus.authenticatedUser,
+          assumedRole: bufStatus.assumedRole,
+          authenticatedRoles: bufStatus.authenticatedRoles,
+          request: bufStatus.request,
+          executorID: bufStatus.executorID,
         });
       }
 
-      const inputs = await inputsDB.get(workflowUUID);
+      const inputs = await inputsDB.get(bufStatus.workflowUUID);
       if (inputs === undefined) {
-        inputsDB.set(workflowUUID, args);
+        inputsDB.set(bufStatus.workflowUUID, args);
         return args;
       }
       return inputs as T;
     });
   }
 
-  bufferWorkflowOutput<R>(workflowUUID: string, output: R) {
-    this.workflowStatusBuffer.set(workflowUUID, output);
+  bufferWorkflowOutput<R>(workflowUUID: string, output: R, status: BufferedStatus) {
+    status.output = output;
+    status.status = StatusString.SUCCESS;
+    this.workflowStatusBuffer.set(workflowUUID, status);
   }
 
   async flushWorkflowStatusBuffer(): Promise<string[]> {
@@ -138,34 +113,38 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     this.workflowStatusBuffer.clear();
     // eslint-disable-next-line @typescript-eslint/require-await
     await this.workflowStatusDB.doTransaction(async (txn) => {
-      for (const [workflowUUID, output] of localBuffer) {
-        const currWf = (await txn.get(workflowUUID)) as WorkflowOutput<unknown>;
+      for (const [workflowUUID, status] of localBuffer) {
         txn.set(workflowUUID, {
-          status: StatusString.SUCCESS,
+          status: status.status,
           error: null,
-          output: output,
-          name: currWf?.name ?? null,
-          authenticatedUser: currWf?.authenticatedUser ?? null,
-          authenticatedRoles: currWf?.authenticatedRoles ?? null,
-          assumedRole: currWf?.assumedRole ?? null,
-          request: currWf?.request ?? null,
+          output: status.output,
+          name: status.name,
+          authenticatedUser: status.authenticatedUser,
+          authenticatedRoles: status.authenticatedRoles,
+          assumedRole: status.assumedRole,
+          request: status.request,
         });
       }
     });
     return Array.from(localBuffer.keys());
   }
 
-  async recordWorkflowError(workflowUUID: string, error: Error): Promise<void> {
+  async recordWorkflowError(workflowUUID: string, error: Error, status: BufferedStatus): Promise<void> {
     const serialErr = JSON.stringify(serializeError(error));
     await this.workflowStatusDB.set(workflowUUID, {
       status: StatusString.ERROR,
       error: serialErr,
       output: null,
+      name: status.name,
+      authenticatedUser: status.authenticatedUser,
+      authenticatedRoles: status.authenticatedRoles,
+      assumedRole: status.assumedRole,
+      request: status.request,
     });
   }
 
   async getPendingWorkflows(executorID: string): Promise<string[]> {
-    const workflows = (await this.workflowStatusDB.getRangeAll("", "\xff")) as Array<[string, WorkflowOutput<unknown>]>;
+    const workflows = (await this.workflowStatusDB.getRangeAll("", "\xff")) as Array<[string, BufferedStatus]>;
     return workflows.filter((i) => i[1].status === StatusString.PENDING && i[1].executorID === executorID).map((i) => i[0]);
   }
 
@@ -232,7 +211,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
       }
     }
 
-    const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<unknown> | undefined;
+    const output = (await this.workflowStatusDB.get(workflowUUID)) as BufferedStatus | undefined;
     let value = null;
     if (output !== undefined) {
       value = {
@@ -261,10 +240,10 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     } else {
       watch.cancel();
     }
-    const output = value as WorkflowOutput<R>;
+    const output = value as BufferedStatus;
     const status = output.status;
     if (status === StatusString.SUCCESS) {
-      return output.output;
+      return output.output as R;
     } else if (status === StatusString.ERROR) {
       throw deserializeError(JSON.parse(output.error));
     } else {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -74,28 +74,28 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     }
   }
 
-  async initWorkflowStatus<T extends any[]>(bufStatus: WorkflowStatusInternal, args: T): Promise<T> {
+  async initWorkflowStatus<T extends any[]>(initStatus: WorkflowStatusInternal, args: T): Promise<T> {
     return this.dbRoot.doTransaction(async (txn) => {
       const statusDB = txn.at(this.workflowStatusDB);
       const inputsDB = txn.at(this.workflowInputsDB);
-      const present = await statusDB.get(bufStatus.workflowUUID);
+      const present = await statusDB.get(initStatus.workflowUUID);
       if (present === undefined) {
-        statusDB.set(bufStatus.workflowUUID, {
-          status: bufStatus.status,
+        statusDB.set(initStatus.workflowUUID, {
+          status: initStatus.status,
           error: null,
           output: null,
-          name: bufStatus.name,
-          authenticatedUser: bufStatus.authenticatedUser,
-          assumedRole: bufStatus.assumedRole,
-          authenticatedRoles: bufStatus.authenticatedRoles,
-          request: bufStatus.request,
-          executorID: bufStatus.executorID,
+          name: initStatus.name,
+          authenticatedUser: initStatus.authenticatedUser,
+          assumedRole: initStatus.assumedRole,
+          authenticatedRoles: initStatus.authenticatedRoles,
+          request: initStatus.request,
+          executorID: initStatus.executorID,
         });
       }
 
-      const inputs = await inputsDB.get(bufStatus.workflowUUID);
+      const inputs = await inputsDB.get(initStatus.workflowUUID);
       if (inputs === undefined) {
-        inputsDB.set(bufStatus.workflowUUID, args);
+        inputsDB.set(initStatus.workflowUUID, args);
         return args;
       }
       return inputs as T;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -110,14 +110,14 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async initWorkflowStatus<T extends any[]>(bufStatus: WorkflowStatusInternal, args: T): Promise<T> {
+  async initWorkflowStatus<T extends any[]>(initStatus: WorkflowStatusInternal, args: T): Promise<T> {
     await this.pool.query(
       `INSERT INTO workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output, executor_id) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (workflow_uuid) DO NOTHING`,
-      [bufStatus.workflowUUID, bufStatus.status, bufStatus.name, bufStatus.authenticatedUser, bufStatus.assumedRole, JSON.stringify(bufStatus.authenticatedRoles), JSON.stringify(bufStatus.request), null, bufStatus.executorID]
+      [initStatus.workflowUUID, initStatus.status, initStatus.name, initStatus.authenticatedUser, initStatus.assumedRole, JSON.stringify(initStatus.authenticatedRoles), JSON.stringify(initStatus.request), null, initStatus.executorID]
     );
     const { rows } = await this.pool.query<workflow_inputs>(
       `INSERT INTO workflow_inputs (workflow_uuid, inputs) VALUES($1, $2) ON CONFLICT (workflow_uuid) DO UPDATE SET workflow_uuid = excluded.workflow_uuid  RETURNING inputs`,
-      [bufStatus.workflowUUID, JSON.stringify(args)]
+      [initStatus.workflowUUID, JSON.stringify(args)]
     )
     return JSON.parse(rows[0].inputs) as T;
   }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -98,7 +98,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     super(workflowName, span, dbosExec.logger, parentCtx);
     this.workflowUUID = workflowUUID;
     this.#dbosExec = dbosExec;
-    this.isTempWorkflow = dbosExec.tempWorkflowName === workflowName;
+    this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
     if (dbosExec.config.application) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.applicationConfig = dbosExec.config.application;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -78,6 +78,10 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   readonly resultBuffer: Map<number, BufferedResult> = new Map<number, BufferedResult>();
   readonly isTempWorkflow: boolean;
 
+  // For temporary workflows
+  tempWfOperationType: string;  // "transaction", "external", or "send"
+  tempWfOperationName: string; // The name of that operation.
+
   constructor(
     dbosExec: DBOSExecutor,
     parentCtx: DBOSContextImpl | undefined,
@@ -99,6 +103,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     this.workflowUUID = workflowUUID;
     this.#dbosExec = dbosExec;
     this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
+    this.tempWfOperationType = "";
+    this.tempWfOperationName = "";
     if (dbosExec.config.application) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.applicationConfig = dbosExec.config.application;

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -3,7 +3,7 @@ import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers
 import { v1 as uuidv1 } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";
 import { PoolClient } from "pg";
-import { TestingRuntime, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
 
 type TestTransactionContext = TransactionContext<PoolClient>;
 const testTableName = "debugger_test_kv";
@@ -124,6 +124,9 @@ describe("debugger-test", () => {
       .then((x) => x.getResult());
     expect(debugRes).toBe(1);
 
+    // Execute again with the provided UUID.
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBe(1);
+
     // Execute a non-exist UUID should fail.
     const wfUUID2 = uuidv1();
     const nonExist = await debugRuntime.invoke(DebuggerTest, wfUUID2).testWorkflow(username);
@@ -142,6 +145,9 @@ describe("debugger-test", () => {
     // Execute again in debug mode.
     await expect(debugRuntime.invoke(DebuggerTest, wfUUID).testFunction(username)).resolves.toBe(1);
 
+    // Execute again with the provided UUID.
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBe(1);
+
     // Execute a non-exist UUID should fail.
     const wfUUID2 = uuidv1();
     await expect(debugRuntime.invoke(DebuggerTest, wfUUID2).testFunction(username)).rejects.toThrow("This should never happen during debug.");
@@ -158,6 +164,9 @@ describe("debugger-test", () => {
 
     // Execute again in debug mode.
     await expect(debugRuntime.invoke(DebuggerTest, wfUUID).testReadOnlyFunction(1)).resolves.toBe(2);
+
+    // Execute again with the provided UUID.
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBe(2);
 
     // Execute a non-exist UUID should fail.
     const wfUUID2 = uuidv1();
@@ -176,6 +185,9 @@ describe("debugger-test", () => {
 
     // Execute again in debug mode.
     await expect(debugRuntime.invoke(DebuggerTest, wfUUID).testCommunicator()).resolves.toBe(1);
+
+    // Execute again with the provided UUID.
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBe(1);
 
     // Execute a non-exist UUID should fail.
     const wfUUID2 = uuidv1();


### PR DESCRIPTION
This PR adds support for replaying temporary workflows. The key idea is to record full workflow status and store transaction/communicator functions. Previously, we don't record metadata for temporary workflows such as the original HTTP request and authenticated roles. This PR adds those metadata for all workflows.

For temporary workflows, we record the name with the format: `temp_workflow-<transaction/external/send>-<function name>`. Then the `executeWorkflowUUID` function parses the name and find the corresponding function.

Add tests to confirm that we can correctly re-execute temporary workflows.