### PR TITLE
Fix Debug Mode TypeORM Init

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -275,9 +275,9 @@ export class DBOSExecutor {
       }
 
       // Debug mode doesn't need to initialize the DBs. Everything should appear to be read-only.
+      await this.userDatabase.init(this.debugMode);
       if (!this.debugMode) {
         await this.systemDatabase.init();
-        await this.userDatabase.init(); // Skip user DB init because we're using the proxy.
         await this.recoverPendingWorkflows();
       }
     } catch (err) {

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -6,7 +6,7 @@ import { ValuesOf } from "./utils";
 import { Knex } from "knex";
 
 export interface UserDatabase {
-  init(): Promise<void>;
+  init(debugMode?: boolean): Promise<void>;
   destroy(): Promise<void>;
   getName(): UserDatabaseName;
 
@@ -54,9 +54,11 @@ export class PGNodeUserDatabase implements UserDatabase {
     this.pool = new Pool(poolConfig);
   }
 
-  async init(): Promise<void> {
-    await this.pool.query(createUserDBSchema);
-    await this.pool.query(userDBSchema);
+  async init(debugMode: boolean = false): Promise<void> {
+    if (!debugMode) {
+      await this.pool.query(createUserDBSchema);
+      await this.pool.query(userDBSchema);
+    }
   }
 
   async destroy(): Promise<void> {
@@ -169,9 +171,11 @@ const PrismaIsolationLevel = {
 export class PrismaUserDatabase implements UserDatabase {
   constructor(readonly prisma: PrismaClient) { }
 
-  async init(): Promise<void> {
-    await this.prisma.$queryRawUnsafe(createUserDBSchema);
-    await this.prisma.$queryRawUnsafe(userDBSchema);
+  async init(debugMode: boolean = false): Promise<void> {
+    if (!debugMode) {
+      await this.prisma.$queryRawUnsafe(createUserDBSchema);
+      await this.prisma.$queryRawUnsafe(userDBSchema);
+    }
   }
 
   async destroy(): Promise<void> {
@@ -273,13 +277,15 @@ export class TypeORMDatabase implements UserDatabase {
     this.dataSource = ds;
   }
 
-  async init(): Promise<void> {
+  async init(debugMode: boolean = false): Promise<void> {
     if (!this.dataSource.isInitialized) {
-      await this.dataSource.initialize();
+      await this.dataSource.initialize(); // Need to initialize datasource even in debug mode.
     }
 
-    await this.dataSource.query(createUserDBSchema);
-    await this.dataSource.query(userDBSchema);
+    if (!debugMode) {
+      await this.dataSource.query(createUserDBSchema);
+      await this.dataSource.query(userDBSchema);
+    }
   }
 
   async destroy(): Promise<void> {
@@ -354,9 +360,11 @@ export class KnexUserDatabase implements UserDatabase {
 
   constructor(readonly knex: Knex) { }
 
-  async init(): Promise<void> {
-    await this.knex.raw(createUserDBSchema);
-    await this.knex.raw(userDBSchema);
+  async init(debugMode: boolean = false): Promise<void> {
+    if (!debugMode) {
+      await this.knex.raw(createUserDBSchema);
+      await this.knex.raw(userDBSchema);
+    }
   }
 
   async destroy(): Promise<void> {

--- a/tests/testing/debug_typeorm.test.ts
+++ b/tests/testing/debug_typeorm.test.ts
@@ -1,0 +1,70 @@
+import { TransactionContext, Transaction, OrmEntities } from "../../src/";
+import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
+import { v1 as uuidv1 } from "uuid";
+import { DBOSConfig } from "../../src/dbos-executor";
+import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import { Column, Entity, EntityManager, PrimaryColumn } from "typeorm";
+import { UserDatabaseName } from "../../src/user_database";
+
+type TestTransactionContext = TransactionContext<EntityManager>;
+
+describe("typeorm-debugger-test", () => {
+  let config: DBOSConfig;
+  let debugConfig: DBOSConfig;
+  let testRuntime: TestingRuntime;
+  let debugRuntime: TestingRuntime;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig(UserDatabaseName.TYPEORM);
+    debugConfig = generateDBOSTestConfig(UserDatabaseName.TYPEORM, "http://127.0.0.1:5432");
+    await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    // TODO: connect to the real proxy.
+    debugRuntime = await createInternalTestRuntime([KVController], debugConfig);
+    testRuntime = await createInternalTestRuntime([KVController], config);
+    await testRuntime.dropUserSchema();
+    await testRuntime.createUserSchema();
+  });
+
+  afterEach(async () => {
+    await debugRuntime.destroy();
+    await testRuntime.destroy();
+  });
+
+  // Test TypeORM
+  @Entity()
+  class KV {
+    @PrimaryColumn()
+    id: string = "t";
+
+    @Column()
+    value: string = "v";
+  }
+
+  @OrmEntities([KV])
+  class KVController {
+    @Transaction()
+    static async testTxn(txnCtxt: TestTransactionContext, id: string, value: string) {
+      const kv: KV = new KV();
+      kv.id = id;
+      kv.value = value;
+      const res = await txnCtxt.client.save(kv);
+      return res.id;
+    }
+  }
+
+  test("debug-typeorm-transaction", async () => {
+    const wfUUID = uuidv1();
+    // Execute the workflow and destroy the runtime
+    await expect(testRuntime.invoke(KVController, wfUUID).testTxn("test", "value")).resolves.toBe("test");
+    await testRuntime.destroy();
+
+    // Execute again in debug mode.
+    await expect(debugRuntime.invoke(KVController, wfUUID).testTxn("test", "value")).resolves.toBe("test");
+
+    // Execute again with the provided UUID.
+    await expect((debugRuntime as TestingRuntimeImpl).getDBOSExec().executeWorkflowUUID(wfUUID).then((x) => x.getResult())).resolves.toBe("test");
+  });
+});


### PR DESCRIPTION
This PR fixes a bug where TypeORM datasource wasn't initialized under debug mode.
Also add a test for TypeORM in debug mode.