### PR TITLE
Update Debug Mode DB Schema and Name

### DIFF
--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -2,11 +2,12 @@ import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
 export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
-  dbosConfig = {...dbosConfig, debugProxy: proxy, system_database: "dbos_systemdb"};
-  dbosConfig.poolConfig.database = `${dbosConfig.poolConfig.database}_prov`;
+  const provDB = `${dbosConfig.poolConfig.database}_prov`;
+  dbosConfig = {...dbosConfig, debugProxy: proxy, system_database: provDB };
+  dbosConfig.poolConfig.database = provDB;
 
   // Point to the correct system DB schema.
-  DBOSExecutor.systemDBSchemaName = "dbos_system";
+  DBOSExecutor.systemDBSchemaName = "dbos";
 
   // Load classes
   const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);


### PR DESCRIPTION
To work correctly with the proxy, now we put all tables under the `dbos` schema in the provenance DB, and we use the `userDB_prov` as the corresponding provenance DB name.