### PR TITLE
Don't Check Partitions for Non-Partitioned Queues 

### DIFF
--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2147,9 +2147,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     // Build partition key filter
     let partitionFilter = '';
     const partitionParams: string[] = [];
-    if (queuePartitionKey === undefined) {
-      partitionFilter = 'AND queue_partition_key IS NULL';
-    } else {
+    if (queuePartitionKey !== undefined) {
       partitionFilter = `AND queue_partition_key = $PARTITION`;
       partitionParams.push(queuePartitionKey);
     }


### PR DESCRIPTION
This fixes an issue where a workflow is stuck when moved from a partitioned queue to the non-partitioned internal queue (for example when resuming a workflow).