### PR TITLE
Otel-log schema migrations, a couple bug fixes

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -309,7 +309,7 @@ export class DBOSExecutor {
     await this.flushWorkflowBuffers();
     await this.systemDatabase.destroy();
     await this.userDatabase.destroy();
-    await this.telemetryCollector.destroy();
+    await this.logger.destroy();
   }
 
   /* WORKFLOW OPERATIONS */

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander';
 import { DBOSConfig } from "../dbos-executor";
 import { init } from "./init";
 import { debugWorkflow } from "./debug";
-import { runAndLog, migrate, rollbackMigration, bugRepro } from "./migrate";
+import { runAndLog, migrate, rollbackMigration } from "./migrate";
 
 const program = new Command();
 
@@ -64,9 +64,7 @@ program
 program
   .command('migrate')
   .description("Perform a database migration")
-  .action( async () => {
-    bugRepro();
-  });
+  .action((() => { runAndLog(migrate) }));
 
 program
   .command('rollback')

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -64,11 +64,11 @@ program
 program
   .command('migrate')
   .description("Perform a database migration")
-  .action((() => { runAndLog(migrate) }));
+  .action((async () => { await runAndLog(migrate) }));
 
 program
   .command('rollback')
-  .action((() => { runAndLog(rollbackMigration) }))
+  .action((async () => { await runAndLog(rollbackMigration) }))
 
 program.parse(process.argv);
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander';
 import { DBOSConfig } from "../dbos-executor";
 import { init } from "./init";
 import { debugWorkflow } from "./debug";
-import { runAndLog, migrate, rollbackMigration } from "./migrate";
+import { runAndLog, migrate, rollbackMigration, bugRepro } from "./migrate";
 
 const program = new Command();
 
@@ -64,7 +64,9 @@ program
 program
   .command('migrate')
   .description("Perform a database migration")
-  .action(() =>  { runAndLog(migrate) });
+  .action( async () => {
+    bugRepro();
+  });
 
 program
   .command('rollback')

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander';
 import { DBOSConfig } from "../dbos-executor";
 import { init } from "./init";
 import { debugWorkflow } from "./debug";
-import { migrate, rollbackMigration } from "./migrate";
+import { runAndLog, migrate, rollbackMigration } from "./migrate";
 
 const program = new Command();
 
@@ -64,17 +64,11 @@ program
 program
   .command('migrate')
   .description("Perform a database migration")
-  .action((async () => {
-    const exitCode = await migrate();
-    process.exit(exitCode);
-  }))
+  .action(() =>  { runAndLog(migrate) });
 
 program
   .command('rollback')
