### PR TITLE
Move system DB tables to dbos schema

### DIFF
--- a/examples/hello/dbos-config.yaml
+++ b/examples/hello/dbos-config.yaml
@@ -1,3 +1,7 @@
+# To enable auto-completion and validation for this file in VSCode, install the RedHat YAML extension
+# https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dbos-inc/dbos-sdk/main/dbos-config.schema.json
 
 database:
   hostname: 'localhost'
@@ -7,5 +11,5 @@ database:
   user_database: 'hello'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
-runtimeConfig:
-  entrypoint: dist/entrypoint.js
+  migrate: ['migrate:latest']
+  rollback: ['migrate:rollback']

--- a/examples/hello/dbos-config.yaml
+++ b/examples/hello/dbos-config.yaml
@@ -1,7 +1,3 @@
-# To enable auto-completion and validation for this file in VSCode, install the RedHat YAML extension 
-# https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
-
-# yaml-language-server: $schema=https://raw.githubusercontent.com/dbos-inc/dbos-sdk/main/dbos-config.schema.json
 
 database:
   hostname: 'localhost'
@@ -11,5 +7,5 @@ database:
   user_database: 'hello'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
-  migrate: ['migrate:latest']
-  rollback: ['migrate:rollback']
+runtimeConfig:
+  entrypoint: dist/entrypoint.js

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -36,7 +36,9 @@ export interface workflow_inputs {
 }
 
 export const systemDBSchema = `
-  CREATE TABLE IF NOT EXISTS operation_outputs (
+  CREATE SCHEMA IF NOT EXISTS dbos;
+
+  CREATE TABLE IF NOT EXISTS dbos.operation_outputs (
     workflow_uuid TEXT NOT NULL,
     function_id INT NOT NULL,
     output TEXT,
@@ -44,12 +46,12 @@ export const systemDBSchema = `
     PRIMARY KEY (workflow_uuid, function_id)
   );
 
