### PR TITLE
use knex user db client in chaos test

### DIFF
--- a/chaos-tests/workflows.test.ts
+++ b/chaos-tests/workflows.test.ts
@@ -13,6 +13,7 @@ describe('chaos-tests', () => {
   beforeAll(() => {
     config = {
       name: 'test-app',
+      userDatabaseClient: 'knex',
       databaseUrl: `postgresql://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?sslmode=disable`,
     };
     DBOS.setConfig(config);


### PR DESCRIPTION
there appears to be an issue with a pooled pg-node user db throwing when the underlying db goes away. The config PR (#1008) changed the default from knex to pg-node, which caused the chaos test to fail. This PR changes the chaos test back to using knex. I also filed #1017 to track the `PGNodeUserDatabase` issue