### PR TITLE
Put ids into logs

### DIFF
--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -231,7 +231,7 @@ class OTLPLogQueueTransport extends TransportStream {
         traceId: span?.spanContext()?.traceId,
         spanId: span?.spanContext()?.spanId,
         stack,
-        applicationId: this.applicationID,
+        applicationID: this.applicationID,
         executorID: this.executorID } as LogAttributes,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       // context: span?.spanContext() || undefined,

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -180,16 +180,16 @@ const consoleFormat = format.combine(
 class OTLPLogQueueTransport extends TransportStream {
   readonly name = "OTLPLogQueueTransport";
   readonly otelLogger: OTelLogger;
-  readonly applicationId: string;
-  readonly vmId: string;
+  readonly applicationID: string;
+  readonly executorID: string;
 
   constructor(readonly telemetryCollector: TelemetryCollector) {
     super();
     // not sure if we need a more explicit name here
     const loggerProvider = new LoggerProvider();
     this.otelLogger = loggerProvider.getLogger("default");
-    this.applicationId = process.env.APPID || "APP_ID_NOT_DEFINED";
-    this.vmId = process.env.VMID || "VM_ID_NOT_DEFINED";
+    this.applicationID = process.env.APPID || "APP_ID_NOT_DEFINED";
+    this.executorID = process.env.VMID || "VM_ID_NOT_DEFINED";
     const logRecordProcessor = {
       forceFlush: async () => {
         // no-op
@@ -231,8 +231,8 @@ class OTLPLogQueueTransport extends TransportStream {
         traceId: span?.spanContext()?.traceId,
         spanId: span?.spanContext()?.spanId,
         stack,
-        applicationId: this.applicationId,
-        vmId: this.vmId } as LogAttributes,
+        applicationId: this.applicationID,
+        executorID: this.executorID } as LogAttributes,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       // context: span?.spanContext() || undefined,
     });

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -180,12 +180,16 @@ const consoleFormat = format.combine(
 class OTLPLogQueueTransport extends TransportStream {
   readonly name = "OTLPLogQueueTransport";
   readonly otelLogger: OTelLogger;
+  readonly applicationId: string;
+  readonly vmId: string;
 
   constructor(readonly telemetryCollector: TelemetryCollector) {
     super();
     // not sure if we need a more explicit name here
     const loggerProvider = new LoggerProvider();
     this.otelLogger = loggerProvider.getLogger("default");
+    this.applicationId = process.env.APPID || "APP_ID_NOT_DEFINED";
+    this.vmId = process.env.VMID || "VM_ID_NOT_DEFINED";
     const logRecordProcessor = {
       forceFlush: async () => {
         // no-op
@@ -223,7 +227,12 @@ class OTLPLogQueueTransport extends TransportStream {
       timestamp: new Date().getTime(), // So far I don't see a major difference between this and observedTimestamp
       observedTimestamp: new Date().getTime(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      attributes: { ...span?.attributes, traceId: span?.spanContext()?.traceId, spanId: span?.spanContext()?.spanId, stack } as LogAttributes,
+      attributes: { ...span?.attributes,
+        traceId: span?.spanContext()?.traceId,
+        spanId: span?.spanContext()?.spanId,
+        stack,
+        applicationId: this.applicationId,
+        vmId: this.vmId } as LogAttributes,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       // context: span?.spanContext() || undefined,
     });

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -6,8 +6,7 @@ import { TelemetryCollector } from "./collector";
 
 export class Tracer {
   private readonly tracer: BasicTracerProvider;
-  readonly applicationId: string;
-  readonly vmId: string;
+  readonly applicationID: string;
   constructor(private readonly telemetryCollector: TelemetryCollector) {
     this.tracer = new BasicTracerProvider({
       resource: new Resource({
@@ -15,8 +14,7 @@ export class Tracer {
       }),
     });
     this.tracer.register();
-    this.applicationId = process.env.APPID || "APP_ID_NOT_DEFINED";
-    this.vmId = process.env.VMID || "VM_ID_NOT_DEFINED";
+    this.applicationID = process.env.APPID || "APP_ID_NOT_DEFINED";
   }
 
   startSpanWithContext(spanContext: SpanContext, name: string, attributes?: Attributes): Span {
@@ -37,8 +35,7 @@ export class Tracer {
 
   endSpan(span: Span) {
     span.end(Date.now());
-    span.attributes.applicationId = this.applicationId;
-    span.attributes.vmId = this.vmId;
+    span.attributes.applicationID = this.applicationID;
     this.telemetryCollector.push(span as ReadableSpan);
   }
 }

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -6,6 +6,8 @@ import { TelemetryCollector } from "./collector";
 
 export class Tracer {
   private readonly tracer: BasicTracerProvider;
+  readonly applicationId: string;
+  readonly vmId: string;
   constructor(private readonly telemetryCollector: TelemetryCollector) {
     this.tracer = new BasicTracerProvider({
       resource: new Resource({
@@ -13,6 +15,8 @@ export class Tracer {
       }),
     });
     this.tracer.register();
+    this.applicationId = process.env.APPID || "APP_ID_NOT_DEFINED";
+    this.vmId = process.env.VMID || "VM_ID_NOT_DEFINED";
   }
 
   startSpanWithContext(spanContext: SpanContext, name: string, attributes?: Attributes): Span {
@@ -33,6 +37,8 @@ export class Tracer {
 
   endSpan(span: Span) {
     span.end(Date.now());
+    span.attributes.applicationId = this.applicationId;
+    span.attributes.vmId = this.vmId;
     this.telemetryCollector.push(span as ReadableSpan);
   }
 }

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -7,6 +7,7 @@ import { TelemetryCollector } from "./collector";
 export class Tracer {
   private readonly tracer: BasicTracerProvider;
   readonly applicationID: string;
+  readonly executorID: string;
   constructor(private readonly telemetryCollector: TelemetryCollector) {
     this.tracer = new BasicTracerProvider({
       resource: new Resource({
@@ -15,6 +16,7 @@ export class Tracer {
     });
     this.tracer.register();
     this.applicationID = process.env.APPID || "APP_ID_NOT_DEFINED";
+    this.executorID = process.env.VMID || "VM_ID_NOT_DEFINED";
   }
 
   startSpanWithContext(spanContext: SpanContext, name: string, attributes?: Attributes): Span {
@@ -36,6 +38,9 @@ export class Tracer {
   endSpan(span: Span) {
     span.end(Date.now());
     span.attributes.applicationID = this.applicationID;
+    if ( !("executorID" in span.attributes)) {
+      span.attributes.executorID = this.executorID;
+    }
     this.telemetryCollector.push(span as ReadableSpan);
   }
 }


### PR DESCRIPTION
The ts-side of the effort to gather app and vm IDs for monitoring. Gather APPID and VMID from environment variables, if defined. Add them to the attributes of both logs and traces (as applicationID and executorID). Note that traces already uses executorID that it gets from headers (for most spans). We only use the environment variable for those spans where it is not already set.