-  CREATE TABLE IF NOT EXISTS workflow_inputs (
+  CREATE TABLE IF NOT EXISTS dbos.workflow_inputs (
     workflow_uuid TEXT PRIMARY KEY NOT NULL,
     inputs TEXT NOT NULL
   );
 
-  CREATE TABLE IF NOT EXISTS workflow_status (
+  CREATE TABLE IF NOT EXISTS dbos.workflow_status (
     workflow_uuid TEXT PRIMARY KEY,
     status TEXT,
     name TEXT,
@@ -62,21 +64,21 @@ export const systemDBSchema = `
     executor_id TEXT
   );
 
-  CREATE TABLE IF NOT EXISTS notifications (
+  CREATE TABLE IF NOT EXISTS dbos.notifications (
     destination_uuid TEXT NOT NULL,
     topic TEXT,
     message TEXT NOT NULL,
     created_at_epoch_ms BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now())*1000)::bigint
   );
 
-  CREATE TABLE IF NOT EXISTS workflow_events (
+  CREATE TABLE IF NOT EXISTS dbos.workflow_events (
     workflow_uuid TEXT NOT NULL,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
     PRIMARY KEY (workflow_uuid, key)
   );
 
-  CREATE INDEX IF NOT EXISTS idx_workflow_topic ON notifications (destination_uuid, topic);
+  CREATE INDEX IF NOT EXISTS idx_workflow_topic ON dbos.notifications (destination_uuid, topic);
 
   CREATE OR REPLACE FUNCTION notifications_function() RETURNS TRIGGER AS $$
     DECLARE
@@ -89,7 +91,7 @@ export const systemDBSchema = `
     $$ LANGUAGE plpgsql;
 
     CREATE OR REPLACE TRIGGER dbos_notifications_trigger
-    AFTER INSERT ON notifications
+    AFTER INSERT ON dbos.notifications
     FOR EACH ROW EXECUTE FUNCTION notifications_function();
 
     CREATE OR REPLACE FUNCTION workflow_events_function() RETURNS TRIGGER AS $$
@@ -103,6 +105,6 @@ export const systemDBSchema = `
     $$ LANGUAGE plpgsql;
 
     CREATE OR REPLACE TRIGGER dbos_workflow_events_trigger
-    AFTER INSERT ON workflow_events
+    AFTER INSERT ON dbos.workflow_events
     FOR EACH ROW EXECUTE FUNCTION workflow_events_function();
 `;

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -80,7 +80,7 @@ export const systemDBSchema = `
 
   CREATE INDEX IF NOT EXISTS idx_workflow_topic ON dbos.notifications (destination_uuid, topic);
 
-  CREATE OR REPLACE FUNCTION notifications_function() RETURNS TRIGGER AS $$
+  CREATE OR REPLACE FUNCTION dbos.notifications_function() RETURNS TRIGGER AS $$
     DECLARE
         payload text := NEW.destination_uuid || '::' || NEW.topic;
     BEGIN
@@ -92,9 +92,9 @@ export const systemDBSchema = `
 
     CREATE OR REPLACE TRIGGER dbos_notifications_trigger
     AFTER INSERT ON dbos.notifications
-    FOR EACH ROW EXECUTE FUNCTION notifications_function();
+    FOR EACH ROW EXECUTE FUNCTION dbos.notifications_function();
 
-    CREATE OR REPLACE FUNCTION workflow_events_function() RETURNS TRIGGER AS $$
+    CREATE OR REPLACE FUNCTION dbos.workflow_events_function() RETURNS TRIGGER AS $$
     DECLARE
         payload text := NEW.workflow_uuid || '::' || NEW.key;
     BEGIN
@@ -106,5 +106,5 @@ export const systemDBSchema = `
 
     CREATE OR REPLACE TRIGGER dbos_workflow_events_trigger
     AFTER INSERT ON dbos.workflow_events
-    FOR EACH ROW EXECUTE FUNCTION workflow_events_function();
+    FOR EACH ROW EXECUTE FUNCTION dbos.workflow_events_function();
 `;

--- a/src/cloud-cli/userdb.ts
+++ b/src/cloud-cli/userdb.ts
@@ -260,12 +260,12 @@ async function createDBOSTables(configFile: ConfigFile) {
   await pgSystemClient.connect();
 
   try {
-    const tableExists = await pgSystemClient.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'operation_outputs')`);
+    const tableExists = await pgSystemClient.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = 'dbos')`);
     if (!tableExists.rows[0].exists) {
       await pgSystemClient.query(systemDBSchema);
     }
   } catch (e) {
-    const tableExists = await pgSystemClient.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'operation_outputs')`);
+    const tableExists = await pgSystemClient.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`);
     if (tableExists.rows[0].exists) {
       // If the table has been created by someone else. Ignore the error.
       logger.warn(`System tables creation failed, may conflict with concurrent tasks: ${(e as Error).message}`);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -124,7 +124,7 @@ export class DBOSExecutor {
   static readonly defaultNotificationTimeoutSec = 60;
 
   readonly debugMode: boolean;
-  static systemDBSchemaName = "public";
+  static systemDBSchemaName = "dbos";
 
   readonly logger: Logger;
   readonly tracer: Tracer;

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -6,9 +6,6 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
   dbosConfig = {...dbosConfig, debugProxy: proxy, system_database: provDB };
   dbosConfig.poolConfig.database = provDB;
 
-  // Point to the correct system DB schema.
-  DBOSExecutor.systemDBSchemaName = "dbos";
-
   // Load classes
   const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);
   const dbosExec = new DBOSExecutor(dbosConfig);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -85,7 +85,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
 
     // Check if the system schema exist.
-    const schemaExists = await this.pool.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'workflow_status')`);
+    const schemaExists = await this.pool.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = '${DBOSExecutor.systemDBSchemaName}')`);
     if (!schemaExists.rows[0].exists) {
       // Load the DBOS system schemas.
       await this.pool.query(systemDBSchema);


### PR DESCRIPTION
Previously, we put all system tables under the `public` schema in the system DB. This PR moves all tables under the `dbos` schema.

This change will make it much easier to export provenance data by leveraging Postgres logical replication, because PG doesn't support exporting tables to a different schema.