### PR TITLE
Changes to support Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .dbos/
+.vscode/
+
 # Logs
 logs
 *.log

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -15,10 +15,22 @@ type DeployOutput = {
 async function createZipData(): Promise<string> {
     const zip = new JSZip();
 
-    const files = await fg(`${process.cwd()}/**/*`, { dot: true, onlyFiles: true, ignore: [`**/${dbosEnvPath}/**`, '**/node_modules/**', '**/dist/**', `**/${dbosConfigFilePath}`] });
+    const globPattern = path.join(process.cwd(), '**', '*');
+
+    const files = await fg(globPattern, {
+      dot: true,
+      onlyFiles: true,
+      ignore: [
+        path.join('**', dbosEnvPath, '**'), // Use path.join for cross-platform paths
+        '**/node_modules/**',
+        '**/dist/**',
+        path.join('**', dbosConfigFilePath)  // Use path.join for cross-platform paths
+      ]
+    });
 
     files.forEach(file => {
-        const relativePath = file.replace(`${process.cwd()}/`, '');
+        // Use path.relative and replace backslashes for zip file compatibility
+        const relativePath = path.relative(process.cwd(), file).replace(/\\/g, '/');
         const fileData = readFileSync(file);
         zip.file(relativePath, fileData, { binary: true });
     });

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -21,15 +21,14 @@ async function createZipData(): Promise<string> {
       dot: true,
       onlyFiles: true,
       ignore: [
-        path.join('**', dbosEnvPath, '**'), // Use path.join for cross-platform paths
+        `**/${dbosEnvPath}/**`,
         '**/node_modules/**',
         '**/dist/**',
-        path.join('**', dbosConfigFilePath)  // Use path.join for cross-platform paths
+        `**/${dbosConfigFilePath}`,
       ]
     });
 
     files.forEach(file => {
-        // Use path.relative and replace backslashes for zip file compatibility
         const relativePath = path.relative(process.cwd(), file).replace(/\\/g, '/');
         const fileData = readFileSync(file);
         zip.file(relativePath, fileData, { binary: true });

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -12,10 +12,16 @@ type DeployOutput = {
   ApplicationVersion: string;
 }
 
+function convertPathForGlob(p: string) {
+  if (path.sep === '\\') {
+      return p.replace(/\\/g, '/');
+  }
+  return p;
+}
 async function createZipData(): Promise<string> {
     const zip = new JSZip();
 
-    const globPattern = path.join(process.cwd(), '**', '*');
+    const globPattern = convertPathForGlob(path.join(process.cwd(), '**', '*'));
 
     const files = await fg(globPattern, {
       dot: true,
@@ -24,6 +30,7 @@ async function createZipData(): Promise<string> {
         `**/${dbosEnvPath}/**`,
         '**/node_modules/**',
         '**/dist/**',
+        '**/.git/**',
         `**/${dbosConfigFilePath}`,
       ]
     });

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -1,4 +1,3 @@
-import { execSync, spawn, StdioOptions } from 'child_process';
 import { transports, createLogger, format, Logger } from "winston";
 import fs from "fs";
 import { AxiosError } from "axios";
@@ -95,29 +94,8 @@ export function deleteCredentials() {
 }
 
 export function writeCredentials(credentials: DBOSCloudCredentials) {
-  execSync(`mkdir -p ${dbosEnvPath}`);
-  fs.writeFileSync(`${dbosEnvPath}/credentials`, JSON.stringify(credentials), "utf-8");
-}
-
-// Run a command, streaming its output to stdout
-export function runCommand(command: string, args: string[] = []): Promise<number> {
-  return new Promise((resolve, reject) => {
-      const stdio: StdioOptions = 'inherit';
-
-      const process = spawn(command, args, { stdio });
-
-      process.on('close', (code) => {
-          if (code === 0) {
-              resolve(code);
-          } else {
-              reject(new Error(`Command "${command}" exited with code ${code}`));
-          }
-      });
-
-      process.on('error', (error) => {
-          reject(error);
-      });
-  });
+  fs.mkdirSync(dbosEnvPath, { recursive: true });
+  fs.writeFileSync(path.join(dbosEnvPath, 'credentials'), JSON.stringify(credentials), "utf-8");
 }
 
 export function checkReadFile(path: string, encoding: BufferEncoding = "utf8"): string | Buffer {


### PR DESCRIPTION
Use node calls instead of shell commands.
Use libraries to build paths in a portable manner.