### PR TITLE
Fix transaction/communicator endSpan

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -359,7 +359,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
       } catch (err) {
         if (this.#dbosExec.userDatabase.isRetriableTransactionError(err)) {
           // serialization_failure in PostgreSQL
-          span.addEvent("TXN SERIALIZATION FAILURE", { retryWaitMillis });
+          span.addEvent("TXN SERIALIZATION FAILURE", { "retryWaitMillis": retryWaitMillis }, performance.now());
           // Retry serialization failures.
           await sleep(retryWaitMillis);
           retryWaitMillis *= backoffFactor;


### PR DESCRIPTION
This PR fixes an issue where `endSpan` is called multiple times incorrectly when a transaction/communicator retries.

Instead, we call `addEvent` to mark the retry event in the function context's trace span.