### PR TITLE
Windows Fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     # Service container for Postgres
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     # Service container for Postgres
     services:

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -5,6 +5,7 @@ import { isObject } from 'lodash';
 import { DBOSFailLoadOperationsError } from '../error';
 import path from 'node:path';
 import { Server } from 'http';
+import { pathToFileURL } from 'url';
 
 interface ModuleExports {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,7 +38,7 @@ export class DBOSRuntime {
       if (classes.length === 0) {
         throw new DBOSFailLoadOperationsError("operations not found");
       }
-      await this.dbosExec.init(...classes);    
+      await this.dbosExec.init(...classes);
       const server = new DBOSHttpServer(this.dbosExec)
       this.servers = await server.listen(this.runtimeConfig.port);
       this.dbosExec.logRegisteredHTTPUrls();
@@ -62,8 +63,8 @@ export class DBOSRuntime {
     const operations = path.isAbsolute(entrypoint) ? entrypoint : path.join(process.cwd(), entrypoint);
     let exports: ModuleExports;
     if (fs.existsSync(operations)) {
-      /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-      exports = (await import(operations)) as Promise<ModuleExports>;
+      const operationsURL = pathToFileURL(operations).href
+      exports = (await import(operationsURL)) as Promise<ModuleExports>;
     } else {
       throw new DBOSFailLoadOperationsError(`Failed to load operations from the entrypoint ${entrypoint}`);
     }

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -63,7 +63,7 @@ export class DBOSRuntime {
     const operations = path.isAbsolute(entrypoint) ? entrypoint : path.join(process.cwd(), entrypoint);
     let exports: ModuleExports;
     if (fs.existsSync(operations)) {
-      const operationsURL = pathToFileURL(operations).href
+      const operationsURL = pathToFileURL(operations).href;
       exports = (await import(operationsURL)) as Promise<ModuleExports>;
     } else {
       throw new DBOSFailLoadOperationsError(`Failed to load operations from the entrypoint ${entrypoint}`);


### PR DESCRIPTION
In ESM, modules must be imported [as URLs](https://github.com/dbos-inc/dbos-ts/pull/352). This is enforced more strictly on Windows. Thus, we now import `operations.js` as a file URL.