### PR TITLE
Add concurrent recovery test case that after 50 or so iterations will crash

### DIFF
--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -316,10 +316,114 @@ describe('recovery-tests', () => {
       await rm(barrierPath, { force: true });
     }
   }, 30000);
+
+  /** Dual recovery with overlapping starter; tune via DBOS_REPRO_MINIMAL_* / DBOS_TEST_* env (default 1 iter for CI). */
+  test(
+    'repro-minimal-dual-local-recovery-with-conflicting-recv',
+    async () => {
+      const iterations = Math.max(1, parseInt(process.env.DBOS_REPRO_MINIMAL_ITERATIONS ?? '1', 10) || 1);
+      const disableBarrier = (process.env.DBOS_REPRO_MINIMAL_DISABLE_BARRIER ?? 'true') === 'true';
+      const workerScript = './tests/recoveryMinimalDualRecoveryWorker.ts';
+      const payload = 'minimal-ping';
+      const timeoutSeconds = 30;
+      const childEnv = {
+        ...process.env,
+        DBOS_TEST_START_WORKER_PREEXIT_GRACE_MS: String(
+          parseInt(process.env.DBOS_TEST_START_WORKER_PREEXIT_GRACE_MS ?? '600', 10) || 600,
+        ),
+        DBOS_TEST_MINIMAL_BEFORE_RECV_MS: String(
+          parseInt(process.env.DBOS_TEST_MINIMAL_BEFORE_RECV_MS ?? '150', 10) || 150,
+        ),
+        DBOS__APPVERSION: globalParams.appVersion,
+      };
+      const worker2JitterMs = parseInt(process.env.DBOS_REPRO_MINIMAL_WORKER2_JITTER_MS ?? '800', 10) || 800;
+      type WorkerOut = { code: number | null; stdout: string; stderr: string };
+      const dump = (label: string, w: WorkerOut) =>
+        console.error(
+          `[minimal dual repro] ${label} exit=${w.code}\n--- stdout ---\n${w.stdout}\n--- stderr ---\n${w.stderr}`,
+        );
+
+      for (let iter = 0; iter < iterations; iter++) {
+        const workflowID = randomUUID();
+        const topic = `minimal-dual-topic-${randomUUID()}`;
+        const barrierPath = path.join(os.tmpdir(), `dbos-minimal-dual-${randomUUID()}`);
+        console.log(
+          `[minimal dual repro] ${iter + 1}/${iterations} start workflowID=${workflowID} t=${new Date().toISOString()}`,
+        );
+        if (disableBarrier) await writeFile(barrierPath, 'go');
+
+        const startW = spawnRecvWorker(
+          ['start', workflowID, topic, `${timeoutSeconds}`],
+          { ...childEnv, DBOS__VMID: 'local' },
+          workerScript,
+        );
+        await startW.waitFor('STARTED');
+        const startDone = startW.done;
+
+        const r1 = spawnRecvWorker(
+          ['recover', workflowID, topic, `${timeoutSeconds}`, barrierPath],
+          { ...childEnv, DBOS__VMID: 'test-minimal-recover-1' },
+          workerScript,
+        );
+        const jitter = Math.floor(Math.random() * (worker2JitterMs + 1));
+        if (jitter > 0) await sleepms(jitter);
+        const r2 = spawnRecvWorker(
+          ['recover', workflowID, topic, `${timeoutSeconds}`, barrierPath],
+          { ...childEnv, DBOS__VMID: 'test-minimal-recover-2' },
+          workerScript,
+        );
+
+        let w1: WorkerOut | undefined;
+        let w2: WorkerOut | undefined;
+        try {
+          await Promise.all([r1.waitFor('PREPARED'), r2.waitFor('PREPARED')]);
+          if (!disableBarrier) await writeFile(barrierPath, 'go');
+          await Promise.all([r1.waitFor('RECOVERED:'), r2.waitFor('RECOVERED:')]);
+          await DBOS.send(workflowID, payload, topic);
+          [w1, w2] = await Promise.all([r1.done, r2.done]);
+          if (w1.code !== 0 || w2.code !== 0) {
+            if (w1.code !== 0) dump('recover-1', w1);
+            if (w2.code !== 0) dump('recover-2', w2);
+          }
+          expect(w1.code).toBe(0);
+          expect(w2.code).toBe(0);
+          await expect(DBOS.retrieveWorkflow<string>(workflowID).getResult()).resolves.toBe(payload);
+          const steps = (await DBOS.listWorkflowSteps(workflowID)) ?? [];
+          expect(steps.some((s) => s.name === 'cleanupOne')).toBe(false);
+          expect(steps.some((s) => s.name === 'cleanupTwo')).toBe(false);
+          const recvSteps = steps.filter((s) => s.name === 'DBOS.recv');
+          expect(recvSteps).toHaveLength(1);
+          expect(recvSteps[0].output).toBe(payload);
+          expect((await startDone).code).toBe(0);
+          console.log(`[minimal dual repro] ${iter + 1}/${iterations} ok workflowID=${workflowID}`);
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error(`[minimal dual repro] FAIL iter ${iter + 1}/${iterations} workflowID=${workflowID}`);
+          console.error(e.stack ?? e.message);
+          if (e.cause instanceof Error) console.error('[cause]', e.cause.stack ?? e.cause.message);
+          if (w1 !== undefined) dump('recover-1@fail', w1);
+          if (w2 !== undefined) dump('recover-2@fail', w2);
+          throw err;
+        } finally {
+          const sr = await startDone;
+          if (sr.code !== 0) {
+            console.error(`[minimal dual repro] starter exit=${sr.code} workflowID=${workflowID}`);
+            dump('starter', sr);
+          }
+          await rm(barrierPath, { force: true });
+        }
+      }
+    },
+    Math.min(900_000, Math.max(45_000, (parseInt(process.env.DBOS_REPRO_MINIMAL_ITERATIONS ?? '1', 10) || 1) * 25_000)),
+  );
 });
 
