### PR TITLE
.dockerignore for deploy + createdb security fix

### DIFF
--- a/src/cloud-cli/applications/deploy-app-code.ts
+++ b/src/cloud-cli/applications/deploy-app-code.ts
@@ -136,7 +136,7 @@ dist/
   try {
     // Write the Dockerfile and .dockerignore
     writeFileSync(dockerFileName, dockerFileContent);
-    writeFileSync(`${deployDirectoryName}/${dockerFileName}.dockerignore`, dockerIgnoreContent);
+    writeFileSync(`${deployDirectoryName}/Dockerfile.dbos.dockerignore`, dockerIgnoreContent);
     // Build the Docker image.  As build takes a long time, use runCommand to stream its output to stdout.
     await runCommand('docker', ['build', '-t', appName, '-f', dockerFileName, '.'])
     // Run the container

--- a/src/cloud-cli/applications/deploy-app-code.ts
+++ b/src/cloud-cli/applications/deploy-app-code.ts
@@ -128,9 +128,15 @@ RUN npm run build
 RUN npm prune --omit=dev
 RUN zip -ry ${appName}.zip ./* -x "${appName}.zip" -x "${deployDirectoryName}/*" > /dev/null
 `;
+  const dockerIgnoreContent = `
+node_modules/
+${deployDirectoryName}/
+dist/
+`;
   try {
-    // Write the Dockerfile
+    // Write the Dockerfile and .dockerignore
     writeFileSync(dockerFileName, dockerFileContent);
+    writeFileSync(`${deployDirectoryName}/${dockerFileName}.dockerignore`, dockerIgnoreContent);
     // Build the Docker image.  As build takes a long time, use runCommand to stream its output to stdout.
     await runCommand('docker', ['build', '-t', appName, '-f', dockerFileName, '.'])
     // Run the container

--- a/src/cloud-cli/userdb.ts
+++ b/src/cloud-cli/userdb.ts
@@ -100,9 +100,10 @@ export function migrate(): number {
   const userDBName = configFile.database.user_database;
 
   logger.info(`Creating database ${userDBName} if it does not already exist`);
-  const createDB = `PGPASSWORD=${configFile.database.password} createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -w ${userDBName}`;
+  const createDB = `createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -ew ${userDBName}`;
   try {
-    const createDBOutput = execSync(createDB).toString();
+    process.env.PGPASSWORD = configFile.database.password;
+    const createDBOutput = execSync(createDB, { env: process.env }).toString();
     if (createDBOutput.includes(`database "${userDBName}" already exists`)) {
       logger.info(`Database ${userDBName} already exists`)
     } else {

--- a/src/cloud-cli/userdb.ts
+++ b/src/cloud-cli/userdb.ts
@@ -100,7 +100,7 @@ export function migrate(): number {
   const userDBName = configFile.database.user_database;
 
   logger.info(`Creating database ${userDBName} if it does not already exist`);
-  const createDB = `PGPASSWORD=${configFile.database.password} createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -ew ${userDBName}`;
+  const createDB = `PGPASSWORD=${configFile.database.password} createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -w ${userDBName}`;
   try {
     const createDBOutput = execSync(createDB).toString();
     if (createDBOutput.includes(`database "${userDBName}" already exists`)) {


### PR DESCRIPTION
On a warm deploy container, not copying over `dist/` and `node_modules/` results in +/- 5s speedup:

[+] Building 15.0s (14/14) FINISHED                                    docker:default

vs

[+] Building 20.9s (15/15) FINISHED                                    docker:default


This pr also hide PGPASSWORD from the logs during migration.

<img width="1480" alt="Screenshot 2024-01-05 at 18 23 34" src="https://github.com/dbos-inc/dbos-ts/assets/3437048/64085fef-d3c2-4fa7-9cf9-d81a5dd69ebb">

