### PR TITLE
Windows Quickstart

### DIFF
--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -5,11 +5,19 @@ This is a [DBOS app](https://docs.dbos.dev/) bootstrapped with `npx @dbos-inc/db
 ## Getting Started
 
 Before you can launch your app, you need a database.
-DBOS works with any Postgres database, but to make things easier, we've provided a script that starts a Docker Postgres container and creates a database:
+DBOS works with any Postgres database, but to make things easier, we've provided a script that starts a Docker Postgres container and creates a database.
+On Linux or Mac, run:
 
 ```bash
 export PGPASSWORD=dbos
 ./start_postgres_docker.sh
+```
+
+On Windows (CMD), run:
+
+```cmd
+set PGPASSWORD=dbos
+start_postgres_docker.bat
 ```
 
 If successful, the script should print `Database started successfully!`.

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -13,7 +13,7 @@ export PGPASSWORD=dbos
 ./start_postgres_docker.sh
 ```
 
-On Windows (CMD), run:
+On Windows (cmd), run:
 
 ```cmd
 set PGPASSWORD=dbos

--- a/examples/hello/start_postgres_docker.bat
+++ b/examples/hello/start_postgres_docker.bat
@@ -21,3 +21,5 @@ for /l %%i in (1,1,30) do (
   timeout /t 1 /nobreak
 )
 :break
+
+echo Database started successfully!

--- a/examples/hello/start_postgres_docker.bat
+++ b/examples/hello/start_postgres_docker.bat
@@ -22,4 +22,4 @@ for /l %%i in (1,1,30) do (
 )
 :break
 
-echo Database started successfully!
+echo Database started successfully^^!

--- a/examples/hello/start_postgres_docker.bat
+++ b/examples/hello/start_postgres_docker.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal EnableDelayedExpansion
 
 rem Check if PGPASSWORD is set
 if "%PGPASSWORD%"=="" (
@@ -16,7 +16,7 @@ for /l %%i in (1,1,30) do (
   docker exec dbos-db psql -U postgres -c "SELECT 1;" >NUL 2>&1
   if !errorlevel! == 0 (
     echo PostgreSQL started!
-    goto :break
+    goto break
   )
   timeout /t 1 /nobreak
 )

--- a/examples/hello/start_postgres_docker.bat
+++ b/examples/hello/start_postgres_docker.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal
+
+rem Check if PGPASSWORD is set
+if "%PGPASSWORD%"=="" (
+  echo Error: PGPASSWORD is not set.
+  exit /b 1
+)
+
+rem Start Postgres in a local Docker container
+docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD=%PGPASSWORD% --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:16.1
+
+rem Wait for PostgreSQL to start
+echo Waiting for PostgreSQL to start...
+for /l %%i in (1,1,30) do (
+  docker exec dbos-db psql -U postgres -c "SELECT 1;" >NUL 2>&1
+  if !errorlevel! == 0 (
+    echo PostgreSQL started!
+    goto :break
+  )
+  timeout /t 1 /nobreak
+)
+:break

--- a/examples/hello/start_postgres_docker.bat
+++ b/examples/hello/start_postgres_docker.bat
@@ -1,25 +1,36 @@
 @echo off
-setlocal EnableDelayedExpansion
 
-rem Check if PGPASSWORD is set
+setlocal ENABLEEXTENSIONS
+
+echo Checking if PGPASSWORD is set.
 if "%PGPASSWORD%"=="" (
   echo Error: PGPASSWORD is not set.
   exit /b 1
 )
 
-rem Start Postgres in a local Docker container
+echo Starting PostgreSQL in a local Docker container
 docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD=%PGPASSWORD% --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:16.1
 
-rem Wait for PostgreSQL to start
+	if %errorlevel% == 125 (
+		echo Error: Check if the Docker container already exists
+		exit /b 1
+		) else (
+		goto :start
+		)
+
+:start
 echo Waiting for PostgreSQL to start...
 for /l %%i in (1,1,30) do (
   docker exec dbos-db psql -U postgres -c "SELECT 1;" >NUL 2>&1
-  if !errorlevel! == 0 (
+
+if %errorlevel% equ 0 (
+(
     echo PostgreSQL started!
-    goto break
+    goto :break
   )
   timeout /t 1 /nobreak
 )
+  )
 :break
 
-echo Database started successfully^^!
+echo Database started successfully^!

--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -19,8 +19,3 @@ for i in {1..30}; do
   fi
   sleep 1
 done
-
-# Create a database in Postgres.
-docker exec dbos-db psql -U postgres -c "CREATE DATABASE hello;"
-
-echo "Database started successfully!"

--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -19,3 +19,5 @@ for i in {1..30}; do
   fi
   sleep 1
 done
+
+echo "Database started successfully!"


### PR DESCRIPTION
Create a `.bat` version of the script starting a local Postgres docker, allowing a Windows user to run the entire quickstart natively without WSL.