### PR TITLE
Add vscode files to template

### DIFF
--- a/examples/hello/.vscode/extensions.json
+++ b/examples/hello/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"dbos-inc.dbos-ttdbg"
+	]
+}

--- a/examples/hello/.vscode/launch.json
+++ b/examples/hello/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node-terminal",
+      "request": "launch",
+      "name": "Time Travel Debug",
+      "command": "npx dbos-sdk debug -x ${command:dbos-ttdbg.get-proxy-url} -u ${command:dbos-ttdbg.pick-workflow-id}",
+      "preLaunchTask": "npm: build"
+    }
+  ]
+}

--- a/examples/hello/.vscode/tasks.json
+++ b/examples/hello/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm: build",
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [
+        "$tsc"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds VS Code files to examples/hello so new projects are configured to use the TT Debugger extension.

[tasks.json](https://code.visualstudio.com/docs/editor/tasks) contains a single task to invoke the npm `build` script

[launch.json](https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes) contains a single debug configuration  configured to use `dbos-ttdbg.get-proxy-url` and `dbos-ttdbg.pick-workflow-id` commands and to invoke the `npm: build` task before debugging

[extensions.json](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions) prompts the user to install our extension when they open a DBOS project in VSCode 