### PR TITLE
Improve Init and Migrations

### DIFF
--- a/examples/hello/dbos-config.yaml
+++ b/examples/hello/dbos-config.yaml
@@ -11,5 +11,5 @@ database:
   user_database: 'hello'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
-  migrate: ['migrate:latest']
-  rollback: ['migrate:rollback']
+  migrate: ['npx knex migrate:latest']
+  rollback: ['npx knex migrate:rollback']

--- a/examples/hello/package-lock.json
+++ b/examples/hello/package-lock.json
@@ -22,6 +22,7 @@
       }
     },
     "../..": {
+      "name": "@dbos-inc/dbos-sdk",
       "version": "0.0.0-placeholder",
       "license": "MIT",
       "workspaces": [

--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -12,7 +12,7 @@ docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD=${PGPASSWORD} --env=PGDAT
 # Wait for PostgreSQL to start
 echo "Waiting for PostgreSQL to start..."
 for i in {1..30}; do
-  if docker exec dbos-db pg_isready -U postgres | grep -q "accepting connections"; then
+  if docker exec dbos-db psql -U postgres -c "SELECT 1;" > /dev/null 2>&1; then
     echo "PostgreSQL started!"
     break
   fi
@@ -21,3 +21,5 @@ done
 
 # Create a database in Postgres.
 docker exec dbos-db psql -U postgres -c "CREATE DATABASE hello;"
+
+echo "Database started successfully!"

--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Check if PGPASSWORD is set
 if [[ -z "${PGPASSWORD}" ]]; then

--- a/src/dbos-runtime/init.ts
+++ b/src/dbos-runtime/init.ts
@@ -59,8 +59,9 @@ export async function init(appName: string) {
   const packageJson: { name: string } = JSON.parse(fs.readFileSync(packageJsonName, 'utf-8')) as { name: string };
   packageJson.name = appName;
   fs.writeFileSync(packageJsonName, JSON.stringify(packageJson, null, 2), 'utf-8');
-  execSync("npm i", {cwd: appName, stdio: 'inherit'})
-  execSync("npm uninstall @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
-  execSync("npm install --save @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
-  execSync("npm install --save-dev @dbos-inc/dbos-cloud", {cwd: appName, stdio: 'inherit'})
+  execSync("npm i --no-fund", {cwd: appName, stdio: 'inherit'})
+  execSync("npm uninstall --no-fund @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
+  execSync("npm install --no-fund --save @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
+  execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud", {cwd: appName, stdio: 'inherit'})
+  console.log("Application initialized successfully!")
 }

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -77,6 +77,7 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
     return 1;
   }
 
+  logger.info("Migration successful!")
   return 0;
 }
 

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -1,6 +1,5 @@
 import { execSync } from "child_process";
 import { GlobalLogger } from "../telemetry/logs";
-import { UserDatabaseName } from "../user_database";
 import { ConfigFile } from "./config";
 import { readFileSync } from "../utils";
 import { PoolConfig, Client } from "pg";

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -35,15 +35,12 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
     }
   }
 
-  const dbType = configFile.database.user_dbclient || UserDatabaseName.KNEX;
-  const migrationScript = `node_modules/.bin/${dbType}`;
   const migrationCommands = configFile.database.migrate;
 
   try {
     migrationCommands?.forEach((cmd) => {
-      const command = `node ${migrationScript} ${cmd}`;
-      logger.info(`Executing migration command: ${command}`);
-      const migrateCommandOutput = execSync(command).toString();
+      logger.info(`Executing migration command: ${cmd}`);
+      const migrateCommandOutput = execSync(cmd).toString();
       logger.info(migrateCommandOutput);
     });
   } catch (e) {

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -11,26 +11,27 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
   const userDBName = configFile.database.user_database;
   logger.info(`Starting migration: creating database ${userDBName} if it does not exist`);
 
-  const createDB = `createdb -h ${configFile.database.hostname} -p ${configFile.database.port} ${userDBName} -U ${configFile.database.username} -ew ${userDBName}`;
-  try {
-    process.env.PGPASSWORD = configFile.database.password;
-    const createDBOutput = execSync(createDB, { env: process.env }).toString();
-    if (createDBOutput.includes(`database "${userDBName}" already exists`)) {
-      logger.info(`Database ${userDBName} already exists`);
-    } else {
-      logger.info(createDBOutput);
-    }
-  } catch (e) {
-    if (e instanceof Error) {
-      if (e.message.includes(`database "${userDBName}" already exists`)) {
-        logger.info(`Database ${userDBName} already exists`);
+  if (!(await checkDatabaseExists(configFile, logger))) {
+    const postgresConfig: PoolConfig = {
+      host: configFile.database.hostname,
+      port: configFile.database.port,
+      user: configFile.database.username,
+      password: configFile.database.password,
+      connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
+      database: "postgres",
+    };
+    const postgresClient = new Client(postgresConfig);
+    try {
+      await postgresClient.connect()
+      await postgresClient.query(`CREATE DATABASE ${configFile.database.user_database}`);
+    } catch (e) {
+      if (e instanceof Error) {
+        logger.error(`Error creating database ${configFile.database.user_database}: ${e.message}`);
       } else {
-        logger.error(`Error creating database: ${e.message}`);
-        return 1;
+        logger.error(e);
       }
-    } else {
-      logger.error(e);
-      return 1;
+    } finally {
+      await postgresClient.end()
     }
   }
 
@@ -80,6 +81,29 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
   }
 
   return 0;
+}
+
+export async function checkDatabaseExists(configFile: ConfigFile, logger: GlobalLogger) {
+  const userPoolConfig: PoolConfig = {
+    host: configFile.database.hostname,
+    port: configFile.database.port,
+    user: configFile.database.username,
+    password: configFile.database.password,
+    connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
+    database: configFile.database.user_database,
+  };
+  const pgUserClient = new Client(userPoolConfig);
+
+  try {
+    await pgUserClient.connect(); // Try to establish a connection
+    logger.info(`Database ${configFile.database.user_database} exists!`)
+    return true; // If successful, return true
+  } catch (error) {
+    logger.info(`Database ${configFile.database.user_database} does not exist, creating...`)
+    return false; // If connection fails, return false
+  } finally {
+    await pgUserClient.end(); // Close pool regardless of the outcome
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -70,7 +70,7 @@ function configureHelloExample() {
   if (process.env.PGPASSWORD === undefined) {
     process.env.PGPASSWORD = "dbos";
   }
-  execSync("npx knex migrate:up", { env: process.env });
+  execSync("npx dbos-sdk migrate", { env: process.env });
 }
 
 describe("runtime-entrypoint-tests", () => {


### PR DESCRIPTION
- Remove `createdb` dependency from `migrate`
- `migrate` now takes in a full shell command and runs it instead of trying to guess prefixes
- Improve `init` output
- Fix timing bug in `start_postgres_docker.sh`
