### PR TITLE
Change package list and dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,7 @@ version.json
 .github/
 tests/
 coverage/
+packages/
 
 # ignore any packed packages in the repo
 *.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -790,9 +790,10 @@
       "link": true
     },
     "node_modules/@dbos-inc/dbos-sdk": {
-      "version": "0.8.41-preview",
-      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-0.8.41-preview.tgz",
-      "integrity": "sha512-r2YRTg8xXJvOn/icPukbGEsGqPQExhfgMzvl8TJus8pfe4M3ft91tAM1eEqnLGX5LAz8jS/8UN/8T+bsuxY8HA==",
+      "version": "0.8.51-preview",
+      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-0.8.51-preview.tgz",
+      "integrity": "sha512-aEtMx2OsgkZVdMdHAjgukjWSTPkHc0nmkG9KcNl8knS1BRsDERYDVTLrX99kYFGxSj6A2kb1/Z8kmM/OUJy4Gw==",
+      "peer": true,
       "dependencies": {
         "@koa/bodyparser": "^5.0.0",
         "@koa/cors": "^5.0.0",
@@ -8465,7 +8466,6 @@
       "version": "0.0.0-placeholder",
       "license": "MIT",
       "dependencies": {
-        "@dbos-inc/dbos-sdk": "^0.8.41-preview",
         "bcryptjs": "^2.4.3"
       },
       "devDependencies": {
@@ -8473,32 +8473,35 @@
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
         "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@dbos-inc/dbos-sdk": "^0.8.51-preview"
       }
     },
     "packages/communicator-datetime": {
       "name": "@dbos-inc/communicator-datetime",
       "version": "0.0.0-placeholder",
       "license": "MIT",
-      "dependencies": {
-        "@dbos-inc/dbos-sdk": "^0.8.41-preview"
-      },
       "devDependencies": {
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
         "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@dbos-inc/dbos-sdk": "^0.8.51-preview"
       }
     },
     "packages/communicator-random": {
       "name": "@dbos-inc/communicator-random",
       "version": "0.0.0-placeholder",
       "license": "MIT",
-      "dependencies": {
-        "@dbos-inc/dbos-sdk": "^0.8.41-preview"
-      },
       "devDependencies": {
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
         "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "@dbos-inc/dbos-sdk": "^0.8.51-preview"
       }
     },
     "packages/dbos-cloud": {

--- a/packages/communicator-bcrypt/package.json
+++ b/packages/communicator-bcrypt/package.json
@@ -23,7 +23,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@dbos-inc/dbos-sdk": "^0.8.41-preview",
     "bcryptjs": "^2.4.3"
+  },
+  "peerDependencies": {
+    "@dbos-inc/dbos-sdk": "^0.8.51-preview"
   }
 }

--- a/packages/communicator-datetime/package.json
+++ b/packages/communicator-datetime/package.json
@@ -21,7 +21,7 @@
     "nerdbank-gitversioning": "^3.6.133",
     "typescript": "^5.3.3"
   },
-  "dependencies": {
-    "@dbos-inc/dbos-sdk": "^0.8.41-preview"
+  "peerDependencies": {
+    "@dbos-inc/dbos-sdk": "^0.8.51-preview"
   }
 }

--- a/packages/communicator-random/package.json
+++ b/packages/communicator-random/package.json
@@ -21,7 +21,7 @@
     "nerdbank-gitversioning": "^3.6.133",
     "typescript": "^5.3.3"
   },
-  "dependencies": {
-    "@dbos-inc/dbos-sdk": "^0.8.41-preview"
+  "peerDependencies": {
+    "@dbos-inc/dbos-sdk": "^0.8.51-preview"
   }
 }


### PR DESCRIPTION
`packages` should not be in the SDK npm package

The communicator libraries should not have `dbos-sdk` as a direct dependency, but rather a peer dependency.