### PR TITLE
Improve Application Hosting 

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -103,7 +103,7 @@ export async function deployAppCode(host: string): Promise<number> {
     }
     await sleep(5000); // Leave time for route cache updates
     logger.info(`Successfully deployed ${appName}!`)
-    logger.info(`Access your application at https://${host}/apps/${userCredentials.userName}/${appName}`)
+    logger.info(`Access your application at https://${userCredentials.userName}-${appName}.${host}/`)
     return 0;
   } catch (e) {
     const errorLabel = `Failed to deploy application ${appName}`;

--- a/packages/dbos-cloud/register.ts
+++ b/packages/dbos-cloud/register.ts
@@ -2,17 +2,29 @@ import axios, { AxiosError } from "axios";
 import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, credentialsExist, DBOSCloudCredentials, writeCredentials } from "./cloudutils";
 import readline from 'readline';
 import { authenticate } from "./login";
+import * as validator from 'validator';
 
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout
 });
 
+function isValidUsername(username: string): boolean {
+  if (username.length < 3 || username.length > 30) {
+    return false;
+  }
+  return validator.matches(username, "^[a-z0-9_]+$");
+}
+
 export async function registerUser(username: string, host: string): Promise<number> {
   const logger = getLogger();
   let givenName = "";
   let familyName = "";
   let company = "";
+  if (!isValidUsername(username)) {
+    logger.error("Invalid username. Usernames must be between 3 and 30 characters long and contain only lowercase letters, underscores, and numbers.")
+    return 1
+  }
   if (!credentialsExist()) {
     logger.info("Welcome to DBOS Cloud!")
     logger.info("Before creating an account, please tell us a bit about yourself!")


### PR DESCRIPTION
Applications are now hosted at `username-appname.cloud.dbos.dev` instead of `cloud.dbos.dev/apps/username/appname`.  We make this change for two reasons:

1. So relative paths are the same locally as in DBOS Cloud.
2. So users have an easier time configuring DNS for their application.

For this to work, usernames can no longer contain dashes.