### PR TITLE
CLI Improvements

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -77,6 +77,10 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
           logger.info(`If ${appName} takes too long to become available, check its logs at...`);
         }
       }
+      if (count > 180) {
+        logger.error("Application taking too long to become available")
+        return 1;
+      }
 
       // Retrieve the application status, check if it is "AVAILABLE"
       const list = await axios.get(

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -74,7 +74,7 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
       if (count % 5 === 0) {
         logger.info(`Waiting for ${appName} with version ${deployOutput.ApplicationVersion} to be available`);
         if (count > 20) {
-          logger.info(`If ${appName} takes too long to become available, check its logs at...`);
+          logger.info(`If ${appName} takes too long to become available, check its logs with 'npx dbos-cloud applications logs'`);
         }
       }
       if (count > 180) {

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { execSync } from "child_process";
 import { writeFileSync, existsSync } from 'fs';
-import { createDirectory, getCloudCredentials, getLogger, readFileSync, runCommand, sleep } from "../cloudutils";
+import { createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, runCommand, sleep } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 
@@ -41,6 +41,10 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
     // Zip the current directory and deploy from there. Requires app to have already been built. Only for testing.
     execSync(`zip -ry ${deployDirectoryName}/${appName}.zip ./* -x ${deployDirectoryName}/* > /dev/null`);
   }
+
+  const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
+  writeFileSync(`${deployDirectoryName}/${dbosConfigFilePath}`, interpolatedConfig)
+  execSync(`zip -j ${deployDirectoryName}/${appName}.zip ${deployDirectoryName}/${dbosConfigFilePath} > /dev/null`);
 
   try {
     const zipData = readFileSync(`${deployDirectoryName}/${appName}.zip`, "base64");
@@ -103,6 +107,14 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
       return 1;
     }
   }