-  .action((() => {
-    const exitCode = rollbackMigration();
-    process.exit(exitCode);
-  }))
+  .action((() => { runAndLog(rollbackMigration) }))
 
 program.parse(process.argv);
 

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -27,13 +27,14 @@ export async function runAndLog(action: (configFile: ConfigFile, logger:GlobalLo
       new TelemetryCollector(new TelemetryExporter(configFile.telemetry.OTLPExporter)), 
       configFile.telemetry?.logs
     )
-    terminate = async (code: number) => {
-      await logger.destroy();
-      process.exit(code);
+    terminate = (code: number) => {
+      void logger.destroy().finally(() => {
+        process.exit(code);
+      });
     };
   }
   else {
-    terminate = async (code:number) => {
+    terminate = (code:number) => {
       process.exit(code);
     }
   }
@@ -121,6 +122,7 @@ export async function migrate(configFile: ConfigFile, logger:GlobalLogger) {
   return 0;
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function rollbackMigration(configFile: ConfigFile, logger:GlobalLogger) {
   logger.info("Starting Migration Rollback");
   

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -48,7 +48,7 @@ export async function runAndLog(action: (configFile: ConfigFile, logger:GlobalLo
 
 export async function migrate(configFile: ConfigFile, logger:GlobalLogger) {
   const userDBName = configFile.database.user_database;
-  logger.info(`Starting Migration: creating database ${userDBName} if it does not exist`);
+  logger.info(`Starting migration: creating database ${userDBName} if it does not exist`);
   
   const createDB = `createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -ew ${userDBName}`;
   try {

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -37,9 +37,11 @@ export class TelemetryCollector {
   }
 
   async destroy() {
+    console.log("in TelemetryCollector::destroy")
     clearInterval(this.signalBufferID);
     await this.processAndExportSignals();
     await this.exporter?.flush();
+    console.log("in TelemetryCollector::destroy complete")
   }
 
   push(signal: TelemetrySignal) {
@@ -51,6 +53,7 @@ export class TelemetryCollector {
   }
 
   async processAndExportSignals(): Promise<void> {
+    console.log("in ProcessAndExportSignals")
     const batch: TelemetrySignal[] = [];
     while (this.signals.size() > 0) {
       const signal = this.pop();
@@ -62,6 +65,7 @@ export class TelemetryCollector {
     if (batch.length > 0) {
       const exports = [];
       if (this.exporter) {
+        console.log("in ProcessAndExportSignals adding export batch")
         exports.push(this.exporter.export(batch));
       }
       try {
@@ -70,5 +74,6 @@ export class TelemetryCollector {
         console.error((e as Error).message);
       }
     }
+    console.log("in ProcessAndExportSignals complete")
   }
 }

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -63,15 +63,13 @@ export class TelemetryCollector {
       batch.push(signal);
     }
     if (batch.length > 0) {
-      const exports = [];
       if (this.exporter) {
         console.log("in ProcessAndExportSignals adding export batch")
-        exports.push(this.exporter.export(batch));
-      }
-      try {
-        await Promise.all(exports);
-      } catch (e) {
-        console.error((e as Error).message);
+        try {
+          await this.exporter.export(batch);
+        } catch (e) {
+          console.error((e as Error).message);
+        }
       }
     }
     console.log("in ProcessAndExportSignals complete")

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -37,11 +37,9 @@ export class TelemetryCollector {
   }
 
   async destroy() {
-    console.log("in TelemetryCollector::destroy")
     clearInterval(this.signalBufferID);
     await this.processAndExportSignals();
     await this.exporter?.flush();
-    console.log("in TelemetryCollector::destroy complete")
   }
 
   push(signal: TelemetrySignal) {
@@ -53,7 +51,6 @@ export class TelemetryCollector {
   }
 
   async processAndExportSignals(): Promise<void> {
-    console.log("in ProcessAndExportSignals")
     const batch: TelemetrySignal[] = [];
     while (this.signals.size() > 0) {
       const signal = this.pop();
@@ -64,7 +61,6 @@ export class TelemetryCollector {
     }
     if (batch.length > 0) {
       if (this.exporter) {
-        console.log("in ProcessAndExportSignals adding export batch")
         try {
           await this.exporter.export(batch);
         } catch (e) {
@@ -72,6 +68,5 @@ export class TelemetryCollector {
         }
       }
     }
-    console.log("in ProcessAndExportSignals complete")
   }
 }

--- a/src/telemetry/exporters.ts
+++ b/src/telemetry/exporters.ts
@@ -35,6 +35,7 @@ export class TelemetryExporter implements ITelemetryExporter {
   }
 
   async export(signals: TelemetrySignal[]): Promise<void> {
+    console.log("TelemetryExporter::export")
     return await new Promise<void>((resolve) => {
       // Sort out traces and logs
       const exportSpans: ReadableSpan[] = [];
@@ -58,21 +59,25 @@ export class TelemetryExporter implements ITelemetryExporter {
       }
 
       if (exportLogs.length > 0 && this.logsExporter) {
+        console.log("TelemetryExporter::export exporting data")
         this.logsExporter.export(exportLogs, (results: ExportResult) => {
           if (results.code !== ExportResultCode.SUCCESS) {
             console.warn(`Log export failed: ${results.code}`);
             console.warn(results);
           }
         });
+        console.log("TelemetryExporter::export export finished")
       }
-
+      
       resolve();
     });
   }
 
   async flush() {
+    console.log("TelemetryExporter::flush")
     await this.logsExporter?.forceFlush();
     await this.tracesExporter?.forceFlush();
+    console.log("TelemetryExporter::flush complete")
   }
 }
 

--- a/src/telemetry/exporters.ts
+++ b/src/telemetry/exporters.ts
@@ -61,30 +61,24 @@ export class TelemetryExporter implements ITelemetryExporter {
       )
     }
     if (exportLogs.length > 0 && this.logsExporter) {
-      console.log("TelemetryExporter::export exporting data")
       tasks.push(
         new Promise<void>((resolve) => {
           this.logsExporter?.export(exportLogs, (results: ExportResult) => {
             if (results.code !== ExportResultCode.SUCCESS) {
              console.warn(`Log export failed: ${results.code}`);
              console.warn(results);
-            } else {
-             console.log("TelemetryExporter::export got Result callback")
-            }
+            } 
             resolve();          
          });
         })
       )
     }
     await Promise.all(tasks);
-    console.log("TelemetryExporter::export export finished")
   }
 
   async flush() {
-    console.log("TelemetryExporter::flush")
     await this.logsExporter?.forceFlush();
     await this.tracesExporter?.forceFlush();
-    console.log("TelemetryExporter::flush complete")
   }
 }
 

--- a/src/telemetry/exporters.ts
+++ b/src/telemetry/exporters.ts
@@ -35,42 +35,49 @@ export class TelemetryExporter implements ITelemetryExporter {
   }
 
   async export(signals: TelemetrySignal[]): Promise<void> {
-    console.log("TelemetryExporter::export")
-    return await new Promise<void>((resolve) => {
-      // Sort out traces and logs
-      const exportSpans: ReadableSpan[] = [];
-      const exportLogs: ReadableLogRecord[] = [];
-      signals.forEach((signal) => {
-        if (isTraceSignal(signal)) {
-          exportSpans.push(signal as ReadableSpan);
-        }
-        if (isLogSignal(signal)) {
-          exportLogs.push(signal as ReadableLogRecord);
-        }
-      });
-
-      if (exportSpans.length > 0 && this.tracesExporter) {
-        this.tracesExporter.export(exportSpans, (results: ExportResult) => {
-          if (results.code !== ExportResultCode.SUCCESS) {
-            console.warn(`Trace export failed: ${results.code}`);
-            console.warn(results);
-          }
-        });
+    // Sort out traces and logs
+    const exportSpans: ReadableSpan[] = [];
+    const exportLogs: ReadableLogRecord[] = [];
+    signals.forEach((signal) => {
+      if (isTraceSignal(signal)) {
+        exportSpans.push(signal as ReadableSpan);
       }
-
-      if (exportLogs.length > 0 && this.logsExporter) {
-        console.log("TelemetryExporter::export exporting data")
-        this.logsExporter.export(exportLogs, (results: ExportResult) => {
-          if (results.code !== ExportResultCode.SUCCESS) {
-            console.warn(`Log export failed: ${results.code}`);
-            console.warn(results);
-          }
-        });
-        console.log("TelemetryExporter::export export finished")
+      if (isLogSignal(signal)) {
+        exportLogs.push(signal as ReadableLogRecord);
       }
-      
-      resolve();
     });
+    const tasks : Promise<void>[] = [];
+    if (exportSpans.length > 0 && this.tracesExporter) {
+      tasks.push(
+        new Promise<void>((resolve) => {
+          this.tracesExporter?.export(exportSpans, (results: ExportResult) => {
+            if (results.code !== ExportResultCode.SUCCESS) {
+              console.warn(`Trace export failed: ${results.code}`);
+              console.warn(results);
+            }
+            resolve();
+          });
+        })
+      )
+    }
+    if (exportLogs.length > 0 && this.logsExporter) {
+      console.log("TelemetryExporter::export exporting data")
+      tasks.push(
+        new Promise<void>((resolve) => {
+          this.logsExporter?.export(exportLogs, (results: ExportResult) => {
+            if (results.code !== ExportResultCode.SUCCESS) {
+             console.warn(`Log export failed: ${results.code}`);
+             console.warn(results);
+            } else {
+             console.log("TelemetryExporter::export got Result callback")
+            }
+            resolve();          
+         });
+        })
+      )
+    }
+    await Promise.all(tasks);
+    console.log("TelemetryExporter::export export finished")
   }
 
   async flush() {

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -96,6 +96,10 @@ export class GlobalLogger {
       this.logger.error(JSON.stringify(inputError), { ...metadata, stack: new Error().stack });
     }
   }
+
+  async destroy() {
+    await this.telemetryCollector?.destroy();
+  }
 }
 
 /******************/

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -213,8 +213,8 @@ class OTLPLogQueueTransport extends TransportStream {
       severityNumber: levelToSeverityNumber[level as string],
       severityText: level as string,
       body: message as string,
-      timestamp: new Date().getTime(), // So far I don't see a major difference between this and observedTimestamp
-      observedTimestamp: new Date().getTime(),
+      timestamp: performance.now(), // So far I don't see a major difference between this and observedTimestamp
+      observedTimestamp: performance.now(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       attributes: { ...span?.attributes, traceId: span?.spanContext()?.traceId, spanId: span?.spanContext()?.spanId, stack, applicationID: this.applicationID, executorID: this.executorID } as LogAttributes,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -22,21 +22,21 @@ export class Tracer {
   startSpanWithContext(spanContext: SpanContext, name: string, attributes?: Attributes): Span {
     const tracer = opentelemetry.trace.getTracer("dbos-tracer");
     const ctx = opentelemetry.trace.setSpanContext(opentelemetry.context.active(), spanContext);
-    return tracer.startSpan(name, { startTime: Date.now(), attributes: attributes }, ctx) as Span;
+    return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }, ctx) as Span;
   }
 
   startSpan(name: string, attributes?: Attributes, parentSpan?: Span): Span {
     const tracer = opentelemetry.trace.getTracer("dbos-tracer");
     if (parentSpan) {
       const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parentSpan);
-      return tracer.startSpan(name, { startTime: Date.now(), attributes: attributes }, ctx) as Span;
+      return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }, ctx) as Span;
     } else {
       return tracer.startSpan(name, { attributes: attributes }) as Span;
     }
   }
 
   endSpan(span: Span) {
-    span.end(Date.now());
+    span.end(performance.now());
     span.attributes.applicationID = this.applicationID;
     if ( !("executorID" in span.attributes)) {
       span.attributes.executorID = this.executorID;


### PR DESCRIPTION
1. Changed the schema migration path to send logs to otel-exporter if available, taking care to flush the logger on exit.
2. Fixed a timing issue: otel-exporter's export() method used a callback to notify when sent. Not waiting for the callback in a very short lived command (like a failed migration) would cause telemetry data to never get sent. Changed our calls to export to wait for the callback.
3. Increased the resolution of exported timestamps.
4. NIT: made logger.destroy() to call otel-collector.destroy() for just a bit more syntax clarity.
