### PR TITLE
split the dbos_greetings table from dbos_hello

### DIFF
--- a/examples/hello/migrations/20240212161006_create_dbos_hello_tables.js
+++ b/examples/hello/migrations/20240212161006_create_dbos_hello_tables.js
@@ -1,13 +1,18 @@
 const { Knex } = require("knex");
 
 exports.up = async function(knex) {
-  return knex.schema.createTable('dbos_hello', table => {
+  await knex.schema.createTable('dbos_hello', table => {
     table.text('name').primary();
-    table.text('greeting_note_content');
     table.integer('greet_count').defaultTo(0);
+  });
+
+  return knex.schema.createTable('dbos_greetings', table => {
+    table.text('greeting_name');
+    table.text('greeting_note_content');
   });
 };
 
 exports.down = async function(knex) {
+  await knex.schema.dropTable('dbos_greetings');
   return knex.schema.dropTable('dbos_hello');
 };


### PR DESCRIPTION
Add a new `dbos_greetings` table for the programming quickstart. This table does not have a primary key to enhance beginner experience.
![Screenshot 2024-02-25 at 10 48 04](https://github.com/dbos-inc/dbos-ts/assets/3437048/e7836148-fb9e-4b98-8512-7ac87a92075c)
![Screenshot 2024-02-25 at 10 47 36](https://github.com/dbos-inc/dbos-ts/assets/3437048/a935b257-7a19-457e-96c6-db83070f97b8)
