### PR TITLE
Only One Can Flush Buffers

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -124,6 +124,7 @@ export class DBOSExecutor {
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;
   readonly flushBufferID: NodeJS.Timeout;
+  isFlushingBuffers = false;
 
   static readonly defaultNotificationTimeoutSec = 60;
 
@@ -170,7 +171,8 @@ export class DBOSExecutor {
     }
 
     this.flushBufferID = setInterval(() => {
-      if (!this.debugMode) {
+      if (!this.debugMode && !this.isFlushingBuffers) {
+        this.isFlushingBuffers = true;
         void this.flushWorkflowBuffers();
       }
     }, this.flushBufferIntervalMs);
@@ -664,9 +666,9 @@ export class DBOSExecutor {
   async flushWorkflowBuffers() {
     if (this.initialized) {
       await this.flushWorkflowResultBuffer();
-      await this.systemDatabase.flushWorkflowStatusBuffer();
-      await this.systemDatabase.flushWorkflowInputsBuffer();
+      await this.systemDatabase.flushWorkflowSystemBuffers();
     }
+    this.isFlushingBuffers = false;
   }
 
   async flushWorkflowResultBuffer(): Promise<void> {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -108,6 +108,11 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
 
   // TODO: support batching
+  async flushWorkflowSystemBuffers(): Promise<void> {
+    await this.flushWorkflowStatusBuffer();
+    await this.flushWorkflowInputsBuffer();
+  }
+
   async flushWorkflowStatusBuffer(): Promise<void> {
     const localBuffer = new Map(this.workflowStatusBuffer);
     this.workflowStatusBuffer.clear();


### PR DESCRIPTION
This PR fixes an issue where potentially multiple concurrent function invocations can export system status and input buffers at the same time (e.g., buffer took a long time to flush, but the background thread invokes flush buffer functions every 1 second), so the race condition can cause foreign key violations on the workflow inputs table.

The fix is to add a "lock" (`isFlushingBuffers`) to prevent launching multiple exporters.
We also consolidate flushing workflow status and inputs into a single system DB interface function, so we always flush workflow status buffer first.