### PR TITLE
Global App Delete/Status Commands + Timestamp Issue

### DIFF
--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -1,13 +1,13 @@
 import axios, { AxiosError } from "axios";
 import { isCloudAPIErrorResponse, handleAPIErrors, getCloudCredentials, getLogger, retrieveApplicationName } from "../cloudutils";
 
-export async function deleteApp(host: string): Promise<number> {
+export async function deleteApp(host: string, appName?: string): Promise<number> {
   const logger = getLogger()
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  const appName = retrieveApplicationName(logger);
-  if (appName === null) {
+  appName = appName ?? retrieveApplicationName(logger);
+  if (!appName) {
     return 1;
   }
   logger.info(`Deleting application: ${appName}`)

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -38,7 +38,7 @@ export async function deployAppCode(host: string): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName === null) {
+  if (!appName) {
     return 1;
   }
 

--- a/packages/dbos-cloud/applications/get-app-info.ts
+++ b/packages/dbos-cloud/applications/get-app-info.ts
@@ -2,13 +2,13 @@ import axios , { AxiosError } from "axios";
 import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName } from "../cloudutils";
 import { Application, prettyPrintApplication } from "./types";
 
-export async function getAppInfo(host: string, json: boolean): Promise<number> {
+export async function getAppInfo(host: string, json: boolean, appName?: string): Promise<number> {
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  const appName = retrieveApplicationName(logger, json);
-  if (appName === null) {
+  appName = appName ?? retrieveApplicationName(logger, json);
+  if (!appName) {
     return 1;
   }
   if (!json) {

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -13,7 +13,7 @@ export async function getAppLogs(host: string, last: number): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName === null) {
+  if (!appName) {
     return 1;
   }
   logger.info(`Retrieving logs for application: ${appName}`)

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -7,7 +7,7 @@ export async function registerApp(dbname: string, host: string): Promise<number>
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName === null) {
+  if (!appName) {
     return 1;
   }
   logger.info(`Registering application: ${appName}`)

--- a/packages/dbos-cloud/applications/update-app.ts
+++ b/packages/dbos-cloud/applications/update-app.ts
@@ -8,7 +8,7 @@ export async function updateApp(host: string): Promise<number> {
   const bearerToken = "Bearer " + userCredentials.token;
 
   const appName = retrieveApplicationName(logger);
-  if (appName === null) {
+  if (!appName) {
     return 1;
   }
   logger.info(`Updating application: ${appName}`)

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -92,8 +92,9 @@ applicationCommands
 applicationCommands
   .command('delete')
   .description('Delete this application')
-  .action(async () => {
-    const exitCode = await deleteApp(DBOSCloudHost);
+  .argument('[string]', 'application name')
+  .action(async (appName?: string) => {
+    const exitCode = await deleteApp(DBOSCloudHost, appName);
     process.exit(exitCode);
   });
 
@@ -106,12 +107,13 @@ applicationCommands
     process.exit(exitCode);
   });
 
-  applicationCommands
+applicationCommands
   .command('status')
   .description("Retrieve this application's status")
+  .argument('[string]', 'application name')
   .option('--json', 'Emit JSON output')
-  .action(async (options: { json: boolean }) => {
-    const exitCode = await getAppInfo(DBOSCloudHost, options.json);
+  .action(async (appName: string | undefined, options: { json: boolean }) => {
+    const exitCode = await getAppInfo(DBOSCloudHost, options.json, appName);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -15,18 +15,18 @@ export const dbosConfigFilePath = "dbos-config.yaml";
 export const DBOSCloudHost = process.env.DBOS_DOMAIN || "cloud.dbos.dev";
 export const dbosEnvPath = ".dbos";
 
-export function retrieveApplicationName(logger: Logger, silent: boolean = false): string | null {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
-    const appName = packageJson.name;
-    if (appName === undefined) {
-      logger.error("Error: cannot find a valid package.json file. Please run this command in an application root directory.")
-      return null;
-    }
-    if (!silent) {
-      logger.info(`Loaded application name from package.json: ${appName}`)
-    }
-    return appName
+export function retrieveApplicationName(logger: Logger, silent: boolean = false): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const packageJson = require(path.join(process.cwd(), 'package.json')) as { name: string };
+  const appName = packageJson.name;
+  if (appName === undefined) {
+    logger.error("Error: cannot find a valid package.json file. Please run this command in an application root directory.")
+    return undefined;
+  }
+  if (!silent) {
+    logger.info(`Loaded application name from package.json: ${appName}`)
+  }
+  return appName
 }
 
 // FIXME: we should have a global instance of the logger created in cli.ts

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -31,7 +31,7 @@ export class Tracer {
       const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parentSpan);
       return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }, ctx) as Span;
     } else {
-      return tracer.startSpan(name, { attributes: attributes }) as Span;
+      return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }) as Span;
     }
   }
 

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -27,11 +27,12 @@ export class Tracer {
 
   startSpan(name: string, attributes?: Attributes, parentSpan?: Span): Span {
     const tracer = opentelemetry.trace.getTracer("dbos-tracer");
+    const startTime = performance.now();
     if (parentSpan) {
       const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parentSpan);
-      return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }, ctx) as Span;
+      return tracer.startSpan(name, { startTime: startTime, attributes: attributes }, ctx) as Span;
     } else {
-      return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }) as Span;
+      return tracer.startSpan(name, { startTime: startTime, attributes: attributes }) as Span;
     }
   }
 

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -3,6 +3,7 @@ import { Resource } from "@opentelemetry/resources";
 import opentelemetry, { Attributes, SpanContext } from "@opentelemetry/api";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { TelemetryCollector } from "./collector";
+import { hrTime } from '@opentelemetry/core';
 
 export class Tracer {
   private readonly tracer: BasicTracerProvider;
@@ -27,7 +28,7 @@ export class Tracer {
 
   startSpan(name: string, attributes?: Attributes, parentSpan?: Span): Span {
     const tracer = opentelemetry.trace.getTracer("dbos-tracer");
-    const startTime = performance.now();
+    const startTime = hrTime(performance.now());
     if (parentSpan) {
       const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parentSpan);
       return tracer.startSpan(name, { startTime: startTime, attributes: attributes }, ctx) as Span;
@@ -37,7 +38,7 @@ export class Tracer {
   }
 
   endSpan(span: Span) {
-    span.end(performance.now());
+    span.end(hrTime(performance.now()));
     span.attributes.applicationID = this.applicationID;
     if ( !("executorID" in span.attributes)) {
       span.attributes.executorID = this.executorID;


### PR DESCRIPTION
This PR adds an optional application name argument to `dbos-cloud app status` and `delete` commands. This way, users can delete or view their application status outside of an app folder, making it easier to install the CLI globally and use it anywhere.

Another issue this PR fixes is the incorrect startTime in traces. We use hrTime() to avoid the incorrect adjustment from opentelemetry.