### PR TITLE
Unique System DB Name Per App

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -32,10 +32,6 @@
           "type": "string",
           "description": "The name of the application database"
         },
-        "system_database": {
-          "type": "string",
-          "description": "The name of a database to which DBOS can write system data. Defaults to `dbos_systemdb`"
-        },
         "ssl_ca": {
           "type": "string",
           "description": "If using SSL/TLS to securely connect to a database, path to an SSL root certificate file"
@@ -52,6 +48,14 @@
             "typeorm",
             "knex"
           ]
+        },
+        "migrate": {
+          "type": "array",
+          "description": "Specify a list of user DB migration commands to run"
+        },
+        "rollback": {
+          "type": "array",
+          "description": "Specify a list of user DB rollback commands to run"
         }
       },
       "required": [

--- a/dbos-test-config.yaml
+++ b/dbos-test-config.yaml
@@ -4,7 +4,6 @@ database:
   username: 'postgres'
   password: ${PGPASSWORD}
   user_database: 'dbostest'
-  system_database: 'dbostest_systemdb'
   user_dbclient: 'pg-node'
   connectionTimeoutMillis: 3000
 telemetry:

--- a/examples/hello/dbos-config.yaml
+++ b/examples/hello/dbos-config.yaml
@@ -9,7 +9,6 @@ database:
   username: 'postgres'
   password: ${PGPASSWORD}
   user_database: 'hello'
-  system_database: 'hello_systemdb'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
   migrate: ['migrate:latest']

--- a/src/cloud-cli/userdb.ts
+++ b/src/cloud-cli/userdb.ts
@@ -237,7 +237,7 @@ async function createDBOSTables(configFile: ConfigFile) {
   }
 
   const systemPoolConfig = { ...userPoolConfig };
-  systemPoolConfig.database = "dbos_systemdb"; // We enforce it to be the dbos_systemdb.
+  systemPoolConfig.database = `${userPoolConfig.database}_dbos_sys`;
 
   const pgUserClient = new Client(userPoolConfig);
   await pgUserClient.connect();

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -20,7 +20,6 @@ export interface ConfigFile {
     password?: string;
     connectionTimeoutMillis?: number;
     user_database: string;
-    system_database?: string;
     ssl_ca?: string;
     observability_database?: string;
     user_dbclient?: UserDatabaseName;
@@ -121,7 +120,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions): [DBOSConfig, 
     poolConfig: poolConfig,
     userDbclient: configFile.database.user_dbclient || UserDatabaseName.KNEX,
     telemetry: configFile.telemetry || undefined,
-    system_database: configFile.database.system_database ?? "dbos_systemdb",
+    system_database: `${poolConfig.database}_dbos_sys`,
     observability_database: configFile.database.observability_database || undefined,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     application: configFile.application || undefined,

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -60,7 +60,7 @@ async function dropHelloSystemDB() {
     database: "hello",
   });
   await pgSystemClient.connect();
-  await pgSystemClient.query(`DROP DATABASE IF EXISTS hello_systemdb;`);
+  await pgSystemClient.query(`DROP DATABASE IF EXISTS hello_dbos_sys;`);
   await pgSystemClient.end();
 }
 
@@ -102,7 +102,6 @@ database:
   username: 'postgres'
   password: \${PGPASSWORD}
   user_database: 'hello'
-  system_database: 'hello_systemdb'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
 runtimeConfig:
@@ -163,7 +162,6 @@ database:
   username: 'postgres'
   password: \${PGPASSWORD}
   user_database: 'hello'
-  system_database: 'hello_systemdb'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
 runtimeConfig:

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -32,8 +32,7 @@ export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugProxy?:
         silent: silenceLogs,
       },
     },
-    system_database: "dbostest_systemdb",
-    // observability_database: "dbostest_observabilitydb",
+    system_database: "dbostest_dbos_sys",
     userDbclient: dbClient || UserDatabaseName.PGNODE,
     dbClientMetadata: {
       entities: ["KV"],


### PR DESCRIPTION
This PR removes the configurable `system_database` parameter from dbos config file.
Instead, we always set the system DB name to `<userdb>_dbos_sys`. We will enforce a similar rule for the provenance DB.

This way, we can easily export all user and system provenance data for an app, and support multiple logical user DBs/apps on the same physical DB (e.g., RDS). Otherwise, if all applications share the same system DB (previously `dbos_systemdb`), it'd be very difficult to export provenance data to each app's provenance DB.