### PR TITLE
Update Cloud CLI

### DIFF
--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -7,7 +7,7 @@ export async function deleteApp(host: string): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   logger.info(`Deleting application: ${appName}`)

--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -1,20 +1,15 @@
 import axios, { AxiosError } from "axios";
-import { isCloudAPIErrorResponse, handleAPIErrors, getCloudCredentials, getLogger } from "../cloudutils";
-import path from "node:path";
+import { isCloudAPIErrorResponse, handleAPIErrors, getCloudCredentials, getLogger, retrieveApplicationName } from "../cloudutils";
 
 export async function deleteApp(host: string): Promise<number> {
   const logger = getLogger()
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
-  logger.info(`Loaded application name from package.json: ${appName}`)
   logger.info(`Deleting application: ${appName}`)
 
   try {

--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -10,6 +10,10 @@ export async function deleteApp(host: string): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   logger.info(`Loaded application name from package.json: ${appName}`)
   logger.info(`Deleting application: ${appName}`)
 

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -20,6 +20,10 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   logger.info(`Loaded application name from package.json: ${appName}`)
 
   createDirectory(deployDirectoryName);

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -18,7 +18,7 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   logger.info(`Loaded application name from package.json: ${appName}`)

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { execSync } from "child_process";
 import { writeFileSync, existsSync } from 'fs';
-import { handleAPIErrors, createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, runCommand, sleep, isCloudAPIErrorResponse } from "../cloudutils";
+import { handleAPIErrors, createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, runCommand, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 
@@ -17,11 +17,8 @@ export async function deployAppCode(host: string, docker: boolean): Promise<numb
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
   logger.info(`Loaded application name from package.json: ${appName}`)

--- a/packages/dbos-cloud/applications/get-app-info.ts
+++ b/packages/dbos-cloud/applications/get-app-info.ts
@@ -11,6 +11,10 @@ export async function getAppInfo(host: string, json: boolean): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   if (!json) {
     logger.info(`Retrieving info for application: ${appName}`)
   }

--- a/packages/dbos-cloud/applications/get-app-info.ts
+++ b/packages/dbos-cloud/applications/get-app-info.ts
@@ -1,6 +1,5 @@
 import axios , { AxiosError } from "axios";
-import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse } from "../cloudutils";
-import path from "node:path";
+import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import { Application } from "./types";
 
 export async function getAppInfo(host: string, json: boolean): Promise<number> {
@@ -8,11 +7,8 @@ export async function getAppInfo(host: string, json: boolean): Promise<number> {
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
   if (!json) {

--- a/packages/dbos-cloud/applications/get-app-info.ts
+++ b/packages/dbos-cloud/applications/get-app-info.ts
@@ -8,7 +8,7 @@ export async function getAppInfo(host: string, json: boolean): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   if (!json) {

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -1,6 +1,5 @@
 import axios , { AxiosError } from "axios";
-import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse } from "../cloudutils";
-import path from "node:path";
+import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 
 export async function getAppLogs(host: string, last: number): Promise<number> {
   if (last != undefined && (isNaN(last) || last <= 0)) {
@@ -13,11 +12,8 @@ export async function getAppLogs(host: string, last: number): Promise<number> {
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
   logger.info(`Retrieving logs for application: ${appName}`)

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -16,6 +16,10 @@ export async function getAppLogs(host: string, last: number): Promise<number> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   logger.info(`Retrieving logs for application: ${appName}`)
 
   try {

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -13,7 +13,7 @@ export async function getAppLogs(host: string, last: number): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   logger.info(`Retrieving logs for application: ${appName}`)

--- a/packages/dbos-cloud/applications/list-apps.ts
+++ b/packages/dbos-cloud/applications/list-apps.ts
@@ -28,7 +28,7 @@ export async function listApps(host: string, json: boolean): Promise<number> {
       applications.forEach(app => {
         console.log(`Application Name: ${app.Name}`);
         console.log(`ID: ${app.ID}`);
-        console.log(`Postgres Instance Name: ${app.ApplicationDatabaseName}`);
+        console.log(`Postgres Instance Name: ${app.PostgresInstanceName}`);
         console.log(`Application Database Name: ${app.ApplicationDatabaseName}`);
         console.log(`Status: ${app.Status}`);
         console.log(`Version: ${app.Version}`);

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -11,6 +11,10 @@ export async function registerApp(dbname: string, host: string): Promise<number>
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
   logger.info(`Loaded application name from package.json: ${appName}`)
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   logger.info(`Registering application: ${appName}`)
 
   try {

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -7,7 +7,7 @@ export async function registerApp(dbname: string, host: string): Promise<number>
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   logger.info(`Registering application: ${appName}`)

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -1,18 +1,13 @@
 import axios, { AxiosError } from "axios";
-import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse } from "../cloudutils";
-import path from "node:path";
+import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 
 export async function registerApp(dbname: string, host: string): Promise<number> {
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  logger.info(`Loaded application name from package.json: ${appName}`)
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
   logger.info(`Registering application: ${appName}`)

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -1,19 +1,14 @@
 import axios, { AxiosError } from "axios";
-import { getCloudCredentials, getLogger, handleAPIErrors, isCloudAPIErrorResponse } from "../cloudutils";
+import { getCloudCredentials, getLogger, handleAPIErrors, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import { Application } from "./types";
-import path from "node:path";
 
 export async function updateApp(host: string): Promise<number> {
   const logger =  getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-  const appName = packageJson.name;
-  logger.info(`Loaded application name from package.json: ${appName}`)
-  if (appName === undefined) {
-    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+  const appName = retrieveApplicationName(logger);
+  if (appName == null) {
     return 1;
   }
   logger.info(`Updating application: ${appName}`)

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -8,7 +8,7 @@ export async function updateApp(host: string): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName == null) {
+  if (appName === null) {
     return 1;
   }
   logger.info(`Updating application: ${appName}`)

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -12,6 +12,10 @@ export async function updateApp(host: string): Promise<number> {
   const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
   const appName = packageJson.name;
   logger.info(`Loaded application name from package.json: ${appName}`)
+  if (appName === undefined) {
+    logger.error("Error: package.json not found. Please run this command in an application root directory.")
+    return 1;
+  }
   logger.info(`Updating application: ${appName}`)
 
   try {

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -110,7 +110,7 @@ applicationCommands
 
   applicationCommands
   .command('status')
-  .description("Retrieve this application's metadata")
+  .description("Retrieve this application's status")
   .option('--json', 'Emit JSON output')
   .action(async (options: { json: boolean }) => {
     const exitCode = await getAppInfo(DBOSCloudHost, options.json);
@@ -149,7 +149,7 @@ databaseCommands
 
 databaseCommands
   .command('status')
-  .description("Retrieve information on a Postgres database instance")
+  .description("Retrieve the status of a Postgres database instance")
   .argument('<string>', 'database instance name')
   .option('--json', 'Emit JSON output')
   .action((async (dbname: string, options: { json: boolean}) => {

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -109,7 +109,7 @@ applicationCommands
   });
 
   applicationCommands
-  .command('get')
+  .command('status')
   .description("Retrieve this application's metadata")
   .option('--json', 'Emit JSON output')
   .action(async (options: { json: boolean }) => {
@@ -148,7 +148,7 @@ databaseCommands
   }))
 
 databaseCommands
-  .command('get')
+  .command('status')
   .description("Retrieve information on a Postgres database instance")
   .argument('<string>', 'database instance name')
   .option('--json', 'Emit JSON output')

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -4,6 +4,7 @@ import { transports, createLogger, format, Logger } from "winston";
 import fs from "fs";
 import { AxiosError } from "axios";
 import jwt from 'jsonwebtoken';
+import path from "node:path";
 
 export interface DBOSCloudCredentials {
   token: string;
@@ -13,6 +14,18 @@ export interface DBOSCloudCredentials {
 export const dbosConfigFilePath = "dbos-config.yaml";
 export const DBOSCloudHost = process.env.DBOS_DOMAIN || "cloud.dbos.dev";
 export const dbosEnvPath = ".dbos";
+
+export function retrieveApplicationName(logger: Logger): string | null {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
+    const appName = packageJson.name;
+    if (appName === undefined) {
+      logger.error("Error: cannot find a valid package.json file. Please run this command in an application root directory.")
+      return null;
+    }
+    logger.info(`Loaded application name from package.json: ${appName}`)
+    return appName
+}
 
 // FIXME: we should have a global instance of the logger created in cli.ts
 export function getLogger(): Logger {

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -77,6 +77,10 @@ export function credentialsExist(): boolean {
   return fs.existsSync(`./${dbosEnvPath}/credentials`);
 }
 
+export function deleteCredentials() {
+  fs.unlinkSync(`./${dbosEnvPath}/credentials`);
+}
+
 // Run a command, streaming its output to stdout
 export function runCommand(command: string, args: string[] = []): Promise<number> {
   return new Promise((resolve, reject) => {

--- a/packages/dbos-cloud/register.ts
+++ b/packages/dbos-cloud/register.ts
@@ -26,7 +26,12 @@ export async function registerUser(username: string, host: string): Promise<numb
     }
   } else {
     const userCredentials = getCloudCredentials();
-    logger.info(`You are currently logged in as ${userCredentials.userName}.  Registering ${userCredentials.userName} with DBOS Cloud...`)
+    if (userCredentials.userName !== username) {
+      logger.error(`You are trying to register ${username}, but are currently logged in as ${userCredentials.userName}. Please run "npx dbos-cloud logout".`)
+      return 1;
+    } else {
+      logger.info(`You are currently logged in as ${userCredentials.userName}.  Registering ${userCredentials.userName} with DBOS Cloud...`)
+    }
   }
 
   const userCredentials = getCloudCredentials();


### PR DESCRIPTION
- Update Cloud CLI command names.  `dbos-cloud applications` now aliases to `application`, `app`, and `apps`.  `dbos-cloud userdb` is now `dbos-cloud database` with an alias to `databases`. 
- Consistently refer to physical database instances as "Postgres database instances" and individual databases on those instances as "application databases". Change the verbs for database instance management from "create" and "delete" to "provision" and "destroy" to reinforce this.
- Return an error if registering a user other than the logged-in user.
- Add a `logout` command.
- Return an error if running application commands outside of an application root directory.