### PR TITLE
Support NamespaceImport in OpenApi gen

### DIFF
--- a/tests/dbos-runtime/openapi.test.ts
+++ b/tests/dbos-runtime/openapi.test.ts
@@ -123,11 +123,12 @@ describe("OpenApiGenerator", () => {
 
   it("OpenApiSecurityScheme RequiredRole", () => {
     const source = /*javascript*/`
-    import { TransactionContext, Transaction, GetApi, ArgSource, ArgSources, OpenApiSecurityScheme, RequiredRole } from '@dbos-inc/dbos-sdk'
+    import { TransactionContext, Transaction, ArgSource, ArgSources, OpenApiSecurityScheme, RequiredRole } from '@dbos-inc/dbos-sdk'
+    import * as dbos from '@dbos-inc/dbos-sdk'
 
     @OpenApiSecurityScheme({ type: 'http', scheme: 'bearer' })
     export class Hello {
-      @GetApi('/greeting/:user')
+      @dbos.GetApi('/greeting/:user')
       @RequiredRole(['user'])
       static async helloTransaction(ctxt: HandlerContext, @ArgSource(ArgSources.URL) user: string): Promise<string>  {
         return "";


### PR DESCRIPTION
Detect the `import * as dbos from '@dbos-inc/dbos-sdk  construct'` for putting decorators in a namespace.
(The name `dbos` is not important.)