### PR TITLE
Remove chmod

### DIFF
--- a/examples/hello/package-lock.json
+++ b/examples/hello/package-lock.json
@@ -22,6 +22,7 @@
       }
     },
     "../..": {
+      "name": "@dbos-inc/dbos-sdk",
       "version": "0.0.0-placeholder",
       "license": "MIT",
       "workspaces": [

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -11,7 +11,7 @@
   "main": "cli.ts",
   "homepage": "https://docs.dbos.dev/",
   "scripts": {
-    "build": "tsc --project tsconfig.json && chmod +x ./dist/packages/dbos-cloud/cli.js",
+    "build": "tsc --project tsconfig.json",
     "test": "echo \"No tests\"",
     "setversion": "grunt setversion"
   },

--- a/packages/dbos-openapi/package.json
+++ b/packages/dbos-openapi/package.json
@@ -11,7 +11,7 @@
   "main": "cli.ts",
   "homepage": "https://docs.dbos.dev/",
   "scripts": {
-    "build": "tsc --project tsconfig.json && chmod +x ./dist/packages/dbos-openapi/cli.js",
+    "build": "tsc --project tsconfig.json",
     "test": "npm run build && jest --coverage --collectCoverageFrom='src/**/*' --detectOpenHandles",
     "setversion": "grunt setversion"
   },


### PR DESCRIPTION
This is supposed to be OK:

1. Within package.json, things are executed by node and it knows what to do without execute bit being set
2. `npm` will set the +x on things it installs that are listed in the `bin` section.  On Windows, its strategy is to create `.cmd` wrappers.

The exception is if someone wants to run cli.js directly from the shell (which only works on Unix-like shells anyway).  Then you need to change the invocation to call `node`.  If we have places that are doing that in the cloud deployment or within the firecracker vm, we will have to adjust.

I tried the OpenAPI command use of cli.js locally and it was fine.  Same for cloud command from within dev env shell, but didn't try execution within the cloud proper.