### PR TITLE
Fix Retry Interval

### DIFF
--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -121,12 +121,12 @@ describe("dbos-tests", () => {
   test("readonly-recording", async () => {
     const workflowUUID = uuidv1();
     // Invoke the workflow, should get the error.
-    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrowError(new Error("dumb test error"));
+    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrow(new Error("dumb test error"));
     expect(ReadRecording.cnt).toBe(1);
     expect(ReadRecording.wfCnt).toBe(2);
 
     // Invoke it again, should return the recorded error and re-execute the workflow function but not the transactions
-    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrowError(new Error("dumb test error"));
+    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrow(new Error("dumb test error"));
     expect(ReadRecording.cnt).toBe(1);
     expect(ReadRecording.wfCnt).toBe(4);
   });
@@ -135,7 +135,7 @@ describe("dbos-tests", () => {
     // Test the recording of transaction snapshot information in our transaction_outputs table.
     const workflowUUID = uuidv1();
     // Invoke the workflow, should get the error.
-    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrowError(new Error("dumb test error"));
+    await expect(testRuntime.invoke(ReadRecording, workflowUUID).testRecordingWorkflow(123, "test").then((x) => x.getResult())).rejects.toThrow(new Error("dumb test error"));
 
     // Check the transaction output table and make sure we record transaction information correctly.
     const readRec = await testRuntime.queryUserDB<transaction_outputs>("SELECT txn_id, txn_snapshot FROM dbos.transaction_outputs WHERE workflow_uuid = $1 AND function_id = $2", workflowUUID, 0);

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -57,8 +57,8 @@ describe("foundationdb-dbos", () => {
     await expect(testRuntime.invoke(FdbTestClass).testErrorCommunicator()).resolves.toBe("success");
 
     const workflowUUID: string = uuidv1();
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrowError(new DBOSError("Communicator reached maximum retries.", 1));
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrowError(new DBOSError("Communicator reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Communicator reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Communicator reached maximum retries.", 1));
   });
 
   test("fdb-workflow-status", async () => {

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -87,7 +87,7 @@ describe("httpserver-defsec-tests", () => {
     expect(res).toBe("hello 1");
 
     // Unauthorized.
-    await expect(testRuntime.invoke(TestEndpointDefSec).testTranscation("alice")).rejects.toThrowError(
+    await expect(testRuntime.invoke(TestEndpointDefSec).testTranscation("alice")).rejects.toThrow(
       new DBOSNotAuthorizedError("User does not have a role with permission to call testTranscation", 403)
     );
   });


### PR DESCRIPTION
This PR fixes:
- Communicators are not sleeping long enough. Sleep method takes in milliseconds but we pass in seconds. Fixed the test so we can make sure communicators are getting enough sleep!
- Cap the maximum retry interval for both communicators (1 hour) and transactions (2 seconds). So our exponential backoff will not explode to infinity.
- Replace the deprecated `toThrowError` with the new recommended `toThrow` in our tests.