+}
+
+function readInterpolatedConfig(configFilePath: string): string {
+  const configFileContent = readFileSync(configFilePath) as string;
+  const regex = /\${([^}]+)}/g;  // Regex to match ${VAR_NAME} style placeholders
+  return configFileContent.replace(regex, (_, g1: string) => {
+    return process.env[g1] || "";  // If the env variable is not set, return an empty string.
+});
 }
 
 async function buildAppInDocker(appName: string): Promise<boolean> {

--- a/packages/dbos-cloud/applications/list-apps.ts
+++ b/packages/dbos-cloud/applications/list-apps.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { getCloudCredentials, getLogger } from "../cloudutils";
 import { Application } from "./types";
 
-export async function listApps(host: string): Promise<number> {
+export async function listApps(host: string, json: boolean): Promise<number> {
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -16,17 +16,24 @@ export async function listApps(host: string): Promise<number> {
         },
       }
     );
-    const data: Application[] = list.data as Application[];
-    if (data.length === 0) {
+    const applications: Application[] = list.data as Application[];
+    if (applications.length === 0) {
       logger.info("No applications found");
       return 1;
     }
-    const formattedData: Application[] = []
-    for (const application of data) {
-      formattedData.push({ "Name": application.Name, "ID": application.ID, "Version": application.Version, "DatabaseName": application.DatabaseName, "MaxVMs": application.MaxVMs, "Status": application.Status });
+    if (json) {
+      console.log(JSON.stringify(applications));
+    } else {
+      logger.info(`Listing applications for ${userCredentials.userName}`)
+      applications.forEach(app => {
+        console.log(`Application Name: ${app.Name}`);
+        console.log(`ID: ${app.ID}`);
+        console.log(`Database Name: ${app.DatabaseName}`);
+        console.log(`Status: ${app.Status}`);
+        console.log(`Version: ${app.Version}`);
+        console.log('-------------------------');
+      });
     }
-    logger.info(`Listing applications for ${userCredentials.userName}`)
-    console.log(JSON.stringify(formattedData));
     return 0;
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
 
-export async function registerApp(dbname: string, host: string, machines: number): Promise<number> {
+export async function registerApp(dbname: string, host: string): Promise<number> {
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -19,7 +19,6 @@ export async function registerApp(dbname: string, host: string, machines: number
       {
         name: appName,
         database: dbname,
-        max_vms: machines,
       },
       {
         headers: {

--- a/packages/dbos-cloud/applications/types.ts
+++ b/packages/dbos-cloud/applications/types.ts
@@ -4,5 +4,4 @@ export type Application = {
   DatabaseName: string;
   Status: string;
   Version: string;
-  MaxVMs: string;
 };

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -30,7 +30,6 @@ export async function updateApp(host: string): Promise<number> {
     );
     const application: Application = update.data as Application;
     logger.info(`Successfully updated: ${application.Name}`);
-    console.log(JSON.stringify({ "Name": application.Name, "ID": application.ID, "Version": application.Version, "MaxVMs": application.MaxVMs }));
     return 0;
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -3,7 +3,7 @@ import { getCloudCredentials, getLogger } from "../cloudutils";
 import { Application } from "./types";
 import path from "node:path";
 
-export async function updateApp(host: string, machines: number): Promise<number> {
+export async function updateApp(host: string): Promise<number> {
   const logger =  getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -15,12 +15,11 @@ export async function updateApp(host: string, machines: number): Promise<number>
   logger.info(`Updating application: ${appName}`)
 
   try {
-    logger.info(`Updating application ${appName} to ${machines} machines`);
+    logger.info(`Updating application ${appName}`);
     const update = await axios.patch(
       `https://${host}/${userCredentials.userName}/application/${appName}`,
       {
         name: appName,
-        max_vms: machines
       },
       {
         headers: {

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -141,9 +141,10 @@ userdbCommands
 userdbCommands
   .command('status')
   .argument('<string>', 'database name')
-  .action((async (dbname: string) => {
+  .option('--json', 'Emit JSON output')
+  .action((async (dbname: string, options: { json: boolean}) => {
     const { host }: { host: string } = userdbCommands.opts()
-    await getUserDb(host, dbname)
+    await getUserDb(host, dbname, options.json)
   }))
 
 userdbCommands

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -102,9 +102,10 @@ applicationCommands
 applicationCommands
   .command('list')
   .description('List all deployed applications')
-  .action(async () => {
+  .option('--json', 'Emit JSON output')
+  .action(async (options: { json: boolean }) => {
     const { host }: { host: string } = applicationCommands.opts()
-    const exitCode = await listApps(host);
+    const exitCode = await listApps(host, options.json);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -74,10 +74,9 @@ applicationCommands
 applicationCommands
   .command('update')
   .description('Update an application')
-  .requiredOption('-m, --machines <string>', 'Number of VMs to deploy')
-  .action(async (options: { machines: string }) => {
+  .action(async () => {
     const { host }: { host: string } = applicationCommands.opts()
-    const exitCode = await updateApp(host, parseInt(options.machines));
+    const exitCode = await updateApp(host);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -65,10 +65,9 @@ applicationCommands
   .command('register')
   .description('Register a new application')
   .requiredOption('-d, --database <string>', 'Specify the app database name')
-  .option('-m, --machines <string>', 'Number of VMs to deploy', '1')
-  .action(async (options: { database: string, machines: string }) => {
+  .action(async (options: { database: string }) => {
     const { host }: { host: string } = applicationCommands.opts()
-    const exitCode = await registerApp(options.database, host, parseInt(options.machines));
+    const exitCode = await registerApp(options.database, host);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 import { spawn, StdioOptions } from 'child_process';
 import { transports, createLogger, format, Logger } from "winston";
 
+export const dbosConfigFilePath = "dbos-config.yaml";
+
 export function getLogger(): Logger {
   const winstonTransports: TransportStream[] = [];
   winstonTransports.push(

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -68,12 +68,20 @@ export async function deleteUserDb(host: string, dbName: string) {
   }
 }
 
-export async function getUserDb(host: string, dbName: string) {
+export async function getUserDb(host: string, dbName: string, json: boolean) {
   const logger = getLogger();
 
   try {
     const userDBInfo = await getUserDBInfo(host, dbName);
-    logger.info(userDBInfo);
+    if (json) {
+      console.log(JSON.stringify(userDBInfo));
+    } else {
+      logger.info(`Retrieving status of: ${dbName}`);
+      console.log(`DB Name: ${userDBInfo.DBName}`);
+      console.log(`Status: ${userDBInfo.Status}`);
+      console.log(`Host Name: ${userDBInfo.HostName}`);
+      console.log(`Port: ${userDBInfo.Port}`);
+    }
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
       logger.error(`Error getting database ${dbName}: ${e.response?.data}`);

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -30,7 +30,7 @@ export async function createUserDb(host: string, dbName: string, adminName: stri
 
     if (sync) {
       let status = "";
-      while (status != "available") {
+      while (status != "available" && status != "backing-up") {
         await sleep(30000);
         const userDBInfo = await getUserDBInfo(host, dbName);
         logger.info(userDBInfo);


### PR DESCRIPTION
- Substitute environment variables in deploy
- Recognize `backing-up` as an available RDS instance status
- All query commands (`list`, `userdb status`) now pretty-print by default and optionally return JSON.
- Remove `MaxVMs` from the interface completely--we're serverless!