### PR TITLE
Better error handling for debug mode CLI

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -609,7 +609,8 @@ export class DBOSExecutor {
     if (nameArr[1] === TempWorkflowType.transaction) {
       const txnInfo: TransactionInfo | undefined = this.transactionInfoMap.get(nameArr[2]);
       if (!txnInfo) {
-        throw new DBOSError(`Cannot find transaction info for UUID ${workflowUUID}, name ${wfName}`);
+        this.logger.error(`Cannot find transaction info for UUID ${workflowUUID}, name ${nameArr[2]}`);
+        throw new DBOSNotRegisteredError(nameArr[2]);
       }
       temp_workflow = async (ctxt: WorkflowContext, ...args: any[]) => {
         const ctxtImpl = ctxt as WorkflowContextImpl;
@@ -619,7 +620,8 @@ export class DBOSExecutor {
     } else if (nameArr[1] === TempWorkflowType.external) {
       const commInfo: CommunicatorInfo | undefined = this.communicatorInfoMap.get(nameArr[2]);
       if (!commInfo) {
-        throw new DBOSError(`Cannot find transaction info for UUID ${workflowUUID}, name ${wfName}`);
+        this.logger.error(`Cannot find communicator info for UUID ${workflowUUID}, name ${nameArr[2]}`);
+        throw new DBOSNotRegisteredError(nameArr[2]);
       }
       temp_workflow = async (ctxt: WorkflowContext, ...args: any[]) => {
         const ctxtImpl = ctxt as WorkflowContextImpl;
@@ -632,7 +634,8 @@ export class DBOSExecutor {
         return await ctxt.send<any>(args[0], args[1], args[2]);
       };
     } else {
-      throw new DBOSError(`Unrecognized temporary workflow! UUID ${workflowUUID}, name ${wfName}`);
+      this.logger.error(`Unrecognized temporary workflow! UUID ${workflowUUID}, name ${wfName}`)
+      throw new DBOSNotRegisteredError(wfName);
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return this.workflow(temp_workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined }, ...inputs);

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -52,7 +52,7 @@ program
   .command('debug')
   .description('Debug a workflow')
   .option('-x, --proxy <string>', 'Specify the time-travel debug proxy URL', 'postgresql://localhost:2345')
-  .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to debug')
+  .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to replay')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
   .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -48,7 +48,7 @@ program
 program
   .command('debug')
   .description('Debug a workflow')
-  .requiredOption('-x, --proxy <string>', 'Specify the debugger proxy URL')
+  .option('-x, --proxy <string>', 'Specify the debugger proxy URL', 'postgresql://localhost:2345')
   .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to debug')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -57,7 +57,7 @@ program
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
   .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
   .action(async (options: DBOSDebugOptions) => {
-    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
+    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, true);
     await debugWorkflow(dbosConfig, runtimeConfig, options.proxy, options.uuid);
   });
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -23,9 +23,12 @@ export interface DBOSCLIStartOptions {
   entrypoint?: string,
 }
 
-interface DBOSDebugOptions extends DBOSCLIStartOptions {
+interface DBOSDebugOptions {
   proxy: string, // TODO: in the future, we provide the proxy URL
   uuid: string, // Workflow UUID
+  loglevel?: string,
+  configfile?: string,
+  entrypoint?: string,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -48,7 +51,7 @@ program
 program
   .command('debug')
   .description('Debug a workflow')
-  .option('-x, --proxy <string>', 'Specify the debugger proxy URL', 'postgresql://localhost:2345')
+  .option('-x, --proxy <string>', 'Specify the time-travel debug proxy URL', 'postgresql://localhost:2345')
   .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to debug')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -64,7 +64,7 @@ export function loadConfigFile(configFilePath: string): ConfigFile | undefined {
  * Parse `dbosConfigFilePath` and return DBOSConfig and DBOSRuntimeConfig
  * Considers DBOSCLIStartOptions if provided, which takes precedence over config file
  * */
-export function parseConfigFile(cliOptions?: DBOSCLIStartOptions): [DBOSConfig, DBOSRuntimeConfig] {
+export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
   const configFilePath = cliOptions?.configfile ?? dbosConfigFilePath;
   const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {
@@ -94,7 +94,11 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions): [DBOSConfig, 
   }
 
   if (!poolConfig.password) {
-    throw new DBOSInitializationError(`DBOS configuration ${configFilePath} does not contain database password`);
+    if (debugMode) {
+      poolConfig.password = "DEBUG-MODE"; // Assign a password if not set. We don't need password to authenticate with the local proxy.
+    } else {
+      throw new DBOSInitializationError(`DBOS configuration ${configFilePath} does not contain database password`);
+    }
   }
 
   if (configFile.database.ssl_ca) {

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,5 +1,5 @@
 import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
-import { DBOSError, DBOSFailLoadOperationsError, DBOSInitializationError, DBOSNotRegisteredError } from "../error";
+import { DBOSFailLoadOperationsError, DBOSInitializationError, DBOSNotRegisteredError } from "../error";
 import { GlobalLogger } from "../telemetry/logs";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,5 +1,5 @@
 import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
-import { DBOSError, DBOSFailLoadOperationsError } from "../error";
+import { DBOSError, DBOSFailLoadOperationsError, DBOSInitializationError, DBOSNotRegisteredError } from "../error";
 import { GlobalLogger } from "../telemetry/logs";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
@@ -31,7 +31,11 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
         }
       }
     } else if (e instanceof DBOSFailLoadOperationsError) {
-      console.error('\x1b[31m%s\x1b[0m', "Did you correctly compile this application? Hint: run `npm run build` and try again");
+      console.error('\x1b[31m%s\x1b[0m', "Did you compile this application? Hint: run `npm run build` and try again");
+    } else if (e instanceof DBOSNotRegisteredError) {
+      console.error('\x1b[31m%s\x1b[0m', "Did you modify this application? Hint: make sure the above function exists in your application, then run `npm run build` to re-compile and try again");
+    } else if (e instanceof DBOSInitializationError) {
+      console.error('\x1b[31m%s\x1b[0m', "Please check your configuration file and try again");
     }
     process.exit(1);
   }

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,20 +1,36 @@
 import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
+import { GlobalLogger } from "../telemetry/logs";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
 export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSRuntimeConfig, proxy: string, workflowUUID: string) {
-  const provDB = `${dbosConfig.poolConfig.database}_prov`;
-  dbosConfig = {...dbosConfig, debugProxy: proxy, system_database: provDB };
-  dbosConfig.poolConfig.database = provDB;
+  dbosConfig = {...dbosConfig, debugProxy: proxy};
+  const logger = new GlobalLogger();
+  try {
+    // Load classes
+    const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);
+    const dbosExec = new DBOSExecutor(dbosConfig);
+    await dbosExec.init(...classes);
 
-  // Load classes
-  const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoint);
-  const dbosExec = new DBOSExecutor(dbosConfig);
-  await dbosExec.init(...classes);
+    // Invoke the workflow in debug mode.
+    const handle = await dbosExec.executeWorkflowUUID(workflowUUID);
+    await handle.getResult();
 
-  // Invoke the workflow in debug mode.
-  const handle = await dbosExec.executeWorkflowUUID(workflowUUID);
-  await handle.getResult();
-
-  // Destroy testing runtime.
-  await dbosExec.destroy();
+    // Destroy testing runtime.
+    await dbosExec.destroy();
+  } catch (e) {
+    const errorLabel = `Debug mode failed`;
+    logger.error(`${errorLabel}: ${(e as Error).message}`);
+    if (e instanceof AggregateError) {
+      console.error(e.errors);
+      for (const err of e.errors) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (err.code && err.code === "ECONNREFUSED") {
+          console.error('\x1b[31m%s\x1b[0m', `Is DBOS time-travel debug proxy running at ${proxy} ?`);
+          break;
+        }
+      }
+    }
+    process.exit(1);
+  }
+  return;
 }

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -1,4 +1,5 @@
 import { DBOSConfig, DBOSExecutor } from "../dbos-executor";
