### PR TITLE
Support the --last parameter

### DIFF
--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -5,7 +5,7 @@ import { stringify } from "node:querystring";
 
 export async function getAppLogs(host: string, last: number): Promise<number> {
   if (last != undefined && (isNaN(last) || last <= 0)) {
-    throw new Error('The --last parmameter must be greater than 0');
+    throw new Error('The --last parmameter must be an integer greater than 0');
   }
   if (last == undefined) {
     last = 0      //internally, 0 means "get all the logs." This is the default.

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { stringify } from "node:querystring";
 
 export async function getAppLogs(host: string, last: number): Promise<number> {
-  if (last != undefined && (isNaN(last) || last < 0)) {
+  if (last != undefined && (isNaN(last) || last <= 0)) {
     throw new Error('The --last parmameter must be greater than 0');
   }
   if (last == undefined) {

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -1,7 +1,6 @@
 import axios , { AxiosError } from "axios";
 import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
-import { stringify } from "node:querystring";
 
 export async function getAppLogs(host: string, last: number): Promise<number> {
   if (last != undefined && (isNaN(last) || last <= 0)) {

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -1,8 +1,15 @@
 import axios , { AxiosError } from "axios";
 import { handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
 import path from "node:path";
+import { stringify } from "node:querystring";
 
-export async function getAppLogs(host: string): Promise<number> {
+export async function getAppLogs(host: string, last: number): Promise<number> {
+  if (last != undefined && (isNaN(last) || last < 0)) {
+    throw new Error('The --last parmameter must be greater than 0');
+  }
+  if (last == undefined) {
+    last = 0      //internally, 0 means "get all the logs." This is the default.
+  }
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -13,15 +20,18 @@ export async function getAppLogs(host: string): Promise<number> {
   logger.info(`Retrieving logs for application: ${appName}`)
 
   try {
-    const res = await axios.get(`https://${host}/${userCredentials.userName}/logs/application/${appName}`, {
+    const res = await axios.get(`https://${host}/${userCredentials.userName}/logs/application/${appName}?last=${last}`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: bearerToken,
-      },
+      }
     });
-
-    logger.info(`Successfully retrieved logs of application: ${appName}`);
-    logger.info(res.data)
+    if (res.data == "") {
+      logger.info(`No logs found for the specified parameters`);
+    } else {
+      logger.info(`Successfully retrieved logs of application: ${appName}`);
+      logger.info(res.data)
+    }
     return 0;
   } catch (e) {
     const errorLabel = `Failed to retrieve logs of application ${appName}`;

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -112,9 +112,10 @@ applicationCommands
 applicationCommands
   .command('logs')
   .description('Print the microVM logs of a deployed application')
-  .action(async () => {
+  .option('-l, --last <integer>', 'How far back to query, in seconds from current time. By default, we retrieve all data', parseInt)
+  .action(async (options: { last: number}) => {
     const { host }: { host: string } = applicationCommands.opts()
-    const exitCode = await getAppLogs(host);
+    const exitCode = await getAppLogs(host, options.last);
     process.exit(exitCode);
   });
 


### PR DESCRIPTION
Send it to the cloud side and retrieve what comes back. Getting back an empty log is no longer an error.