### PR TITLE
Provide an option for the testing runtime to keep the systemDB

### DIFF
--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -19,20 +19,22 @@ import { Client } from "pg";
 /**
  * Create a testing runtime. Warn: this function will drop the existing system DB and create a clean new one. Don't run tests against your production database!
  */
-export async function createTestingRuntime(userClasses: object[], configFilePath: string = dbosConfigFilePath): Promise<TestingRuntime> {
+export async function createTestingRuntime(userClasses: object[], configFilePath: string = dbosConfigFilePath, dropSysDB: boolean = true): Promise<TestingRuntime> {
   const [ dbosConfig ] = parseConfigFile({configfile: configFilePath});
 
-  // Drop system database. Testing runtime always uses Postgres for local testing.
-  const pgSystemClient = new Client({
-    user: dbosConfig.poolConfig.user,
-    port: dbosConfig.poolConfig.port,
-    host: dbosConfig.poolConfig.host,
-    password: dbosConfig.poolConfig.password,
-    database: dbosConfig.poolConfig.database,
-  });
-  await pgSystemClient.connect();
-  await pgSystemClient.query(`DROP DATABASE IF EXISTS ${dbosConfig.system_database};`);
-  await pgSystemClient.end();
+  if (dropSysDB) {
+    // Drop system database. Testing runtime always uses Postgres for local testing.
+    const pgSystemClient = new Client({
+      user: dbosConfig.poolConfig.user,
+      port: dbosConfig.poolConfig.port,
+      host: dbosConfig.poolConfig.host,
+      password: dbosConfig.poolConfig.password,
+      database: dbosConfig.poolConfig.database,
+    });
+    await pgSystemClient.connect();
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${dbosConfig.system_database};`);
+    await pgSystemClient.end();
+  }
 
   const otr = createInternalTestRuntime(userClasses, dbosConfig, undefined)
   return otr;


### PR DESCRIPTION
Previously, we always drop the system DB when we create a new testing runtime. However, sometimes we don't want to drop it.

For example, if I want to run multiple concurrent testing runtimes, we may not want to drop and re-create the system DB from every process.
Another example is the debug proxy test may want to keep system DB data across test runs, so we can have full provenance information.