### PR TITLE
Fixes to Create

### DIFF
--- a/examples/hello/package-lock.json
+++ b/examples/hello/package-lock.json
@@ -59,6 +59,7 @@
         "yaml": "2.4.1"
       },
       "bin": {
+        "dbos": "dist/src/dbos-runtime/cli.js",
         "dbos-sdk": "dist/src/dbos-runtime/cli.js"
       },
       "devDependencies": {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testRegex: '((\\.|/)(test|spec))\\.ts?$',
-  testPathIgnorePatterns: ['examples/*'],
+  testPathIgnorePatterns: ['examples/*', 'packages/*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   modulePaths: ["./"],
   collectCoverageFrom: [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test-fdb": "npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && npm run build-fdb && jest --runInBand --coverage"
   },
   "bin": {
+    "dbos": "./dist/src/dbos-runtime/cli.js",
     "dbos-sdk": "./dist/src/dbos-runtime/cli.js"
   },
   "devDependencies": {

--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -10,3 +10,9 @@ tsconfig.json
 
 # ignore any packed packages in the repo
 *.tgz
+
+# Include the templates code, but not node_modules or dist
+!templates/**
+templates/hello/.dbos
+templates/hello/dist
+templates/hello/node_modules

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -74,8 +74,8 @@ export async function init(appName: string, templateName: string) {
   const packageJson: { name: string } = JSON.parse(fs.readFileSync(packageJsonName, 'utf-8')) as { name: string };
   packageJson.name = appName;
   fs.writeFileSync(packageJsonName, JSON.stringify(packageJson, null, 2), 'utf-8');
-  execSync("npm ci --no-fund", {cwd: appName, stdio: 'inherit'})
   execSync("npm uninstall --no-fund @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
+  execSync("npm ci --no-fund", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
   console.log("Application initialized successfully!")

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -74,9 +74,8 @@ export async function init(appName: string, templateName: string) {
   const packageJson: { name: string } = JSON.parse(fs.readFileSync(packageJsonName, 'utf-8')) as { name: string };
   packageJson.name = appName;
   fs.writeFileSync(packageJsonName, JSON.stringify(packageJson, null, 2), 'utf-8');
-  execSync("npm uninstall --no-fund @dbos-inc/dbos-sdk", {cwd: appName, stdio: 'inherit'})
-  execSync("npm ci --no-fund", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest", {cwd: appName, stdio: 'inherit'})
+  execSync("npm ci --no-fund", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
   console.log("Application initialized successfully!")
 }


### PR DESCRIPTION
- Fix an issue where `create` would fail if `../../../..` wasn't in the filesystem (for example, if running from `/tmp`).
- Set `.npmignore` for create so all template files are included (`tsconfig.json` was excluded before)
- Alias the `dbos-sdk` command to `dbos`.