### PR TITLE
CLI Fixes

### DIFF
--- a/packages/dbos-cloud/register.ts
+++ b/packages/dbos-cloud/register.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError } from "axios";
-import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, credentialsExist, DBOSCloudCredentials, writeCredentials } from "./cloudutils";
+import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, credentialsExist, DBOSCloudCredentials, writeCredentials, deleteCredentials } from "./cloudutils";
 import readline from 'readline';
 import { authenticate } from "./login";
 import * as validator from 'validator';
@@ -79,6 +79,9 @@ export async function registerUser(username: string, host: string): Promise<numb
       handleAPIErrors(errorLabel, axiosError);
     } else {
       logger.error(`${errorLabel}: ${(e as Error).message}`);
+    }
+    if (credentialsExist()) {
+      deleteCredentials();
     }
     return 1;
   }

--- a/src/dbos-runtime/init.ts
+++ b/src/dbos-runtime/init.ts
@@ -70,7 +70,7 @@ export async function init(appName: string) {
   const packageJson: { name: string } = JSON.parse(fs.readFileSync(packageJsonName, 'utf-8')) as { name: string };
   packageJson.name = appName;
   fs.writeFileSync(packageJsonName, JSON.stringify(packageJson, null, 2), 'utf-8');
-  execSync("npm i --no-fund", {cwd: appName, stdio: 'inherit'})
+  execSync("npm ci --no-fund", {cwd: appName, stdio: 'inherit'})
   execSync("npm uninstall --no-fund @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud", {cwd: appName, stdio: 'inherit'})


### PR DESCRIPTION
- Use `npm ci` instead of `npm i` in `init`.
- Delete credentials when registration fails.