### PR TITLE
Fix Debug Mode Output Check

### DIFF
--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -119,11 +119,9 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     }
 
     if (JSON.stringify(check!.output) !== JSON.stringify(result)) {
-      check!.output = check!.output ?? undefined as R;  // TODO: is it safe to coalesce null into undefined?
       this.logger.error(`Detected different transaction output than the original one!\n Result: ${JSON.stringify(result)}\n Original: ${JSON.stringify(check!.output)}`);
-      return check!.output; // Always return the recorded result.
     }
-    return result;
+    return check!.output; // Always return the recorded result.
   }
 
   async external<T extends any[], R>(commFn: Communicator<T, R>, ..._args: T): Promise<R> {

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -113,8 +113,14 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
     const result = await this.#dbosExec.userDatabase.transaction(wrappedTransaction, txnInfo.config);
 
-    if (result !== undefined && JSON.stringify(check!.output) !== JSON.stringify(result)) {
-      this.logger.error(`Detected different transaction output than the original one!\n Expected: ${JSON.stringify(result)}\n Received: ${JSON.stringify(check!.output)}`);
+    // If returned nothing and the recorded value is also null/undefined, we just return it
+    if (result === undefined && !check!.output) {
+      return result;
+    }
+
+    if (JSON.stringify(check!.output) !== JSON.stringify(result)) {
+      check!.output = check!.output ?? undefined as R;  // TODO: is it safe to coalesce null into undefined?
+      this.logger.error(`Detected different transaction output than the original one!\n Result: ${JSON.stringify(result)}\n Original: ${JSON.stringify(check!.output)}`);
       return check!.output; // Always return the recorded result.
     }
     return result;

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -113,10 +113,11 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
     const result = await this.#dbosExec.userDatabase.transaction(wrappedTransaction, txnInfo.config);
 
-    if (JSON.stringify(check!.output) !== JSON.stringify(result)) {
+    if (result !== undefined && JSON.stringify(check!.output) !== JSON.stringify(result)) {
       this.logger.error(`Detected different transaction output than the original one!\n Expected: ${JSON.stringify(result)}\n Received: ${JSON.stringify(check!.output)}`);
+      return check!.output; // Always return the recorded result.
     }
-    return check!.output; // Always return the recorded result.
+    return result;
   }
 
   async external<T extends any[], R>(commFn: Communicator<T, R>, ..._args: T): Promise<R> {

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator } from "../../src/";
+import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator, Debug } from "../../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers";
 import { v1 as uuidv1 } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";
@@ -26,6 +26,7 @@ describe("debugger-test", () => {
     // TODO: connect to the real proxy.
     debugRuntime = await createInternalTestRuntime([DebuggerTest], debugConfig);
     testRuntime = await createInternalTestRuntime([DebuggerTest], config);
+    DebuggerTest.cnt = 0;
   });
 
   afterEach(async () => {
@@ -109,6 +110,10 @@ describe("debugger-test", () => {
     // eslint-disable-next-line @typescript-eslint/require-await
     @Transaction()
     static async voidFunction(_txnCtxt: TestTransactionContext) {
+      if (DebuggerTest.cnt > 0) {
+        return DebuggerTest.cnt;
+      }
+      DebuggerTest.cnt++;
       return;
     }
   }
@@ -146,13 +151,16 @@ describe("debugger-test", () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
     await expect(testRuntime.invoke(DebuggerTest, wfUUID).voidFunction()).resolves.toBeUndefined();
+    expect(DebuggerTest.cnt).toBe(1);
     await testRuntime.destroy();
 
     // Execute again in debug mode.
     await expect(debugRuntime.invoke(DebuggerTest, wfUUID).voidFunction()).resolves.toBeUndefined();
+    expect(DebuggerTest.cnt).toBe(1);
 
     // Execute again with the provided UUID.
     await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBeUndefined();
+    expect(DebuggerTest.cnt).toBe(1);
   });
 
   test("debug-transaction", async () => {

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator, Debug } from "../../src/";
+import { WorkflowContext, TransactionContext, Transaction, Workflow, DBOSInitializer, InitContext, CommunicatorContext, Communicator } from "../../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "../helpers";
 import { v1 as uuidv1 } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -155,11 +155,11 @@ describe("debugger-test", () => {
     await testRuntime.destroy();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invoke(DebuggerTest, wfUUID).voidFunction()).resolves.toBeUndefined();
+    await expect(debugRuntime.invoke(DebuggerTest, wfUUID).voidFunction()).resolves.toBeFalsy();
     expect(DebuggerTest.cnt).toBe(1);
 
     // Execute again with the provided UUID.
-    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBeUndefined();
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBeFalsy();
     expect(DebuggerTest.cnt).toBe(1);
   });
 


### PR DESCRIPTION
This PR solves a minor issue for the debug mode: If a function returns nothing, we record `null` in the database (there's no good way to serialize undefined to a valid JSON string). So when we get the recorded output, we would get `null` instead of `undefined`. Therefore, the debugger would incorrectly print out an error message when it compares `undefined` to `null` when the function returns nothing.

This PR updates the debug mode code to handle the `undefined` return value.
