### PR TITLE
No Zip Deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8598,6 +8598,7 @@
       "dependencies": {
         "axios": "^1.6.5",
         "commander": "^11.0.0",
+        "fast-glob": "^3.3.2",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",
         "jwks-rsa": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3138,6 +3138,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -4560,6 +4565,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4791,6 +4801,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5522,6 +5537,44 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -5870,6 +5923,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/liftup": {
@@ -6533,6 +6594,11 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7022,6 +7088,11 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7404,6 +7475,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8523,6 +8599,7 @@
         "axios": "^1.6.5",
         "commander": "^11.0.0",
         "jsonwebtoken": "^9.0.2",
+        "jszip": "^3.10.1",
         "jwks-rsa": "^3.1.0",
         "winston": "^3.11.0",
         "winston-transport": "^4.6.0"

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -11,7 +11,7 @@ type DeployOutput = {
   ApplicationVersion: string;
 }
 
-async function createZipBuffer(): Promise<Buffer | null> {
+async function createZipData(): Promise<string> {
     const zip = new JSZip();
     // Add the interpolated config file at package root
     const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
@@ -27,7 +27,7 @@ async function createZipBuffer(): Promise<Buffer | null> {
 
     // Generate ZIP file as a Buffer
     const buffer = await zip.generateAsync({ type: 'nodebuffer' });
-    return buffer;
+    return buffer.toString('base64');
 }
 
 
@@ -48,7 +48,7 @@ export async function deployAppCode(host: string): Promise<number> {
   }
 
   try {
-    const zipData = createZipBuffer();
+    const zipData = createZipData();
 
     // Submit the deploy request
     logger.info(`Submitting deploy request for ${appName}`)

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -17,7 +17,7 @@ async function createZipData(): Promise<string> {
     const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
     zip.file('', interpolatedConfig, { binary: true });
 
-    const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['dbos_deploy/**', 'node_modules/**', 'dist/**'] });
+    const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['**/node_modules/**', '**/dist/**'] });
 
     files.forEach(file => {
         const relativePath = file.replace(`${process.cwd()}/`, '');

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from "axios";
-import { existsSync } from 'fs';
-import { handleAPIErrors, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
+import { existsSync, readFileSync } from 'fs';
+import { handleAPIErrors, dbosConfigFilePath, getCloudCredentials, getLogger, checkReadFile, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 import JSZip from "jszip";
@@ -117,7 +117,7 @@ export async function deployAppCode(host: string): Promise<number> {
 }
 
 function readInterpolatedConfig(configFilePath: string): string {
-  const configFileContent = readFileSync(configFilePath) as string;
+  const configFileContent = checkReadFile(configFilePath) as string;
   const regex = /\${([^}]+)}/g;  // Regex to match ${VAR_NAME} style placeholders
   return configFileContent.replace(regex, (_, g1: string) => {
     return process.env[g1] || "";  // If the env variable is not set, return an empty string.

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from "axios";
 import { existsSync } from 'fs';
-import { handleAPIErrors, createDirectory, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
+import { handleAPIErrors, dbosConfigFilePath, getCloudCredentials, getLogger, readFileSync, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 import JSZip from "jszip";

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -13,9 +13,6 @@ type DeployOutput = {
 
 async function createZipData(): Promise<string> {
     const zip = new JSZip();
-    // Add the interpolated config file at package root
-    const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
-    zip.file('', interpolatedConfig, { binary: true });
 
     const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['**/node_modules/**', '**/dist/**'] });
 
@@ -24,6 +21,10 @@ async function createZipData(): Promise<string> {
         const fileData = readFileSync(file);
         zip.file(relativePath, fileData, { binary: true });
     });
+
+    // Add the interpolated config file at package root
+    const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
+    zip.file('', interpolatedConfig, { binary: true });
 
     // Generate ZIP file as a Buffer
     const buffer = await zip.generateAsync({ type: 'nodebuffer' });

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -24,7 +24,7 @@ async function createZipData(): Promise<string> {
 
     // Add the interpolated config file at package root
     const interpolatedConfig = readInterpolatedConfig(dbosConfigFilePath)
-    zip.file('', interpolatedConfig, { binary: true });
+    zip.file(dbosConfigFilePath, interpolatedConfig, { binary: true });
 
     // Generate ZIP file as a Buffer
     const buffer = await zip.generateAsync({ type: 'nodebuffer' });

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from "axios";
 import { existsSync, readFileSync } from 'fs';
-import { handleAPIErrors, dbosConfigFilePath, getCloudCredentials, getLogger, checkReadFile, sleep, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
+import { handleAPIErrors, dbosConfigFilePath, getCloudCredentials, getLogger, checkReadFile, sleep, isCloudAPIErrorResponse, retrieveApplicationName, dbosEnvPath } from "../cloudutils";
 import path from "path";
 import { Application } from "./types";
 import JSZip from "jszip";
@@ -14,7 +14,7 @@ type DeployOutput = {
 async function createZipData(): Promise<string> {
     const zip = new JSZip();
 
-    const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['**/node_modules/**', '**/dist/**', `**/${dbosConfigFilePath}`] });
+    const files = await fg(`${process.cwd()}/**/*`, { dot: true, onlyFiles: true, ignore: [`**/${dbosEnvPath}/**`, '**/node_modules/**', '**/dist/**', `**/${dbosConfigFilePath}`] });
 
     files.forEach(file => {
         const relativePath = file.replace(`${process.cwd()}/`, '');

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -14,7 +14,7 @@ type DeployOutput = {
 async function createZipData(): Promise<string> {
     const zip = new JSZip();
 
-    const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['**/node_modules/**', '**/dist/**'] });
+    const files = await fg(`${process.cwd()}/**/*`, { dot: false, onlyFiles: true, ignore: ['**/node_modules/**', '**/dist/**', `**/${dbosConfigFilePath}`] });
 
     files.forEach(file => {
         const relativePath = file.replace(`${process.cwd()}/`, '');

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -48,7 +48,7 @@ export async function deployAppCode(host: string): Promise<number> {
   }
 
   try {
-    const zipData = createZipData();
+    const zipData = await createZipData();
 
     // Submit the deploy request
     logger.info(`Submitting deploy request for ${appName}`)

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -122,7 +122,7 @@ export function runCommand(command: string, args: string[] = []): Promise<number
   });
 }
 
-export function readFileSync(path: string, encoding: BufferEncoding = "utf8"): string | Buffer {
+export function checkReadFile(path: string, encoding: BufferEncoding = "utf8"): string | Buffer {
   // First, check the file
   fs.stat(path, (error: NodeJS.ErrnoException | null, stats: fs.Stats) => {
     if (error) {

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -82,7 +82,7 @@ export function getCloudCredentials(): DBOSCloudCredentials {
     token: userCredentials.token.replace(/\r|\n/g, ""), // Trim the trailing /r /n.
   };
   if (isTokenExpired(credentials.token)) {
-    logger.error("Error: Login expired. Please log in again with 'npx dbos-cloud login -u <username>'")
+    logger.error("Error: Login expired. Please log in again with 'npx dbos-cloud login'")
     process.exit(1)
   }
   return credentials

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -28,6 +28,7 @@
     "axios": "^1.6.5",
     "commander": "^11.0.0",
     "jsonwebtoken": "^9.0.2",
+    "jszip": "^3.10.1",
     "jwks-rsa": "^3.1.0",
     "winston": "^3.11.0",
     "winston-transport": "^4.6.0"

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "axios": "^1.6.5",
     "commander": "^11.0.0",
+    "fast-glob": "^3.3.2",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "jwks-rsa": "^3.1.0",


### PR DESCRIPTION
Zip the deploy package locally using native JS libraries instead of using `execSync("zip...")`.  Eliminates the zip dependency and makes behavior more predictable.