### PR TITLE
Foreign Key Constraints for System Tables

### DIFF
--- a/migrations/20240205223925_foreign_keys.js
+++ b/migrations/20240205223925_foreign_keys.js
@@ -4,6 +4,9 @@
  */
 exports.up = function(knex) {
   return knex.schema.withSchema('dbos')
+    .alterTable('workflow_status', function(table) {
+      table.index('created_at');
+    })
     .alterTable('operation_outputs', function(table) {
       table.foreign('workflow_uuid').references('workflow_uuid').inTable('dbos.workflow_status').onDelete('CASCADE').onUpdate('CASCADE');
     })
@@ -24,6 +27,9 @@ exports.up = function(knex) {
  */
 exports.down = function(knex) {
   return knex.schema.withSchema('dbos')
+    .alterTable('workflow_status', function(table) {
+      table.dropIndex('created_at');
+    })
     .alterTable('operation_outputs', function(table) {
       table.dropForeign('workflow_uuid');
     })

--- a/migrations/20240205223925_foreign_keys.js
+++ b/migrations/20240205223925_foreign_keys.js
@@ -1,0 +1,39 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.withSchema('dbos')
+    .alterTable('operation_outputs', function(table) {
+      table.foreign('workflow_uuid').references('workflow_uuid').inTable('dbos.workflow_status').onDelete('CASCADE').onUpdate('CASCADE');
+    })
+    .alterTable('workflow_inputs', function(table) {
+      table.foreign('workflow_uuid').references('workflow_uuid').inTable('dbos.workflow_status').onDelete('CASCADE').onUpdate('CASCADE');
+    })
+    .alterTable('notifications', function(table) {
+      table.foreign('destination_uuid').references('workflow_uuid').inTable('dbos.workflow_status').onDelete('CASCADE').onUpdate('CASCADE');
+    })
+    .alterTable('workflow_events', function(table) {
+      table.foreign('workflow_uuid').references('workflow_uuid').inTable('dbos.workflow_status').onDelete('CASCADE').onUpdate('CASCADE');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.withSchema('dbos')
+    .alterTable('operation_outputs', function(table) {
+      table.dropForeign('workflow_uuid');
+    })
+    .alterTable('workflow_inputs', function(table) {
+      table.dropForeign('workflow_uuid');
+    })
+    .alterTable('notifications', function(table) {
+      table.dropForeign('destination_uuid');
+    })
+    .alterTable('workflow_events', function(table) {
+      table.dropForeign('workflow_uuid');
+    });
+};

--- a/schemas/user_db_schema.ts
+++ b/schemas/user_db_schema.ts
@@ -21,3 +21,7 @@ export const userDBSchema = `
     PRIMARY KEY (workflow_uuid, function_id)
   );
 `;
+
+export const userDBIndex = `
+  CREATE INDEX IF NOT EXISTS transaction_outputs_created_at_index ON dbos.transaction_outputs (created_at);
+`

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -76,6 +76,11 @@ interface CommunicatorInfo {
   config: CommunicatorConfig;
 }
 
+interface InternalWorkflowParams extends WorkflowParams {
+  readonly tempWfType?: string;
+  readonly tempWfName?: string;
+}
+
 export const OperationType = {
   HANDLER: "handler",
   WORKFLOW: "workflow",
@@ -347,7 +352,7 @@ export class DBOSExecutor {
     this.communicatorInfoMap.set(comm.name, commInfo);
   }
 
-  async workflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
+  async workflow<T extends any[], R>(wf: Workflow<T, R>, params: InternalWorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
     if (this.debugMode) {
       return this.debugWorkflow(wf, params, undefined, undefined, ...args);
     }
@@ -355,7 +360,7 @@ export class DBOSExecutor {
   }
 
   // If callerUUID and functionID are set, it means the workflow is invoked from within a workflow.
-  async internalWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
+  async internalWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: InternalWorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     const workflowUUID: string = params.workflowUUID ? params.workflowUUID : this.#generateUUID();
     const presetUUID: boolean = params.workflowUUID ? true : false;
 
@@ -365,7 +370,7 @@ export class DBOSExecutor {
     }
     const wConfig = wInfo.config;
 
-    const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name, presetUUID);
+    const wCtxt: WorkflowContextImpl = new WorkflowContextImpl(this, params.parentCtx, workflowUUID, wConfig, wf.name, presetUUID, params.tempWfType, params.tempWfName);
 
     // If running in DBOS Cloud, set the executor ID
     if (process.env.DBOS__VMID) {
@@ -385,12 +390,15 @@ export class DBOSExecutor {
       executorID: wCtxt.executorID,
       createdAt: Date.now() // Remember the start time of this workflow
     };
-    // Synchronously set the workflow's status to PENDING and record workflow inputs.
-    if (!wCtxt.isTempWorkflow) {
+
+    if (wCtxt.isTempWorkflow) {
+      internalStatus.name = `${DBOSExecutor.tempWorkflowName}-${wCtxt.tempWfOperationType}-${wCtxt.tempWfOperationName}`;
+    }
+
+    // Synchronously set the workflow's status to PENDING and record workflow inputs (for non single-transaction workflows).
+    // We have to do it for all types of workflows because operation_outputs table has a foreign key constraint on workflow status table.
+    if (wCtxt.tempWfOperationType !== TempWorkflowType.transaction) {
       args = await this.systemDatabase.initWorkflowStatus(internalStatus, args);
-    } else {
-      // For temporary workflows, instead asynchronously record inputs.
-      this.systemDatabase.bufferWorkflowInputs(workflowUUID, args);
     }
 
     const runWorkflow = async () => {
@@ -398,9 +406,6 @@ export class DBOSExecutor {
       // Execute the workflow.
       try {
         result = await wf(wCtxt, ...args);
-        if (wCtxt.isTempWorkflow) {
-          internalStatus.name = `${DBOSExecutor.tempWorkflowName}-${wCtxt.tempWfOperationType}-${wCtxt.tempWfOperationName}`;
-        }
         internalStatus.output = result;
         internalStatus.status = StatusString.SUCCESS;
         this.systemDatabase.bufferWorkflowOutput(workflowUUID, internalStatus);
@@ -428,6 +433,11 @@ export class DBOSExecutor {
         }
       } finally {
         this.tracer.endSpan(wCtxt.span);
+        if (wCtxt.tempWfOperationType === TempWorkflowType.transaction) {
+          // For single-transaction workflows, asynchronously record inputs.
+          // We must buffer inputs after workflow status is buffered/flushed because workflow_inputs table has a foreign key reference to the workflow_status table.
+          this.systemDatabase.bufferWorkflowInputs(workflowUUID, args);
+        }
       }
       // Asynchronously flush the result buffer.
       if (wCtxt.resultBuffer.size > 0) {
@@ -501,33 +511,27 @@ export class DBOSExecutor {
     // Create a workflow and call transaction.
     const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;
-      ctxtImpl.tempWfOperationType = TempWorkflowType.transaction;
-      ctxtImpl.tempWfOperationName = txn.name;
       return await ctxtImpl.transaction(txn, ...args);
     };
-    return (await this.workflow(temp_workflow, params, ...args)).getResult();
+    return (await this.workflow(temp_workflow, { ...params, tempWfType: TempWorkflowType.transaction, tempWfName: txn.name }, ...args)).getResult();
   }
 
   async external<T extends any[], R>(commFn: Communicator<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call external.
     const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;
-      ctxtImpl.tempWfOperationType = TempWorkflowType.external;
-      ctxtImpl.tempWfOperationName = commFn.name;
       return await ctxtImpl.external(commFn, ...args);
     };
-    return (await this.workflow(temp_workflow, params, ...args)).getResult();
+    return (await this.workflow(temp_workflow, { ...params, tempWfType: TempWorkflowType.external, tempWfName: commFn.name }, ...args)).getResult();
   }
 
   async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void> {
     // Create a workflow and call send.
     const temp_workflow = async (ctxt: WorkflowContext, destinationUUID: string, message: T, topic?: string) => {
-      const ctxtImpl = ctxt as WorkflowContextImpl;
-      ctxtImpl.tempWfOperationType = TempWorkflowType.send;
       return await ctxt.send<T>(destinationUUID, message, topic);
     };
     const workflowUUID = idempotencyKey ? destinationUUID + idempotencyKey : undefined;
-    return (await this.workflow(temp_workflow, { workflowUUID: workflowUUID }, destinationUUID, message, topic)).getResult();
+    return (await this.workflow(temp_workflow, { workflowUUID: workflowUUID, tempWfType: TempWorkflowType.send }, destinationUUID, message, topic)).getResult();
   }
 
   /**

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -659,9 +659,9 @@ export class DBOSExecutor {
    */
   async flushWorkflowBuffers() {
     if (this.initialized) {
-      await this.systemDatabase.flushWorkflowInputsBuffer();
       await this.flushWorkflowResultBuffer();
       await this.systemDatabase.flushWorkflowStatusBuffer();
+      await this.systemDatabase.flushWorkflowInputsBuffer();
     }
   }
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -681,11 +681,12 @@ export class DBOSExecutor {
           for (const [funcID, recorded] of wfBuffer) {
             const output = recorded.output;
             const txnSnapshot = recorded.txn_snapshot;
+            const createdAt = recorded.created_at!
             if (paramCnt > 1) {
               sqlStmt += ", ";
             }
             sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, null, $${paramCnt++}, $${paramCnt++})`;
-            values.push(workflowUUID, funcID, JSON.stringify(output), JSON.stringify(null), txnSnapshot, Date.now());
+            values.push(workflowUUID, funcID, JSON.stringify(output), JSON.stringify(null), txnSnapshot, createdAt);
           }
           batchUUIDs.push(workflowUUID);
           finishedCnt++;

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -4,7 +4,7 @@ import { UserDatabaseName } from "../user_database";
 import { ConfigFile } from "./config";
 import { readFileSync } from "../utils";
 import { PoolConfig, Client } from "pg";
-import { createUserDBSchema, userDBSchema } from "../../schemas/user_db_schema";
+import { createUserDBSchema, userDBIndex, userDBSchema } from "../../schemas/user_db_schema";
 import { ExistenceCheck, migrateSystemDatabase } from "../system_database";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
@@ -135,6 +135,7 @@ async function createDBOSTables(configFile: ConfigFile) {
   if (!schemaExists.rows[0].exists) {
     await pgUserClient.query(createUserDBSchema);
     await pgUserClient.query(userDBSchema);
+    await pgUserClient.query(userDBIndex);
   }
 
   // Create the DBOS system database.

--- a/src/error.ts
+++ b/src/error.ts
@@ -161,9 +161,9 @@ export class DBOSDebuggerError extends DBOSError {
   }
 }
 
-const NonExistWorkflowError = 16;
-export class DBOSNonExistWorkflowError extends DBOSError {
+const NonExistentWorkflowError = 16;
+export class DBOSNonExistentWorkflowError extends DBOSError {
   constructor(msg: string) {
-    super(msg, NonExistWorkflowError);
+    super(msg, NonExistentWorkflowError);
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -160,3 +160,10 @@ export class DBOSDebuggerError extends DBOSError {
     super("DEBUGGER: " + msg, DebuggerError);
   }
 }
+
+const NonExistWorkflowError = 16;
+export class DBOSNonExistWorkflowError extends DBOSError {
+  constructor(msg: string) {
+    super(msg, NonExistWorkflowError);
+  }
+}

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -359,7 +359,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       const err: DatabaseError = error as DatabaseError;
       if (err.code === "23503") {
         // Foreign key constraint violation
-        throw new DBOSNonExistWorkflowError(`Send to non-exist destination UUID: ${destinationUUID}`);
+        throw new DBOSNonExistWorkflowError(`Sent to non-existent destination workflow UUID: ${destinationUUID}`);
       } else {
         throw err;
       }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -3,7 +3,7 @@
 import { deserializeError, serializeError } from "serialize-error";
 import { DBOSExecutor, dbosNull, DBOSNull } from "./dbos-executor";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from "pg";
-import { DuplicateWorkflowEventError, DBOSWorkflowConflictUUIDError, DBOSNonExistWorkflowError } from "./error";
+import { DuplicateWorkflowEventError, DBOSWorkflowConflictUUIDError, DBOSNonExistentWorkflowError } from "./error";
 import { StatusString, WorkflowStatus } from "./workflow";
 import { notifications, operation_outputs, workflow_status, workflow_events, workflow_inputs } from "../schemas/system_db_schema";
 import { sleep, findPackageRoot } from "./utils";
@@ -359,7 +359,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       const err: DatabaseError = error as DatabaseError;
       if (err.code === "23503") {
         // Foreign key constraint violation
-        throw new DBOSNonExistWorkflowError(`Sent to non-existent destination workflow UUID: ${destinationUUID}`);
+        throw new DBOSNonExistentWorkflowError(`Sent to non-existent destination workflow UUID: ${destinationUUID}`);
       } else {
         throw err;
       }

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Pool, PoolConfig, PoolClient, DatabaseError as PGDatabaseError } from "pg";
-import { createUserDBSchema, userDBSchema } from "../schemas/user_db_schema";
+import { createUserDBSchema, userDBIndex, userDBSchema } from "../schemas/user_db_schema";
 import { IsolationLevel, TransactionConfig } from "./transaction";
 import { ValuesOf } from "./utils";
 import { Knex } from "knex";
@@ -58,6 +58,7 @@ export class PGNodeUserDatabase implements UserDatabase {
     if (!debugMode) {
       await this.pool.query(createUserDBSchema);
       await this.pool.query(userDBSchema);
+      await this.pool.query(userDBIndex);
     }
   }
 
@@ -175,6 +176,7 @@ export class PrismaUserDatabase implements UserDatabase {
     if (!debugMode) {
       await this.prisma.$queryRawUnsafe(createUserDBSchema);
       await this.prisma.$queryRawUnsafe(userDBSchema);
+      await this.prisma.$queryRawUnsafe(userDBIndex);
     }
   }
 
@@ -285,6 +287,7 @@ export class TypeORMDatabase implements UserDatabase {
     if (!debugMode) {
       await this.dataSource.query(createUserDBSchema);
       await this.dataSource.query(userDBSchema);
+      await this.dataSource.query(userDBIndex);
     }
   }
 
@@ -364,6 +367,7 @@ export class KnexUserDatabase implements UserDatabase {
     if (!debugMode) {
       await this.knex.raw(createUserDBSchema);
       await this.knex.raw(userDBSchema);
+      await this.knex.raw(userDBIndex);
     }
   }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -79,8 +79,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   readonly isTempWorkflow: boolean;
 
   // For temporary workflows
-  tempWfOperationType: string;  // "transaction", "external", or "send"
-  tempWfOperationName: string; // The name of that operation.
+  readonly tempWfOperationType: string = "";  // "transaction", "external", or "send"
+  readonly tempWfOperationName: string = ""; // The name of that operation.
 
   constructor(
     dbosExec: DBOSExecutor,
@@ -89,6 +89,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     readonly workflowConfig: WorkflowConfig,
     workflowName: string,
     readonly presetUUID: boolean,
+    tempWfType: string = "",
+    tempWfName: string = ""
   ) {
     const span = dbosExec.tracer.startSpan(
       workflowName,
@@ -106,8 +108,11 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     this.workflowUUID = workflowUUID;
     this.#dbosExec = dbosExec;
     this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
-    this.tempWfOperationType = "";
-    this.tempWfOperationName = "";
+    if (this.isTempWorkflow) {
+      this.tempWfOperationType = tempWfType;
+      this.tempWfOperationName = tempWfName;
+    }
+
     if (dbosExec.config.application) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       this.applicationConfig = dbosExec.config.application;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -52,6 +52,7 @@ export interface PgTransactionId {
 export interface BufferedResult {
   output: unknown;
   txn_snapshot: string;
+  created_at?: number;
 }
 
 export const StatusString = {
@@ -188,11 +189,12 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
         const recorded = this.resultBuffer.get(funcID);
         const output = recorded!.output;
         const txnSnapshot = recorded!.txn_snapshot;
+        const createdAt = recorded!.created_at!;
         if (paramCnt > 1) {
           sqlStmt += ", ";
         }
         sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, null, $${paramCnt++}, $${paramCnt++})`;
-        values.push(this.workflowUUID, funcID, JSON.stringify(output), JSON.stringify(null), txnSnapshot, Date.now());
+        values.push(this.workflowUUID, funcID, JSON.stringify(output), JSON.stringify(null), txnSnapshot, createdAt);
       }
       this.logger.debug(sqlStmt);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -214,6 +216,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     const guardOutput: BufferedResult = {
       output: null,
       txn_snapshot: txnSnapshot,
+      created_at: Date.now(),
     }
     this.resultBuffer.set(funcID, guardOutput);
   }
@@ -339,6 +342,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
           const guardOutput: BufferedResult = {
             output: result,
             txn_snapshot: txn_snapshot!,
+            created_at: Date.now(),
           }
           this.resultBuffer.set(funcId, guardOutput);
         } else {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -79,10 +79,6 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   readonly resultBuffer: Map<number, BufferedResult> = new Map<number, BufferedResult>();
   readonly isTempWorkflow: boolean;
 
-  // For temporary workflows
-  readonly tempWfOperationType: string = "";  // "transaction", "external", or "send"
-  readonly tempWfOperationName: string = ""; // The name of that operation.
-
   constructor(
     dbosExec: DBOSExecutor,
     parentCtx: DBOSContextImpl | undefined,
@@ -90,8 +86,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     readonly workflowConfig: WorkflowConfig,
     workflowName: string,
     readonly presetUUID: boolean,
-    tempWfType: string = "",
-    tempWfName: string = ""
+    readonly tempWfOperationType: string = "", // "transaction", "external", or "send"
+    readonly tempWfOperationName: string = "" // Name for the temporary workflow operation
   ) {
     const span = dbosExec.tracer.startSpan(
       workflowName,
@@ -109,10 +105,6 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     this.workflowUUID = workflowUUID;
     this.#dbosExec = dbosExec;
     this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
-    if (this.isTempWorkflow) {
-      this.tempWfOperationType = tempWfType;
-      this.tempWfOperationName = tempWfName;
-    }
 
     if (dbosExec.config.application) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -65,6 +65,9 @@ describe("dbos-tests", () => {
   });
 
   test("simple-workflow-notifications", async () => {
+    // Send to non-exist workflow should fail
+    await expect(testRuntime.invoke(DBOSTestClass).sendWorkflow('1234567').then((x) => x.getResult())).rejects.toThrow('Send to non-exist destination UUID');
+
     const workflowUUID = uuidv1();
     const handle = await testRuntime.invoke(DBOSTestClass, workflowUUID).receiveWorkflow();
     await expect(testRuntime.invoke(DBOSTestClass).sendWorkflow(handle.getWorkflowUUID()).then((x) => x.getResult())).resolves.toBeFalsy(); // return void.

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -65,8 +65,8 @@ describe("dbos-tests", () => {
   });
 
   test("simple-workflow-notifications", async () => {
-    // Send to non-exist workflow should fail
-    await expect(testRuntime.invoke(DBOSTestClass).sendWorkflow('1234567').then((x) => x.getResult())).rejects.toThrow('Send to non-exist destination UUID');
+    // Send to non-existent workflow should fail
+    await expect(testRuntime.invoke(DBOSTestClass).sendWorkflow('1234567').then((x) => x.getResult())).rejects.toThrow('Sent to non-existent destination workflow UUID');
 
     const workflowUUID = uuidv1();
     const handle = await testRuntime.invoke(DBOSTestClass, workflowUUID).receiveWorkflow();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -179,13 +179,16 @@ describe("oaoo-tests", () => {
     const recvWorkflowUUID = uuidv1();
     const idempotencyKey = "test-suffix";
 
+    // Receive twice with the same UUID.  Each should get the same result of true.
+    const recvHandle1 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 10);
+    const recvHandle2 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 10);
+  
     // Send twice with the same idempotency key.  Only one message should be sent.
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();
 
-    // Receive twice with the same UUID.  Each should get the same result of true.
-    await expect(testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1).then((x) => x.getResult())).resolves.toBe(true);
-    await expect(testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1).then((x) => x.getResult())).resolves.toBe(true);
+    await expect(recvHandle1.getResult()).resolves.toBe(true)
+    await expect(recvHandle2.getResult()).resolves.toBe(true)
 
     // A receive with a different UUID should return false.
     await expect(testRuntime.invoke(NotificationOAOO).receiveOaooWorkflow("testTopic", 0).then((x) => x.getResult())).resolves.toBe(false);

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -180,8 +180,8 @@ describe("oaoo-tests", () => {
     const idempotencyKey = "test-suffix";
 
     // Receive twice with the same UUID.  Each should get the same result of true.
-    const recvHandle1 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 10);
-    const recvHandle2 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 10);
+    const recvHandle1 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
+    const recvHandle2 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
   
     // Send twice with the same idempotency key.  Only one message should be sent.
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();


### PR DESCRIPTION
This PR adds foreign key constraints on DBOS system tables, making the `workflow_staus.workflow_uuid` column as the core reference column for all other tables, and configures cascading updates and deletes so we can later correctly garbage collect these tables.

In addition, this PR changes behavior of the following operations:
- When we initialize workflow status, we now must synchronously set the workflow's status to PENDING and record workflow inputs for all non temp-transaction workflows. We have to do it for all types of workflows because `operation_outputs` table has a foreign key constraint on `workflow_status` table. We must ensure the workflow status exists before we record any operation output.
- For temp-transaction workflows, we must buffer inputs after workflow status is buffered (which is after the transaction completes) because `workflow_inputs` table now has a foreign key reference to the `workflow_status` table. Similarly, we also have to skip flushing a workflow's inputs if its status is still in the buffer and not flushed to the DB yet.
- The target workflow's status must exist when another function sends a notification to it. Otherwise, inserting a non-exist `destinationUUID` violates foreign key constraint on the `notifications` table, and we throw a `DBOSNonExistWorkflowError`.

This PR updates several tests to comply with these changes.