### PR TITLE
Send Telemetry Data Faster

### DIFF
--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -25,8 +25,9 @@ export class TelemetryCollector {
   // Signals buffer management
   private readonly signals: SignalsQueue = new SignalsQueue();
   private readonly signalBufferID: NodeJS.Timeout;
-  private readonly processAndExportSignalsIntervalMs = 1000;
-  private readonly processAndExportSignalsMaxBatchSize = 10;
+  
+  // We iterate on an interval and export whatever has accumulated so far 
+  private readonly processAndExportSignalsIntervalMs = 100;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(readonly exporter?: ITelemetryExporter) {
@@ -50,7 +51,7 @@ export class TelemetryCollector {
 
   async processAndExportSignals(): Promise<void> {
     const batch: TelemetrySignal[] = [];
-    while (this.signals.size() > 0 && batch.length < this.processAndExportSignalsMaxBatchSize) {
+    while (this.signals.size() > 0) {
       const signal = this.pop();
       if (!signal) {
         break;


### PR DESCRIPTION
Per our slack exchange with @maxdml , reduce the sleep wait time to 100ms and, every cycle, send all the data that has accumulated in the queue. Thus there is no "max message size" and we send everything we have to avoid delays and a growing RAM footprint.

I tested this change by re-running test_load and verifying that there are exactly 10,000 unique traces in the monitoring DB as soon as the test finishes. I'm considering modifying that test to check that. Requires a companion PR on the dbos-cloud side that will ensure that Zazu and otel-pg-exporter only use one postgres connection. 

Ran all the other integration tests too.