### PR TITLE
Cloud CLI UX improvements

### DIFF
--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -35,7 +35,7 @@ export async function registerApp(dbname: string, host: string, machines: number
     return 0;
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to register application ${appName}: ${e.response?.data}`);
+      logger.error(`${e.response?.data}`);
       return 1;
     } else {
       logger.error(`Failed to register application ${appName}: ${(e as Error).message}`);


### PR DESCRIPTION
- Remove redundant part of `2024-01-22 22:29:10 [error]: failed to register application network2: Error registering application: database dbos-controller-database not found for user max` (we expect the API to return a correctly formatted error)