+import { DBOSError, DBOSFailLoadOperationsError } from "../error";
 import { GlobalLogger } from "../telemetry/logs";
 import { DBOSRuntime, DBOSRuntimeConfig,  } from "./runtime";
 
@@ -18,7 +19,7 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
     // Destroy testing runtime.
     await dbosExec.destroy();
   } catch (e) {
-    const errorLabel = `Debug mode failed`;
+    const errorLabel = `Debug mode error`;
     logger.error(`${errorLabel}: ${(e as Error).message}`);
     if (e instanceof AggregateError) {
       console.error(e.errors);
@@ -29,6 +30,8 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
           break;
         }
       }
+    } else if (e instanceof DBOSFailLoadOperationsError) {
+      console.error('\x1b[31m%s\x1b[0m', "Did you correctly compile this application? Hint: run `npm run build` and try again");
     }
     process.exit(1);
   }

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -44,7 +44,7 @@ export class DBOSRuntime {
     } catch (error) {
       this.dbosExec?.logger.error(error);
       if (error instanceof DBOSFailLoadOperationsError) {
-        console.error('\x1b[31m%s\x1b[0m', "Did you correctly compile this application? Hint: run `npm run build` and try again");
+        console.error('\x1b[31m%s\x1b[0m', "Did you compile this application? Hint: run `npm run build` and try again");
         process.exit(1);
       }
       await this.destroy(); //wrap up, i.e. flush log contents to OpenTelemetry exporters

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -2,7 +2,7 @@ import { DBOSExecutor, DBOSConfig } from '../dbos-executor';
 import { DBOSHttpServer } from '../httpServer/server';
 import * as fs from 'fs';
 import { isObject } from 'lodash';
-import { DBOSError } from '../error';
+import { DBOSFailLoadOperationsError } from '../error';
 import path from 'node:path';
 import { Server } from 'http';
 
@@ -35,7 +35,7 @@ export class DBOSRuntime {
       this.dbosExec = new DBOSExecutor(this.dbosConfig);
       const classes = await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoint);
       if (classes.length === 0) {
-        throw new DBOSError("operations not found");
+        throw new DBOSFailLoadOperationsError("operations not found");
       }
       await this.dbosExec.init(...classes);    
       const server = new DBOSHttpServer(this.dbosExec)
@@ -43,6 +43,10 @@ export class DBOSRuntime {
       this.dbosExec.logRegisteredHTTPUrls();
     } catch (error) {
       this.dbosExec?.logger.error(error);
+      if (error instanceof DBOSFailLoadOperationsError) {
+        console.error('\x1b[31m%s\x1b[0m', "Did you correctly compile this application? Hint: run `npm run build` and try again");
+        process.exit(1);
+      }
       await this.destroy(); //wrap up, i.e. flush log contents to OpenTelemetry exporters
       throw error;
     }
@@ -61,7 +65,7 @@ export class DBOSRuntime {
       /* eslint-disable-next-line @typescript-eslint/no-var-requires */
       exports = (await import(operations)) as Promise<ModuleExports>;
     } else {
-      throw new DBOSError(`Failed to load operations from the entrypoint ${entrypoint}`);
+      throw new DBOSFailLoadOperationsError(`Failed to load operations from the entrypoint ${entrypoint}`);
     }
     const classes: object[] = [];
     for (const key in exports) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -167,3 +167,10 @@ export class DBOSNonExistentWorkflowError extends DBOSError {
     super(msg, NonExistentWorkflowError);
   }
 }
+
+const FailLoadOperationsError = 17;
+export class DBOSFailLoadOperationsError extends DBOSError {
+  constructor(msg: string) {
+    super(msg, FailLoadOperationsError);
+  }
+}


### PR DESCRIPTION
This PR fixes the uncaught errors from the debug mode CLI, and also improves the user experience:
- `proxy` is no longer a required option. By default we run the proxy at `localhost:2345`. The only required argument is a workflow UUID.
- Capture errors from debug mode and print them out. Especially, if we get an `ECONNREFUSED` error, we prompt a hint `Is DBOS time-travel debug proxy running at ${proxy}`
- No longer need to set the database name in debug mode because the proxy is only connected to one database.
- Provide better error messages for uncompiled apps or for unrecognized operations in debug mode/runtime, adding hints for developers.
- Also bypass database password check if in debug mode, because we don't have auth between local debug proxy.