### PR TITLE
SDK Improvements

### DIFF
--- a/migrations/20240124015239_status_timestamp.js
+++ b/migrations/20240124015239_status_timestamp.js
@@ -1,0 +1,22 @@
+exports.up = function(knex) {
+    return knex.schema.withSchema('dbos')
+        .table('workflow_status', function(table) {
+            // Add CREATED_AT column with default value as current epoch time in milliseconds
+            table.bigInteger('created_at')
+                .notNullable()
+                .defaultTo(knex.raw('(EXTRACT(EPOCH FROM now())*1000)::bigint'));
+
+            // Add UPDATED_AT column with default value as current epoch time in milliseconds
+            table.bigInteger('updated_at')
+                .notNullable()
+                .defaultTo(knex.raw('(EXTRACT(EPOCH FROM now())*1000)::bigint'));
+        });
+};
+
+exports.down = function(knex) {
+    return knex.schema.withSchema('dbos')
+        .table('workflow_status', function(table) {
+            table.dropColumn('created_at');
+            table.dropColumn('updated_at');
+        });
+};

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -18,7 +18,6 @@ export interface DBOSRuntimeConfig {
 
 export class DBOSRuntime {
   private dbosExec: DBOSExecutor;
-  private server: Server | null = null;
 
   constructor(dbosConfig: DBOSConfig, private readonly runtimeConfig: DBOSRuntimeConfig) {
     // Initialize workflow executor.
@@ -65,17 +64,9 @@ export class DBOSRuntime {
   startServer() {
     // CLI takes precedence over config file, which takes precedence over default config.
 
-    const server: DBOSHttpServer = new DBOSHttpServer(this.dbosExec)
+    const server = new DBOSHttpServer(this.dbosExec)
 
-    this.server = server.listen(this.runtimeConfig.port);
+    server.listen(this.runtimeConfig.port);
     this.dbosExec.logRegisteredHTTPUrls();
-  }
-
-  /**
-   * Shut down the HTTP server and destroy workflow executor.
-   */
-  async destroy() {
-    this.server?.close();
-    await this.dbosExec?.destroy();
   }
 }

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -2,7 +2,6 @@ import { DBOSExecutor, DBOSConfig } from '../dbos-executor';
 import { DBOSHttpServer } from '../httpServer/server';
 import * as fs from 'fs';
 import { isObject } from 'lodash';
-import { Server } from 'http';
 import { DBOSError } from '../error';
 import path from 'node:path';
 

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { MethodRegistration, MethodParameter, registerAndWrapFunction, getOrCreateMethodArgsRegistration, MethodRegistrationBase, getRegisteredOperations } from "../decorators";
-import { DBOSExecutor, DBOSExecutorIDHeader, OperationType } from "../dbos-executor";
+import { DBOSExecutor, OperationType } from "../dbos-executor";
 import { DBOSContext, DBOSContextImpl } from "../context";
 import Koa from "koa";
 import { Workflow, TailParameters, WorkflowHandle, WorkflowParams, WorkflowContext, WFInvokeFuncs } from "../workflow";
@@ -69,8 +69,9 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
 
     super(koaContext.url, span, dbosExec.logger);
 
-    if (koaContext.request.headers && koaContext.request.headers[DBOSExecutorIDHeader]) {
-      this.executorID = koaContext.request.headers[DBOSExecutorIDHeader] as string;
+    // If running in DBOS Cloud, set the executor ID
+    if (process.env.DBOS__VMID) {
+      this.executorID = process.env.DBOS__VMID
     }
 
     this.W3CTraceContextPropagator = httpTracer;

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -52,7 +52,7 @@ export class DBOSHttpServer {
     // Register HTTP endpoints.
     DBOSHttpServer.registerHealthEndpoint(this.dbosExec, this.adminRouter);
     DBOSHttpServer.registerRecoveryEndpoint(this.dbosExec, this.adminRouter);
-    this.app.use(this.adminRouter.routes()).use(this.adminRouter.allowedMethods());
+    this.adminApp.use(this.adminRouter.routes()).use(this.adminRouter.allowedMethods());
     DBOSHttpServer.registerDecoratedEndpoints(this.dbosExec, this.applicationRouter);
     this.app.use(this.applicationRouter.routes()).use(this.applicationRouter.allowedMethods());
   }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -63,13 +63,14 @@ export class DBOSHttpServer {
    */
   listen(port: number) {
     // Start the HTTP server.
-    this.app.listen(port, () => {
+    const appServer = this.app.listen(port, () => {
       this.logger.info(`DBOS Server is running at http://localhost:${port}`);
     });
     const adminPort = port + 1
-    this.adminApp.listen(adminPort, () => {
+    const adminServer = this.adminApp.listen(adminPort, () => {
       this.logger.info(`DBOS Server is running at http://localhost:${adminPort}`);
     });
+    return {appServer: appServer, adminServer: adminServer}
   }
 
   /**

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -68,7 +68,7 @@ export class DBOSHttpServer {
     });
     const adminPort = port + 1
     const adminServer = this.adminApp.listen(adminPort, () => {
-      this.logger.info(`DBOS Server is running at http://localhost:${adminPort}`);
+      this.logger.info(`DBOS Admin Server is running at http://localhost:${adminPort}`);
     });
     return {appServer: appServer, adminServer: adminServer}
   }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -117,18 +117,6 @@ export class DBOSHttpServer {
     dbosExec.registeredOperations.forEach((registeredOperation) => {
       const ro = registeredOperation as HandlerRegistration<unknown, unknown[], unknown>;
       if (ro.apiURL) {
-        // Ignore URL with "/dbos-workflow-recovery" prefix.
-        if (ro.apiURL.startsWith(WorkflowRecoveryUrl)) {
-          dbosExec.logger.error(`Invalid URL: ${ro.apiURL} -- should not start with ${WorkflowRecoveryUrl}!`);
-          return;
-        }
-
-        // Ignore URL with "/dbos-healthz" prefix.
-        if (ro.apiURL.startsWith(HealthUrl)) {
-          dbosExec.logger.error(`Invalid URL: ${ro.apiURL} -- should not start with ${HealthUrl}!`);
-          return;
-        }
-
         // Check if we need to apply any Koa middleware.
         const defaults = ro.defaults as MiddlewareDefaults;
         if (defaults?.koaMiddlewares) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,6 @@ export {
 } from "./httpServer/handler";
 
 export {
-  DBOSHttpServer, // TODO: Remove
-} from "./httpServer/server";
-
-export {
   DBOSHttpAuthMiddleware,
   DBOSHttpAuthReturn,
   MiddlewareContext,

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -151,7 +151,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     try {
       let finishedCnt = 0;
       while (finishedCnt < totalSize) {
-        let sqlStmt = `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output, executor_id) VALUES `;
+        let sqlStmt = `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output, executor_id, updated_at) VALUES `;
         let paramCnt = 1;
         const values: any[] = [];
         const batchUUIDs: string[] = [];
@@ -159,7 +159,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
           if (paramCnt > 1) {
             sqlStmt += ", ";
           }
-          sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++})`;
+          sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, (EXTRACT(EPOCH FROM now())*1000)::bigint)`;
           values.push(workflowUUID, status.status, status.name, status.authenticatedUser, status.assumedRole, JSON.stringify(status.authenticatedRoles), JSON.stringify(status.request), JSON.stringify(status.output), status.executorID);
           batchUUIDs.push(workflowUUID);
           finishedCnt++;
@@ -169,7 +169,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
             break;
           }
         }
-        sqlStmt += " ON CONFLICT (workflow_uuid) DO UPDATE SET status=EXCLUDED.status, output=EXCLUDED.output;";
+        sqlStmt += " ON CONFLICT (workflow_uuid) DO UPDATE SET status=EXCLUDED.status, output=EXCLUDED.output, updated_at=EXCLUDED.updated_at;";
 
         await this.pool.query(sqlStmt, values);
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -191,8 +191,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
   async recordWorkflowError(workflowUUID: string, status: WorkflowStatusInternal): Promise<void> {
     await this.pool.query(
-      `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, error, executor_id) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (workflow_uuid)
-    DO UPDATE SET status=EXCLUDED.status, error=EXCLUDED.error;`,
+      `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, error, executor_id, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, (EXTRACT(EPOCH FROM now())*1000)::bigint) ON CONFLICT (workflow_uuid)
+    DO UPDATE SET status=EXCLUDED.status, error=EXCLUDED.error, updated_at=EXCLUDED.updated_at;`,
       [workflowUUID, StatusString.ERROR, status.name, status.authenticatedUser, status.assumedRole, JSON.stringify(status.authenticatedRoles), JSON.stringify(status.request), status.error, status.executorID]
     );
   }

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -188,8 +188,8 @@ class OTLPLogQueueTransport extends TransportStream {
     // not sure if we need a more explicit name here
     const loggerProvider = new LoggerProvider();
     this.otelLogger = loggerProvider.getLogger("default");
-    this.applicationID = process.env.DBOS__APPID  || process.env.APPID || "APP_ID_NOT_DEFINED"; // TODO: Remove APPID
-    this.executorID = process.env.DBOS__VMID || process.env.VMID || "VM_ID_NOT_DEFINED"; // TODO: Remove VMID
+    this.applicationID = process.env.DBOS__APPID  || "APP_ID_NOT_DEFINED";
+    this.executorID = process.env.DBOS__VMID || "VM_ID_NOT_DEFINED";
     const logRecordProcessor = {
       forceFlush: async () => {
         // no-op

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -15,8 +15,8 @@ export class Tracer {
       }),
     });
     this.tracer.register();
-    this.applicationID = process.env.DBOS__APPID  || process.env.APPID || "APP_ID_NOT_DEFINED"; // TODO: Remove APPID
-    this.executorID = process.env.DBOS__VMID || process.env.VMID || "VM_ID_NOT_DEFINED"; // TODO: Remove VMID
+    this.applicationID = process.env.DBOS__APPID  || "APP_ID_NOT_DEFINED";
+    this.executorID = process.env.DBOS__VMID || "VM_ID_NOT_DEFINED";
   }
 
   startSpanWithContext(spanContext: SpanContext, name: string, attributes?: Attributes): Span {

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -53,6 +53,7 @@ export interface TestingRuntime {
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
 
   getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
+  getAdminCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
   getConfig<T>(key: string): T | undefined; // Get application configuration.
   getConfig<T>(key: string, defaultValue: T): T;
@@ -169,6 +170,13 @@ export class TestingRuntimeImpl implements TestingRuntime {
       throw new DBOSError("Uninitialized testing runtime! Did you forget to call init() first?");
     }
     return this.#server.app.callback();
+  }
+
+  getAdminCallback() {
+    if (!this.#server) {
+      throw new DBOSError("Uninitialized testing runtime! Did you forget to call init() first?");
+    }
+    return this.#server.adminApp.callback();
   }
 
   async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void> {

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -154,7 +154,7 @@ describe("foundationdb-recovery", () => {
     process.env.DBOS__VMID = "fcvm123"
     const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
-    const response = await request(testRuntime.getHandlersCallback())
+    const response = await request(testRuntime.getAdminCallback())
       .post(WorkflowRecoveryUrl)
       .send(["fcvm123"]);
     expect(response.statusCode).toBe(200);

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -18,6 +18,7 @@ describe("foundationdb-recovery", () => {
   beforeEach(async () => {
     const systemDB = await createInternalTestFDB();
     testRuntime = await createInternalTestRuntime([LocalRecovery, ExecutorRecovery], config, systemDB);
+    process.env.DBOS__VMID = ""
   });
 
   afterEach(async () => {
@@ -122,7 +123,8 @@ describe("foundationdb-recovery", () => {
 
     const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
 
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "dbos-executor-id": "fcvm123" } } }).executorWorkflow(5);
+    process.env.DBOS__VMID = "fcvm123"
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows(["fcvm123"]);
     await ExecutorRecovery.promise2; // Wait for the recovery to be done.
@@ -149,7 +151,8 @@ describe("foundationdb-recovery", () => {
       ExecutorRecovery.resolve2 = resolve;
     });
 
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "dbos-executor-id": "fcvm123" } } }).executorWorkflow(5);
+    process.env.DBOS__VMID = "fcvm123"
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const response = await request(testRuntime.getHandlersCallback())
       .post(WorkflowRecoveryUrl)

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -16,6 +16,7 @@ describe("recovery-tests", () => {
 
   beforeEach(async () => {
     testRuntime = await createInternalTestRuntime([LocalRecovery, ExecutorRecovery], config);
+    process.env.DBOS__VMID = ""
   });
 
   afterEach(async () => {
@@ -119,7 +120,8 @@ describe("recovery-tests", () => {
 
     const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
 
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "dbos-executor-id": "fcvm123" } } }).executorWorkflow(5);
+    process.env.DBOS__VMID = "fcvm123"
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows(["fcvm123"]);
     await ExecutorRecovery.promise2; // Wait for the recovery to be done.
@@ -146,7 +148,8 @@ describe("recovery-tests", () => {
       ExecutorRecovery.resolve2 = resolve;
     });
 
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "dbos-executor-id": "fcvm123", executorID: "fcvm123" } } }).executorWorkflow(5);
+    process.env.DBOS__VMID = "fcvm123"
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const response = await request(testRuntime.getHandlersCallback())
       .post(WorkflowRecoveryUrl)

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -151,7 +151,7 @@ describe("recovery-tests", () => {
     process.env.DBOS__VMID = "fcvm123"
     const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
-    const response = await request(testRuntime.getHandlersCallback())
+    const response = await request(testRuntime.getAdminCallback())
       .post(WorkflowRecoveryUrl)
       .send(["fcvm123"]);
     expect(response.statusCode).toBe(200);


### PR DESCRIPTION
- Add `created_at` and `updated_at` columns to `workflow_status`
- Completely remove recovery headers, rely on the `DBOS__VMID` environment variable instead.
- Move the admin API to a separate port so it can't be triggered accidentally/maliciously by normal requests.