### PR TITLE
update GitHub actions

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -28,16 +28,19 @@ jobs:
         run: npm ci
       - name: Stamp Version 
         run: npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
-      - run: npm run build
-      - run: npm publish
-        # boolean properties from NBGV step appears to be converted into *capitalized* strings
-        # so explicitly string compare PublicRelease output value
-        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm pack
+      - name: Build
+        run: npm run build --workspaces --include-workspace-root
+      # - run: npm publish
+      #   # boolean properties from NBGV step appears to be converted into *capitalized* strings
+      #   # so explicitly string compare PublicRelease output value
+      #   if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          mkdir ./out
+          npm pack --workspaces --include-workspace-root --pack-destination ./out
       - name: Upload package
         uses: actions/upload-artifact@v4.3.1
         with:
-          name: dbos-workflow
-          path: ./dbos-inc-workflow-*.tgz
+          name: packages
+          path: out/dbos-inc-*.tgz

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm publish --workspaces --include-workspace-root
         # boolean properties from NBGV step appears to be converted into *capitalized* strings
         # so explicitly string compare PublicRelease output value
-        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+        # if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload package

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -24,21 +24,25 @@ jobs:
         uses: dotnet/nbgv@v0.4.2
         with:
           setAllVars: true
-      - name: Build Packages
-        run: |
-          npm ci
-          npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
-          npm run build --workspaces --include-workspace-root
-          mkdir ./out
-          npm pack --workspaces --include-workspace-root --pack-destination ./out
+      - name: Install Dependencies
+        run: npm ci
+      - name: Stamp Packages Version
+        run: npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - run: npm publish
-      #   # boolean properties from NBGV step appears to be converted into *capitalized* strings
-      #   # so explicitly string compare PublicRelease output value
-      #   if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Packages
+        run: npm run build --workspaces --include-workspace-root
+      - name: Pack Packages
+        run: |
+          mkdir ./out
+          npm pack --workspaces --include-workspace-root --pack-destination ./out
+      - name: Publish Packages
+        run: npm publish --workspaces --include-workspace-root
+        # boolean properties from NBGV step appears to be converted into *capitalized* strings
+        # so explicitly string compare PublicRelease output value
+        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload package
         uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -36,15 +36,15 @@ jobs:
         run: |
           mkdir ./out
           npm pack --workspaces --include-workspace-root --pack-destination ./out
-      - name: Publish Packages
-        run: npm publish --workspaces --include-workspace-root
-        # boolean properties from NBGV step appears to be converted into *capitalized* strings
-        # so explicitly string compare PublicRelease output value
-        # if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload package
+      - name: Upload Packages artifact
         uses: actions/upload-artifact@v4.3.1
         with:
           name: packages
           path: out/dbos-inc-*.tgz
+      - name: Publish Packages
+        run: npm publish --workspaces --include-workspace-root
+        # boolean properties from NBGV step appears to be converted into *capitalized* strings
+        # so explicitly string compare PublicRelease output value
+        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-          registry-url: 'https://npm.pkg.github.com'
+          # registry-url: 'https://npm.pkg.github.com'
       - name: Nerdbank.GitVersioning
         id: nbgv
         uses: dotnet/nbgv@v0.4.2

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Stamp Version 
-        run: npm version -ws --no-git-tag-version "$NBGV_NpmPackageVersion"
+        run: npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
       - run: npm run build
       - run: npm publish
         # boolean properties from NBGV step appears to be converted into *capitalized* strings

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -15,13 +15,13 @@ jobs:
         with:
           fetch-depth: 0 # fetch-depth 0 needed for NBGV
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'
       - name: Nerdbank.GitVersioning
         id: nbgv
-        uses: dotnet/nbgv@v0.4.1
+        uses: dotnet/nbgv@v0.4.2
         with:
           stamp: package.json
       - run: npm ci
@@ -34,7 +34,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm pack
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: dbos-workflow
           path: ./dbos-inc-workflow-*.tgz

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -18,27 +18,27 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-          # registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://npm.pkg.github.com'
       - name: Nerdbank.GitVersioning
         id: nbgv
         uses: dotnet/nbgv@v0.4.2
         with:
           setAllVars: true
-      - name: Install Dependencies
-        run: npm ci
-      - name: Stamp Version 
-        run: npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
-      - name: Build
-        run: npm run build --workspaces --include-workspace-root
+      - name: Build Packages
+        run: |
+          npm ci
+          npm version --workspaces --include-workspace-root --no-git-tag-version "$NBGV_NpmPackageVersion"
+          npm run build --workspaces --include-workspace-root
+          mkdir ./out
+          npm pack --workspaces --include-workspace-root --pack-destination ./out
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # - run: npm publish
       #   # boolean properties from NBGV step appears to be converted into *capitalized* strings
       #   # so explicitly string compare PublicRelease output value
       #   if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
       #   env:
       #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
-          mkdir ./out
-          npm pack --workspaces --include-workspace-root --pack-destination ./out
       - name: Upload package
         uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -11,11 +11,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0 # fetch-depth 0 needed for NBGV
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -23,8 +23,11 @@ jobs:
         id: nbgv
         uses: dotnet/nbgv@v0.4.2
         with:
-          stamp: package.json
-      - run: npm ci
+          setAllVars: true
+      - name: Install Dependencies
+        run: npm ci
+      - name: Stamp Version 
+        run: npm version -ws --no-git-tag-version "$NBGV_NpmPackageVersion"
       - run: npm run build
       - run: npm publish
         # boolean properties from NBGV step appears to be converted into *capitalized* strings

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -12,8 +12,9 @@ on:
       - synchronize
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
+  # temp comment out test
+  # test:
+  #   uses: ./.github/workflows/test.yml
   artifact:
-    needs: test
+    # needs: test
     uses: ./.github/workflows/artifact.yml

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -12,9 +12,8 @@ on:
       - synchronize
 
 jobs:
-  # temp comment out test
-  # test:
-  #   uses: ./.github/workflows/test.yml
+  test:
+    uses: ./.github/workflows/test.yml
   artifact:
-    # needs: test
+    needs: test
     uses: ./.github/workflows/artifact.yml

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -17,12 +17,12 @@ jobs:
         with:
           fetch-depth: 0 # fetch-depth 0 needed for NBGV
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Nerdbank.GitVersioning
         id: nbgv
-        uses: dotnet/nbgv@v0.4.1
+        uses: dotnet/nbgv@v0.4.2
         with:
           stamp: ${{ matrix.package }}/package.json
       - run: cd ${{ matrix.package }}; npm ci

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -13,11 +13,11 @@ jobs:
         package: [., packages/dbos-cloud, packages/dbos-openapi, packages/communicator-datetime, packages/communicator-bcrypt, packages/communicator-random]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0 # fetch-depth 0 needed for NBGV
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
       - name: Nerdbank.GitVersioning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
           docker exec -i ${{ job.services.postgres.id }} apt update
           docker exec ${{ job.services.postgres.id }} sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
           docker restart ${{ job.services.postgres.id }}
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
       - name: Compile and Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
           docker exec -i ${{ job.services.postgres.id }} apt update
           docker exec ${{ job.services.postgres.id }} sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
           docker restart ${{ job.services.postgres.id }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.0
       - name: Use Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Compile and Test


### PR DESCRIPTION
* Update deprecated action versions (checkout, setup-node, nbgv)
* update artifact workflow to build/pack/publish *ALL* packages

> Note, `pack` is used to build compressed tarballs of each package and attach them as an build run artifact. `publish` pushes the built packages to DBOS's GitHub package feed