### PR TITLE
System Schema in Debug Mode

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -117,6 +117,7 @@ export class DBOSExecutor {
   static readonly defaultNotificationTimeoutSec = 60;
 
   readonly debugMode: boolean;
+  static systemDBSchemaName = "public";
 
   readonly logger: Logger;
   readonly tracer: Tracer;

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -4,6 +4,9 @@ import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
   dbosConfig = {...dbosConfig, debugProxy: proxy};
 
+  // Point to the correct system DB schema.
+  DBOSExecutor.systemDBSchemaName = "dbos_system";
+
   // Load classes
   const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);
   const dbosExec = new DBOSExecutor(dbosConfig);

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -2,7 +2,8 @@ import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
 export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
-  dbosConfig = {...dbosConfig, debugProxy: proxy};
+  dbosConfig = {...dbosConfig, debugProxy: proxy, system_database: "dbos_systemdb"};
+  dbosConfig.poolConfig.database = `${dbosConfig.poolConfig.database}_prov`;
 
   // Point to the correct system DB schema.
   DBOSExecutor.systemDBSchemaName = "dbos_system";

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -82,7 +82,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
     // Send a signal to the debug proxy.
     // TODO: use the real command once the proxy is fully implemented.
-    await this.#dbosExec.userDatabase.queryWithClient(client, `--proxy:${res.txn_id}`);
+    await this.#dbosExec.userDatabase.queryWithClient(client, `--proxy:${res.txn_id ?? ''}:${res.txn_snapshot}`);
 
     return res;
   }


### PR DESCRIPTION
This PR uses a non-public `dbos_system` as the system DB schema in debug mode. Because the provenance exporter will export all system tables into the `dbos_system` schema in the provenance database.

This PR also updates the debug CLI to work with the debug proxy.