### PR TITLE
Custom Body Parsers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     # Service container for Postgres
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     # Service container for Postgres
     services:

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -39,12 +39,14 @@ export interface DBOSHttpAuthReturn {
 
 // Class-level decorators
 export interface MiddlewareDefaults extends RegistrationDefaults {
-  koaMiddlewares?: Koa.Middleware[];
   authMiddleware?: DBOSHttpAuthMiddleware;
+  koaBodyParser?: Koa.Middleware;
+  koaMiddlewares?: Koa.Middleware[];
 }
 
 export class MiddlewareClassRegistration<CT extends { new(...args: unknown[]): object }> extends ClassRegistration<CT> implements MiddlewareDefaults {
   authMiddleware?: DBOSHttpAuthMiddleware;
+  koaBodyParser?: Koa.Middleware;
   koaMiddlewares?: Koa.Middleware[];
 
   constructor(ctor: CT) {
@@ -66,6 +68,17 @@ export function Authentication(authMiddleware: DBOSHttpAuthMiddleware) {
   function clsdec<T extends { new(...args: unknown[]): object }>(ctor: T) {
     const clsreg = getOrCreateClassRegistration(ctor) as MiddlewareClassRegistration<T>;
     clsreg.authMiddleware = authMiddleware;
+  }
+  return clsdec;
+}
+
+/**
+ * Define a Koa body parser applied before any middleware. If not set, the default @koa/bodyparser is used.
+ */
+export function KoaBodyParser(koaBodyParser: Koa.Middleware) {
+  function clsdec<T extends { new(...args: unknown[]): object }>(ctor: T) {
+    const clsreg = getOrCreateClassRegistration(ctor) as MiddlewareClassRegistration<T>;
+    clsreg.koaBodyParser = koaBodyParser;
   }
   return clsdec;
 }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -46,7 +46,6 @@ export class DBOSHttpServer {
     this.adminRouter = new Router();
     this.logger = dbosExec.logger;
     this.app = new Koa();
-    this.app.use(bodyParser());
     this.app.use(cors());
     this.adminApp = new Koa();
     this.adminApp.use(bodyParser());
@@ -168,8 +167,14 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
     dbosExec.registeredOperations.forEach((registeredOperation) => {
       const ro = registeredOperation as HandlerRegistration<unknown, unknown[], unknown>;
       if (ro.apiURL) {
-        // Check if we need to apply any Koa middleware.
         const defaults = ro.defaults as MiddlewareDefaults;
+        // Check if we need to apply a custom body parser
+        if (defaults.koaBodyParser) {
+          router.use(ro.apiURL, defaults.koaBodyParser)
+        } else {
+          router.use(ro.apiURL, bodyParser())
+        }
+        // Check if we need to apply any Koa middleware.
         if (defaults?.koaMiddlewares) {
           defaults.koaMiddlewares.forEach((koaMiddleware) => {
             dbosExec.logger.debug(`DBOS Server applying middleware ${koaMiddleware.name} to ${ro.apiURL}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export {
 
   // Middleware Decorators
   Authentication,
+  KoaBodyParser,
   KoaMiddleware,
 
   // OpenApi Decorators

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -78,9 +78,11 @@ describe("httpserver-tests", () => {
   });
 
   test("post-test-custom-body", async () => {
-    const response = await request(testRuntime.getHandlersCallback()).post("/testpost").set('Content-Type', 'application/custom-content-type').send(JSON.stringify({ name: "alice" }));
+    let response = await request(testRuntime.getHandlersCallback()).post("/testpost").set('Content-Type', 'application/custom-content-type').send(JSON.stringify({ name: "alice" }));
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe("hello alice");
+    response = await request(testRuntime.getHandlersCallback()).post("/testpost").set('Content-Type', 'application/rejected-custom-content-type').send(JSON.stringify({ name: "alice" }));
+    expect(response.statusCode).toBe(400);
   });
 
   test("endpoint-transaction", async () => {

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -18,13 +18,14 @@ import { TestKvTable, generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers
 import request from "supertest";
 import { ArgSource, HandlerContext } from "../../src/httpServer/handler";
 import { ArgSources } from "../../src/httpServer/handlerTypes";
-import { Authentication } from "../../src/httpServer/middleware";
+import { Authentication, KoaBodyParser } from "../../src/httpServer/middleware";
 import { v1 as uuidv1, validate as uuidValidate } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";
 import { DBOSNotAuthorizedError, DBOSResponseError } from "../../src/error";
 import { PoolClient } from "pg";
 import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
 import { IncomingMessage } from "http";
+import { bodyParser } from "@koa/bodyparser";
 
 describe("httpserver-tests", () => {
   const testTableName = "dbos_test_kv";
@@ -72,6 +73,12 @@ describe("httpserver-tests", () => {
 
   test("post-test", async () => {
     const response = await request(testRuntime.getHandlersCallback()).post("/testpost").send({ name: "alice" });
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("hello alice");
+  });
+
+  test("post-test-custom-body", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).post("/testpost").set('Content-Type', 'application/custom-content-type').send(JSON.stringify({ name: "alice" }));
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe("hello alice");
   });
@@ -212,6 +219,12 @@ describe("httpserver-tests", () => {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @Authentication(testAuthMiddlware)
+  @KoaBodyParser(bodyParser({
+    extendTypes: {
+      json: ["application/json", "application/custom-content-type"],
+    },
+    encoding: "utf-8"
+  }))
   class TestEndpoints {
     // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/hello")


### PR DESCRIPTION
PR adding support for custom body parsers through the `@KoaBodyParser` class decorator. If set, this overrides the default body parser for all endpoints in its class. 

Example:

```javascript
  @KoaBodyParser(bodyParser({
    extendTypes: {
      json: ["application/json", "application/custom-content-type"],
    },
    encoding: "utf-8"
  }))
  class TestEndpoints {
...
}
```

Addresses issue https://github.com/dbos-inc/dbos-ts/issues/350