### PR TITLE
Add primary key to dbos.notifications

### DIFF
--- a/migrations/20240201213211_replica_identity.js
+++ b/migrations/20240201213211_replica_identity.js
@@ -1,0 +1,15 @@
+exports.up = async function(knex) {
+  await knex.raw('create extension if not exists "uuid-ossp"');
+  return knex.schema.withSchema('dbos')
+    .table('notifications', function(table) {
+      table.text('message_uuid').notNullable().defaultTo(knex.raw('uuid_generate_v4()'))
+    })
+
+};
+
+exports.down = function(knex) {
+  return knex.schema.withSchema('dbos')
+    .table('notifications', function(table) {
+      table.dropColumn('message_uuid');
+    });
+};

--- a/migrations/20240201213211_replica_identity.js
+++ b/migrations/20240201213211_replica_identity.js
@@ -2,8 +2,7 @@ exports.up = async function(knex) {
   await knex.raw('create extension if not exists "uuid-ossp"');
   return knex.schema.withSchema('dbos')
     .table('notifications', function(table) {
-      table.text('message_uuid').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
-      table.primary('message_uuid');
+      table.text('message_uuid').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     })
 
 };

--- a/migrations/20240201213211_replica_identity.js
+++ b/migrations/20240201213211_replica_identity.js
@@ -2,7 +2,8 @@ exports.up = async function(knex) {
   await knex.raw('create extension if not exists "uuid-ossp"');
   return knex.schema.withSchema('dbos')
     .table('notifications', function(table) {
-      table.text('message_uuid').notNullable().defaultTo(knex.raw('uuid_generate_v4()'))
+      table.text('message_uuid').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.primary('message_uuid');
     })
 
 };


### PR DESCRIPTION
This PR adds a new column `message_uuid` as the primary key to the `dbos.notifications` table, which fixes the logical replication issue (`cannot delete from table \"notifications\" because it does not have a replica identity and publishes deletes`).