### PR TITLE
Emergency Fix for Workflow Status

### DIFF
--- a/migrations/20240207192338_executor_id_index.js
+++ b/migrations/20240207192338_executor_id_index.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.withSchema('dbos')
+    .alterTable('workflow_status', function(table) {
+      table.index('executor_id');
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.withSchema('dbos')
+    .alterTable('workflow_status', function(table) {
+      table.dropIndex('executor_id');
+    });
+};

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -560,6 +560,10 @@ export class DBOSExecutor {
   async recoverPendingWorkflows(executorIDs: string[] = ["local"]): Promise<WorkflowHandle<any>[]> {
     const pendingWorkflows: string[] = [];
     for (const execID of executorIDs) {
+      if (execID == "local" && process.env.DBOS__VMID) {
+        this.logger.debug(`Skip local recovery because it's running in a VM: ${process.env.DBOS__VMID}`);
+        continue;
+      }
       this.logger.debug(`Recovering workflows of executor: ${execID}`);
       const wIDs = await this.systemDatabase.getPendingWorkflows(execID);
       pendingWorkflows.push(...wIDs);


### PR DESCRIPTION
This PR adds an `executor_id` index to the workflow_status table, and also skips workflow recovery if `DBOS__VMID` env variable is set.

Context: select queries on workflow_status became too slow without an index, and local workflow recovery is unnecessary if we run SDK in a FC VM.