### PR TITLE
Implement sleep in Workflow Context

### DIFF
--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -222,6 +222,11 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     const functionID: number = this.functionIDGetIncrement();
     return new RetrievedHandleDebug(this.#dbosExec.systemDatabase, targetUUID, this.workflowUUID, functionID);
   }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async sleep(_: number): Promise<void> {
+    return;
+  }
 }
 
 /**

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -390,6 +390,6 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
 
 
   async sleep(workflowUUID: string, functionID: number, durationSec: number): Promise<void> {
-    await sleep(durationSec * 1000);
+    await sleep(durationSec * 1000); // TODO: Implement
   }
 }

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -7,6 +7,7 @@ import { StatusString, WorkflowStatus } from "../workflow";
 import * as fdb from "foundationdb";
 import { DuplicateWorkflowEventError, DBOSWorkflowConflictUUIDError } from "../error";
 import { NativeValue } from "foundationdb/dist/lib/native";
+import { sleep } from "../utils";
 
 interface OperationOutput<R> {
   output: R;
@@ -385,5 +386,10 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
       await this.recordOperationOutput(callerUUID, functionID, value);
     }
     return value;
+  }
+
+
+  async sleep(workflowUUID: string, functionID: number, durationSec: number): Promise<void> {
+    await sleep(durationSec * 1000);
   }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -33,6 +33,8 @@ export interface SystemDatabase {
   getWorkflowStatus(workflowUUID: string, callerUUID?: string, functionID?: number): Promise<WorkflowStatus | null>;
   getWorkflowResult<R>(workflowUUID: string): Promise<R>;
 
+  sleep(workflowUUID: string, functionID: number, duration: number): Promise<void>;
+
   send<T extends NonNullable<any>>(workflowUUID: string, functionID: number, destinationUUID: string, message: T, topic?: string): Promise<void>;
   recv<T extends NonNullable<any>>(workflowUUID: string, functionID: number, topic?: string, timeoutSeconds?: number): Promise<T | null>;
 
@@ -338,6 +340,20 @@ export class PostgresSystemDatabase implements SystemDatabase {
       } else {
         throw err;
       }
+    }
+  }
+
+  async sleep(workflowUUID: string, functionID: number, durationSec: number): Promise<void> {
+    const { rows } = await this.pool.query<operation_outputs>(`SELECT output FROM ${DBOSExecutor.systemDBSchemaName}.operation_outputs WHERE workflow_uuid=$1 AND function_id=$2`, [workflowUUID, functionID]);
+    if (rows.length > 0) {
+      const endTimeMs = JSON.parse(rows[0].output) as number;
+      await sleep(endTimeMs - Date.now())
+      return;
+    } else {
+      const endTimeMs = Date.now() + durationSec * 1000;
+      await this.pool.query(`INSERT INTO ${DBOSExecutor.systemDBSchemaName}.operation_outputs (workflow_uuid, function_id, output) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;`, [workflowUUID, functionID, JSON.stringify(endTimeMs)]);
+      await sleep(endTimeMs - Date.now())
+      return;
     }
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -347,12 +347,12 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const { rows } = await this.pool.query<operation_outputs>(`SELECT output FROM ${DBOSExecutor.systemDBSchemaName}.operation_outputs WHERE workflow_uuid=$1 AND function_id=$2`, [workflowUUID, functionID]);
     if (rows.length > 0) {
       const endTimeMs = JSON.parse(rows[0].output) as number;
-      await sleep(endTimeMs - Date.now())
+      await sleep(Math.max(endTimeMs - Date.now(), 0))
       return;
     } else {
       const endTimeMs = Date.now() + durationSec * 1000;
       await this.pool.query(`INSERT INTO ${DBOSExecutor.systemDBSchemaName}.operation_outputs (workflow_uuid, function_id, output) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;`, [workflowUUID, functionID, JSON.stringify(endTimeMs)]);
-      await sleep(endTimeMs - Date.now())
+      await sleep(Math.max(endTimeMs - Date.now(), 0))
       return;
     }
   }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -71,6 +71,8 @@ export interface WorkflowContext extends DBOSContext {
 
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
+
+  sleep(durationSec: number): Promise<void>;
 }
 
 export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowContext {
@@ -549,6 +551,17 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   retrieveWorkflow<R>(targetUUID: string): WorkflowHandle<R> {
     const functionID: number = this.functionIDGetIncrement();
     return new RetrievedHandle(this.#dbosExec.systemDatabase, targetUUID, this.workflowUUID, functionID);
+  }
+
+  /**
+   * Sleep for the duration.
+   */
+  async sleep(durationSec: number): Promise<void> {
+    if (durationSec <= 0) {
+      return;
+    }
+    const functionID = this.functionIDGetIncrement()
+    return await this.#dbosExec.systemDatabase.sleep(this.workflowUUID, functionID, durationSec);
   }
 
 }

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -111,7 +111,24 @@ describe("oaoo-tests", () => {
     static async nestedWorkflow(wfCtxt: WorkflowContext, name: string) {
       return wfCtxt.childWorkflow(WorkflowOAOO.testTxWorkflow, name).then((x) => x.getResult());
     }
+
+    @Workflow()
+    static async sleepWorkflow(wfCtxt: WorkflowContext, durationSec: number) {
+      await wfCtxt.sleep(durationSec);
+      return;
+    }
   }
+
+  test("workflow-sleep-oaoo", async () => {
+    const workflowUUID = uuidv1();
+    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(3).then((x) => x.getResult())).resolves.toBeFalsy();
+
+    // Rerunning should skip the sleep
+    const startTime = Date.now();
+    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(3).then((x) => x.getResult())).resolves.toBeFalsy();
+    const elapsedTimeMs = Date.now() - startTime;
+    expect(elapsedTimeMs).toBeLessThanOrEqual(1000);
+  });
 
   test("workflow-oaoo", async () => {
     let workflowResult: number;

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -121,13 +121,14 @@ describe("oaoo-tests", () => {
 
   test("workflow-sleep-oaoo", async () => {
     const workflowUUID = uuidv1();
-    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(3).then((x) => x.getResult())).resolves.toBeFalsy();
+    const initTime = Date.now();
+    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(2).then((x) => x.getResult())).resolves.toBeFalsy();
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(1500);
 
     // Rerunning should skip the sleep
     const startTime = Date.now();
-    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(3).then((x) => x.getResult())).resolves.toBeFalsy();
-    const elapsedTimeMs = Date.now() - startTime;
-    expect(elapsedTimeMs).toBeLessThanOrEqual(1000);
+    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(2).then((x) => x.getResult())).resolves.toBeFalsy();
+    expect(Date.now() - startTime).toBeLessThanOrEqual(1000);
   });
 
   test("workflow-oaoo", async () => {


### PR DESCRIPTION
This PR implements a `sleep(durationSec)` method in workflow context.
We guarantee OAOO sleep by recording the end time in the database during the first invocation of the sleep function, and only sleep until then. This way, we will never oversleep!