### PR TITLE
Handle api errors

### DIFF
--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { getCloudCredentials, getLogger } from "../cloudutils";
+import axios, { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
 
 export async function deleteApp(host: string): Promise<number> {
@@ -24,12 +24,12 @@ export async function deleteApp(host: string): Promise<number> {
     logger.info(`Successfully deleted application: ${appName}`);
     return 0;
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to delete application ${appName}: ${e.response?.data}`);
-      return 1;
+    const errorLabel = `Failed to delete application ${appName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to delete application ${appName}: ${(e as Error).message}`);
-      return 1;
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,7 +1,7 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { execSync } from "child_process";
 import { writeFileSync, existsSync } from 'fs';
-import { createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, runCommand, sleep } from "../cloudutils";
+import { handleAPIErrors, createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, runCommand, sleep } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 
@@ -103,13 +103,13 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
     logger.info(`Access your application at https://${host}/${userCredentials.userName}/application/${appName}`)
     return 0;
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to deploy application ${appName}: ${e.response?.data}`);
-      return 1;
+    const errorLabel = `Failed to deploy application ${appName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to deploy application ${appName}: ${(e as Error).message}`);
-      return 1;
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }
 

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { getCloudCredentials, getLogger } from "../cloudutils";
+import axios , { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
 
 export async function getAppLogs(host: string): Promise<number> {
@@ -24,12 +24,12 @@ export async function getAppLogs(host: string): Promise<number> {
     logger.info(res.data)
     return 0;
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to retrieve logs of application ${appName}: ${e.response?.data}`);
-      return 1;
+    const errorLabel = `Failed to retrieve logs of application ${appName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to retrieve logs of application ${appName}: ${(e as Error).message}`);
-      return 1;
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }

--- a/packages/dbos-cloud/applications/list-apps.ts
+++ b/packages/dbos-cloud/applications/list-apps.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { getCloudCredentials, getLogger } from "../cloudutils";
+import axios, { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import { Application } from "./types";
 
 export async function listApps(host: string, json: boolean): Promise<number> {
@@ -36,12 +36,12 @@ export async function listApps(host: string, json: boolean): Promise<number> {
     }
     return 0;
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to list applications: ${e.response?.data}`);
-      return 1;
+    const errorLabel = 'Failed to list applications';
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to list applications: ${(e as Error).message}`);
-      return 1;
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getCloudCredentials, getLogger } from "../cloudutils";
+import { CloudAPIErrorResponse, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
 
 export async function registerApp(dbname: string, host: string): Promise<number> {
@@ -33,7 +33,8 @@ export async function registerApp(dbname: string, host: string): Promise<number>
     return 0;
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to register application ${appName}: ${e.response?.data}`);
+      const resp: CloudAPIErrorResponse = e.response?.data as CloudAPIErrorResponse;
+      logger.error(`Failed to register application ${appName}: ${resp.message}. Request ID: ${resp.requestID}`);
       return 1;
     } else {
       logger.error(`Failed to register application ${appName}: ${(e as Error).message}`);

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -32,10 +32,11 @@ export async function registerApp(dbname: string, host: string): Promise<number>
     logger.info(`${appName} ID: ${uuid}`);
     return 0;
   } catch (e) {
+    const errorLabel = `Failed to register application ${appName}`;
     if (axios.isAxiosError(e) && (e as AxiosError).response) {
-      handleAPIErrors(`Failed to register application ${appName}`, e);
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to register application ${appName}: ${(e as Error).message}`);
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
     return 1;
   }

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { CloudAPIErrorResponse, getCloudCredentials, getLogger } from "../cloudutils";
+import axios, { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
 
 export async function registerApp(dbname: string, host: string): Promise<number> {
@@ -32,13 +32,11 @@ export async function registerApp(dbname: string, host: string): Promise<number>
     logger.info(`${appName} ID: ${uuid}`);
     return 0;
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      const resp: CloudAPIErrorResponse = e.response?.data as CloudAPIErrorResponse;
-      logger.error(`Failed to register application ${appName}: ${resp.message}. Request ID: ${resp.requestID}`);
-      return 1;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(`Failed to register application ${appName}`, e);
     } else {
       logger.error(`Failed to register application ${appName}: ${(e as Error).message}`);
-      return 1;
     }
+    return 1;
   }
 }

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -97,3 +97,10 @@ export type ValuesOf<T> = T[keyof T];
 export function createDirectory(path: string): string | undefined {
   return fs.mkdirSync(path, { recursive: true });
 }
+
+export interface CloudAPIErrorResponse {
+  message: string,
+  statusCode: number,
+  requestID: string,
+}
+

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -109,6 +109,6 @@ interface CloudAPIErrorResponse {
 export function handleAPIErrors(label: string, e: AxiosError) {
   const logger = getLogger();
   const resp: CloudAPIErrorResponse = e.response?.data as CloudAPIErrorResponse;
-  logger.error(`${label}: ${resp.message}. Request ID: ${resp.requestID}`);
+  logger.error(`[${resp.requestID}] ${label}: ${resp.message}.`);
 }
 

--- a/packages/dbos-cloud/register.ts
+++ b/packages/dbos-cloud/register.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { getCloudCredentials, getLogger } from "./cloudutils";
+import axios, { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "./cloudutils";
 
 export async function registerUser(username: string, host: string): Promise<number> {
   const userCredentials = getCloudCredentials();
@@ -23,10 +23,11 @@ export async function registerUser(username: string, host: string): Promise<numb
     const userUUID = register.data as string;
     logger.info(`Registered user ${userName}, UUID: ${userUUID}`);
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Failed to register user ${userName}: ${e.response.data}`);
+    const errorLabel = `Failed to register user ${username}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Failed to register user ${userName}: ${(e as Error).message}`);
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
     return 1;
   }

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { getCloudCredentials, getLogger } from "./cloudutils";
+import axios, { AxiosError } from "axios";
+import { handleAPIErrors, getCloudCredentials, getLogger } from "./cloudutils";
 import { sleep } from "../../src/utils";
 
 export interface UserDBInstance {
@@ -38,11 +38,13 @@ export async function createUserDb(host: string, dbName: string, adminName: stri
       }
     }
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Error creating database ${dbName}: ${e.response?.data}`);
+    const errorLabel = `Failed to create database ${dbName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Error creating database ${dbName}: ${(e as Error).message}`);
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }
 
@@ -60,11 +62,13 @@ export async function deleteUserDb(host: string, dbName: string) {
     });
     logger.info(`Database deleted: ${dbName}`);
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Error deleting database ${dbName}: ${e.response?.data}`);
+    const errorLabel = `Failed to delete database ${dbName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Error deleting database ${dbName}: ${(e as Error).message}`);
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }
 
@@ -83,11 +87,13 @@ export async function getUserDb(host: string, dbName: string, json: boolean) {
       console.log(`Port: ${userDBInfo.Port}`);
     }
   } catch (e) {
-    if (axios.isAxiosError(e) && e.response) {
-      logger.error(`Error getting database ${dbName}: ${e.response?.data}`);
+    const errorLabel = `Failed to retreive database record ${dbName}`;
+    if (axios.isAxiosError(e) && (e as AxiosError).response) {
+      handleAPIErrors(errorLabel, e);
     } else {
-      logger.error(`Error getting database ${dbName}: ${(e as Error).message}`);
+      logger.error(`${errorLabel}: ${(e as Error).message}`);
     }
+    return 1;
   }
 }
 


### PR DESCRIPTION
Update the cloud CLI to better handle API errors, specifically printing a request ID. This ID will be useful for debugging.

Register an application:
![egrister](https://github.com/dbos-inc/dbos-ts/assets/3437048/33fb8be7-b8c8-4d9d-bf1f-24a8a979a0e0)

Delete an application:
![delete](https://github.com/dbos-inc/dbos-ts/assets/3437048/2e445ed8-042b-4802-adef-1648c83ad0e4)

Deploying an application:
![deploy](https://github.com/dbos-inc/dbos-ts/assets/3437048/52c934a6-78fb-4987-ab8d-2fbc18229c30)

Retrieving application logs:
![logs](https://github.com/dbos-inc/dbos-ts/assets/3437048/62c3e122-cd56-4df8-835b-49a5c9a9856a)

Registering a user:
![register user](https://github.com/dbos-inc/dbos-ts/assets/3437048/c4d15d19-ebfd-4e27-b055-146b0757eab8)