-function spawnRecvWorker(args: string[], env: NodeJS.ProcessEnv) {
-  const child = spawn('npx', ['ts-node', './tests/recoveryRecvWorker.ts', ...args], {
+function spawnRecvWorker(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  workerScript: string = './tests/recoveryRecvWorker.ts',
+) {
+  const child = spawn('npx', ['ts-node', workerScript, ...args], {
     cwd: process.cwd(),
     env,
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/recoveryMinimalDualRecoveryWorker.ts
+++ b/tests/recoveryMinimalDualRecoveryWorker.ts
@@ -1,0 +1,111 @@
+import { DBOS } from '../src';
+import { DBOSExecutor } from '../src/dbos-executor';
+import { sleepms } from '../src/utils';
+import { generateDBOSTestConfig } from './helpers';
+import { access } from 'node:fs/promises';
+
+/** Child process for `repro-minimal-dual-local-recovery-with-conflicting-recv` in `recovery.test.ts`. */
+class MinimalDualRecoveryWorker {
+  @DBOS.workflow()
+  static async workflow(topic: string, timeout: number) {
+    const beforeRecvMs = Math.max(0, parseInt(process.env.DBOS_TEST_MINIMAL_BEFORE_RECV_MS ?? '0', 10) || 0);
+
+    await DBOS.runStep(() => Promise.resolve({ phase: 'preflight' } as const), { name: 'preflight' });
+
+    try {
+      await DBOS.runStep(
+        async () => {
+          if (beforeRecvMs > 0) {
+            await sleepms(beforeRecvMs);
+          }
+          return { phase: 'beforeRecv' } as const;
+        },
+        { name: 'beforeRecv' },
+      );
+
+      const msg = (await DBOS.recv<string>(topic, timeout)) ?? 'NULL';
+      await DBOS.runStep(() => Promise.resolve({ msg }), { name: 'afterFirstRecv' });
+      return msg;
+    } catch (err) {
+      await DBOS.runStep(() => Promise.resolve({ cleanup: 1 } as const), { name: 'cleanupOne' });
+      await DBOS.runStep(() => Promise.resolve({ cleanup: 2 } as const), { name: 'cleanupTwo' });
+      throw err;
+    }
+  }
+}
+
+async function waitForBarrier(barrierPath: string) {
+  while (true) {
+    try {
+      await access(barrierPath);
+      return;
+    } catch {
+      await sleepms(25);
+    }
+  }
+}
+
+async function main() {
+  const mode = process.argv[2];
+  const workflowID = process.argv[3];
+  const topic = process.argv[4];
+  const timeout = Number(process.argv[5] ?? '5');
+
+  if (!mode || !workflowID || !topic) {
+    console.error(
+      'Usage: ts-node recoveryMinimalDualRecoveryWorker.ts <start|recover> <workflowID> <topic> <timeout> [barrierPath]',
+    );
+    process.exit(1);
+  }
+
+  DBOS.setConfig({
+    ...generateDBOSTestConfig(),
+    runAdminServer: false,
+  });
+  await DBOS.launch();
+
+  if (mode === 'start') {
+    await DBOS.startWorkflow(MinimalDualRecoveryWorker, { workflowID }).workflow(topic, timeout);
+    console.log('STARTED');
+    const preExitGrace = Math.max(0, parseInt(process.env.DBOS_TEST_START_WORKER_PREEXIT_GRACE_MS ?? '0', 10) || 0);
+    if (preExitGrace > 0) {
+      await sleepms(preExitGrace);
+    }
+    process.exit(0);
+  }
+
+  if (mode === 'recover') {
+    const barrierPath = process.argv[6];
+    if (!barrierPath) {
+      console.error('Recovery mode requires barrierPath');
+      process.exit(1);
+    }
+
+    console.log('PREPARED');
+    await waitForBarrier(barrierPath);
+
+    const recoveredHandles = await DBOSExecutor.globalInstance!.recoverPendingWorkflows(['local']);
+    console.log(`RECOVERED:${recoveredHandles.map((h) => h.workflowID).join(',')}`);
+
+    await sleepms(100);
+    console.log('READY');
+
+    const handle =
+      recoveredHandles.find((h) => h.workflowID === workflowID) ?? DBOS.retrieveWorkflow<string>(workflowID);
+    const result = await handle.getResult();
+    console.log(`RESULT:${String(result)}`);
+
+    await DBOS.shutdown();
+    process.exit(0);
+  }
+
+  console.error(`Unknown mode: ${String(mode)}`);
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds a **minimal repro** for nondeterministic failures when **two separate Node processes** both call `recoverPendingWorkflows(['local'])` on the same workflow while a **third process** (the original starter) can still be executing that workflow. The new test is intentionally **flaky under current behavior**: it defaults to **1** iteration so normal `npm test` usually passes; use **`DBOS_REPRO_MINIMAL_ITERATIONS`** to surface the race. On my machine it usually fails before 50 iterations have completed.

**New files**

- `tests/recoveryMinimalDualRecoveryWorker.ts` — child worker: small workflow (`preflight` → try { `beforeRecv` → `recv` → `afterFirstRecv` } catch { `cleanupOne` / `cleanupTwo` }) plus `start` / `recover` modes, with optional starter overlap via `DBOS_TEST_START_WORKER_PREEXIT_GRACE_MS`.

**`tests/recovery.test.ts`**

- New test: `repro-minimal-dual-local-recovery-with-conflicting-recv`.
- `spawnRecvWorker` takes an optional **worker script** argument (default remains `./tests/recoveryRecvWorker.ts` for the existing `recv-recovery-with-two-processes-on-local` test).

---

## What the test does

1. Starts the workflow in a **local** child process, which logs `STARTED` then stays alive for a **grace period** so execution can overlap recoverers.
2. Spawns **two** recoverer children (different executor IDs), both calling `recoverPendingWorkflows(['local'])` for the same workflow (barrier off by default; optional jitter before the second recoverer).
3. Sends a message so `recv` can complete.
4. Asserts both recoverers exit **0**, the workflow ends with the expected payload, a single `DBOS.recv` step, and **no** catch-path cleanup steps (`cleanupOne` / `cleanupTwo`).

---

## How to run the repro (e.g. 100 iterations)

From the repo root, with Postgres credentials set for the test DB (e.g. `DB_PASSWORD` / `PGPASSWORD` as your suite expects):

```bash
cd dbos-transact-ts

DBOS_REPRO_MINIMAL_ITERATIONS=100 \
  npx jest tests/recovery.test.ts \
  -t repro-minimal-dual \
  --runInBand