### PR TITLE
Fix retry step span context propagation

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -781,9 +781,11 @@ export class DBOSExecutor {
           await this.systemDatabase.checkIfCanceled(wfid);
 
           let cresult: R | undefined;
-          await runInStepContext(lctx, funcID, maxAttempts, attemptNum, async () => {
-            const sf = stepFn as unknown as (...args: T) => Promise<R>;
-            cresult = await sf.call(clsInst, ...args);
+          await runWithTrace(span, async () => {
+            await runInStepContext(lctx, funcID, maxAttempts, attemptNum, async () => {
+              const sf = stepFn as unknown as (...args: T) => Promise<R>;
+              cresult = await sf.call(clsInst, ...args);
+            });
           });
           result = cresult!;
         } catch (error) {


### PR DESCRIPTION
Context
Steps with retriesAllowed, do not properly run steps with otel context. This leads to children spans being attached to the step's parent instead of the step itself.

Description of the fix/feature:
- Retries now run inside their step span so downstream instrumentation (Langfuse, OpenTelemetry) attaches to the correct parent instead of the workflow span.

Brief description of implementation:
- Reused the existing step span and wrapped each retry attempt with `runWithTrace(span, ...)` around `runInStepContext(...)`.

Description of how you tested the fix:
- I ran the change locally inside my app. Before this change, child spans were siblings of step spans. After this change, they were correctly nested under the step's span.
