### PR TITLE
Improve MAX_RECOVERY_ATTEMPTS Semantics

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -29,6 +29,7 @@ import {
   DBOSNotRegisteredError,
   DBOSAwaitedWorkflowCancelledError,
   DBOSConflictingRegistrationError,
+  DBOSAwaitedWorkflowExceededMaxRecoveryAttempts,
 } from './error';
 import {
   getDbosConfig,
@@ -584,6 +585,9 @@ export class DBOS {
         if (!rres) return null;
         if (rres?.cancelled) {
           throw new DBOSAwaitedWorkflowCancelledError(workflowID);
+        }
+        if (rres?.maxRecoveryAttemptsExceeded) {
+          throw new DBOSAwaitedWorkflowExceededMaxRecoveryAttempts(workflowID);
         }
         return DBOSExecutor.reviveResultOrError<T>(rres, DBOS.#executor.serializer);
       },

--- a/src/error.ts
+++ b/src/error.ts
@@ -159,10 +159,10 @@ export class DBOSUnexpectedStepError extends DBOSError {
   }
 }
 
-const TargetWorkFlowCancelled = 27;
+const TargetWorkflowCancelled = 27;
 export class DBOSAwaitedWorkflowCancelledError extends DBOSError {
   constructor(readonly workflowID: string) {
-    super(`Awaited ${workflowID} was cancelled`, TargetWorkFlowCancelled);
+    super(`Awaited ${workflowID} was cancelled`, TargetWorkflowCancelled);
   }
 }
 
@@ -190,6 +190,13 @@ export class DBOSInvalidQueuePriorityError extends DBOSError {
     readonly max: number,
   ) {
     super(`Invalid priority ${priority}. Priority must be between ${min} and ${max}.`, InvalidQueuePriority);
+  }
+}
+
+const AwaitedWorkflowExceededMaxRecoveryAttempts = 30;
+export class DBOSAwaitedWorkflowExceededMaxRecoveryAttempts extends DBOSError {
+  constructor(readonly workflowID: string) {
+    super(`Awaited ${workflowID} exceeded its maximum recovery attempts`, AwaitedWorkflowExceededMaxRecoveryAttempts);
   }
 }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -36,6 +36,7 @@ export interface SystemDatabaseStoredResult {
   output?: string | null;
   error?: string | null;
   cancelled?: boolean;
+  maxRecoveryAttemptsExceeded?: boolean;
   childWorkflowID?: string | null;
   functionName?: string;
 }
@@ -2152,6 +2153,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
               return { error: rows[0].error };
             } else if (status === StatusString.CANCELLED) {
               return { cancelled: true };
+            } else if (status === StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED) {
+              return { maxRecoveryAttemptsExceeded: true };
             } else {
               // Status is not actionable
             }


### PR DESCRIPTION
Fix an issue where the MAX_RECOVERY_ATTEMPTS_EXCEEDED was not recognized as terminal by getResult.