### PR TITLE
Update SSL Configuration

### DIFF
--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -117,7 +117,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
   /* Handle user database config */
   /*******************************/
 
-  const poolConfig = constructPoolConfig(configFile)
+  const poolConfig = constructPoolConfig(configFile, debugMode)
 
   /***************************/
   /* Handle telemetry config */

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -90,7 +90,7 @@ export function constructPoolConfig(configFile: ConfigFile, debugMode: boolean =
   if (configFile.database.ssl_ca) {
     // If an SSL certificate is provided, connect to Postgres using TLS and verify the server certificate. (equivalent to verify-full)
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  } else if (poolConfig.host != "localhost") {
+  } else if (poolConfig.host != "localhost" && poolConfig.host != "127.0.0.1") {
     // Otherwise, connect to Postgres using TLS but do not verify the server certificate. (equivalent to require)
     poolConfig.ssl = { rejectUnauthorized: false }
   } else {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -105,9 +105,12 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
   if (configFile.database.ssl_ca) {
     // If an SSL certificate is provided, connect to Postgres using TLS and verify the server certificate. (equivalent to verify-full)
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  } else {
+  } else if (poolConfig.host != "localhost") {
     // Otherwise, connect to Postgres using TLS but do not verify the server certificate. (equivalent to require)
     poolConfig.ssl = { rejectUnauthorized: false }
+  } else {
+    // For local development only, do not use TLS (to support Dockerized Postgres, which does not support SSL connections)
+    poolConfig.ssl = false
   }
 
   /***************************/

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -101,8 +101,13 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
     }
   }
 
+  // Details on Postgres SSL/TLS modes: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
   if (configFile.database.ssl_ca) {
+    // If an SSL certificate is provided, connect to Postgres using TLS and verify the server certificate. (equivalent to verify-full)
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
+  } else {
+    // Otherwise, connect to Postgres using TLS but do not verify the server certificate. (equivalent to require)
+    poolConfig.ssl = { rejectUnauthorized: false }
   }
 
   /***************************/

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { GlobalLogger } from "../telemetry/logs";
-import { ConfigFile } from "./config";
+import { ConfigFile, constructPoolConfig } from "./config";
 import { readFileSync } from "../utils";
 import { PoolConfig, Client } from "pg";
 import { createUserDBSchema, userDBIndex, userDBSchema } from "../../schemas/user_db_schema";
@@ -15,17 +15,8 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
   logger.info(`Starting migration: creating database ${userDBName} if it does not exist`);
 
   if (!(await checkDatabaseExists(configFile, logger))) {
-    const postgresConfig: PoolConfig = {
-      host: configFile.database.hostname,
-      port: configFile.database.port,
-      user: configFile.database.username,
-      password: configFile.database.password,
-      connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
-      database: "postgres",
-    };
-    if (configFile.database.ssl_ca) {
-      postgresConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-    }
+    const postgresConfig: PoolConfig = constructPoolConfig(configFile)
+    postgresConfig.database = "postgres"
     const postgresClient = new Client(postgresConfig);
     try {
       await postgresClient.connect()
@@ -89,17 +80,7 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
 }
 
 export async function checkDatabaseExists(configFile: ConfigFile, logger: GlobalLogger) {
-  const pgUserConfig: PoolConfig = {
-    host: configFile.database.hostname,
-    port: configFile.database.port,
-    user: configFile.database.username,
-    password: configFile.database.password,
-    connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
-    database: configFile.database.app_db_name,
-  };
-  if (configFile.database.ssl_ca) {
-    pgUserConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  }
+  const pgUserConfig: PoolConfig = constructPoolConfig(configFile)
   const pgUserClient = new Client(pgUserConfig);
 
   try {
@@ -142,18 +123,7 @@ export async function rollbackMigration(configFile: ConfigFile, logger: GlobalLo
 async function createDBOSTables(configFile: ConfigFile) {
   const logger = new GlobalLogger();
 
-  const userPoolConfig: PoolConfig = {
-    host: configFile.database.hostname,
-    port: configFile.database.port,
-    user: configFile.database.username,
-    password: configFile.database.password,
-    connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
-    database: configFile.database.app_db_name,
-  };
-
-  if (configFile.database.ssl_ca) {
-    userPoolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  }
+  const userPoolConfig: PoolConfig = constructPoolConfig(configFile)
 
   const systemPoolConfig = { ...userPoolConfig };
   systemPoolConfig.database = `${userPoolConfig.database}_dbos_sys`;

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -1,7 +1,6 @@
 import { execSync } from "child_process";
 import { GlobalLogger } from "../telemetry/logs";
 import { ConfigFile, constructPoolConfig } from "./config";
-import { readFileSync } from "../utils";
 import { PoolConfig, Client } from "pg";
 import { createUserDBSchema, userDBIndex, userDBSchema } from "../../schemas/user_db_schema";
 import { ExistenceCheck, migrateSystemDatabase } from "../system_database";


### PR DESCRIPTION
This PR streamlines the use of SSL for database connections.  For more details on Postgres SSL modes, see: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION

- If an SSL certificate  is provided, connect to Postgres using SSL/TLS and verify the server certificate.
- If an SSL certificate is not provided, connect to Postgres using SSL/TLS.
- If an SSL certificate is not provided and the database hostname is `localhost`, do not use SSL/TLS. This is to support Dockerized Postgres, which does not support SSL connectinos.