### PR TITLE
Add otelAttributeFormat config for OTel-semconv span attributes

### DIFF
--- a/packages/koa-serve/src/dboskoa.ts
+++ b/packages/koa-serve/src/dboskoa.ts
@@ -295,18 +295,20 @@ export class DBOSKoa extends DBOSHTTPBase {
             const extractedSpanContext = trace.getSpanContext(
               httpTracer.extract(ROOT_CONTEXT, koaCtxt.request.headers, defaultTextMapGetter),
             );
-            const spanAttributes = {
-              operationType: DBOSHTTPBase.HTTP_OPERATION_TYPE,
-              requestID: requestID,
-              requestIP: koaCtxt.request.ip,
-              requestURL: koaCtxt.request.url,
-              requestMethod: koaCtxt.request.method,
-            };
-            if (extractedSpanContext === undefined) {
-              span = DBOS.tracer?.startSpan(koaCtxt.url, spanAttributes) as Span;
-            } else {
-              extractedSpanContext.isRemote = true;
-              span = DBOS.tracer?.startSpanWithContext(extractedSpanContext, koaCtxt.url, spanAttributes) as Span;
+            if (DBOS.tracer) {
+              const spanAttributes = {
+                [DBOS.tracer.resolveAttributeName('operationType')]: DBOSHTTPBase.HTTP_OPERATION_TYPE,
+                [DBOS.tracer.resolveAttributeName('requestID')]: requestID,
+                [DBOS.tracer.resolveAttributeName('requestIP')]: koaCtxt.request.ip,
+                [DBOS.tracer.resolveAttributeName('requestURL')]: koaCtxt.request.url,
+                [DBOS.tracer.resolveAttributeName('requestMethod')]: koaCtxt.request.method,
+              };
+              if (extractedSpanContext === undefined) {
+                span = DBOS.tracer.startSpan(koaCtxt.url, spanAttributes) as Span;
+              } else {
+                extractedSpanContext.isRemote = true;
+                span = DBOS.tracer.startSpanWithContext(extractedSpanContext, koaCtxt.url, spanAttributes) as Span;
+              }
             }
 
             // Finally, invoke the function and properly set HTTP response.

--- a/packages/koa-serve/src/dboskoa.ts
+++ b/packages/koa-serve/src/dboskoa.ts
@@ -297,11 +297,11 @@ export class DBOSKoa extends DBOSHTTPBase {
             );
             if (DBOS.tracer) {
               const spanAttributes = {
-                [DBOS.tracer.resolveAttributeName('operationType')]: DBOSHTTPBase.HTTP_OPERATION_TYPE,
-                [DBOS.tracer.resolveAttributeName('requestID')]: requestID,
-                [DBOS.tracer.resolveAttributeName('requestIP')]: koaCtxt.request.ip,
-                [DBOS.tracer.resolveAttributeName('requestURL')]: koaCtxt.request.url,
-                [DBOS.tracer.resolveAttributeName('requestMethod')]: koaCtxt.request.method,
+                operationType: DBOSHTTPBase.HTTP_OPERATION_TYPE,
+                requestID,
+                requestIP: koaCtxt.request.ip,
+                requestURL: koaCtxt.request.url,
+                requestMethod: koaCtxt.request.method,
               };
               if (extractedSpanContext === undefined) {
                 span = DBOS.tracer.startSpan(koaCtxt.url, spanAttributes) as Span;

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,6 +197,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
         tracesEndpoint: options.otlpTracesEndpoints,
         logsEndpoint: options.otlpLogsEndpoints,
       },
+      otelAttributeFormat: options.otelAttributeFormat ?? 'legacy',
     },
     schedulerPollingIntervalMs: options.schedulerPollingIntervalMs,
     useListenNotify: options.useListenNotify ?? true,
@@ -267,6 +268,7 @@ export function overwriteConfigForDBOSCloud(
         logsEndpoint: Array.from(logsSet).filter((e) => !!e),
         tracesEndpoint: Array.from(tracesSet).filter((e) => !!e),
       },
+      otelAttributeFormat: providedDBOSConfig.telemetry.otelAttributeFormat,
     },
   };
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -139,15 +139,16 @@ export async function runTransaction<T>(
 
   const callnum = functionIDGetIncrement();
 
-  const span = DBOSExecutor.globalInstance!.tracer.startSpan(
+  const tracer = DBOSExecutor.globalInstance!.tracer;
+  const span = tracer.startSpan(
     funcName,
     {
-      operationUUID: DBOS.workflowID,
-      operationType: OperationType.TRANSACTION,
-      operationName: funcName,
-      authenticatedUser: DBOS.authenticatedUser ?? '',
-      assumedRole: DBOS.assumedRole ?? '',
-      authenticatedRoles: DBOS.authenticatedRoles ?? [],
+      [tracer.resolveAttributeName('operationUUID')]: DBOS.workflowID,
+      [tracer.resolveAttributeName('operationType')]: OperationType.TRANSACTION,
+      [tracer.resolveAttributeName('operationName')]: funcName,
+      [tracer.resolveAttributeName('authenticatedUser')]: DBOS.authenticatedUser ?? '',
+      [tracer.resolveAttributeName('assumedRole')]: DBOS.assumedRole ?? '',
+      [tracer.resolveAttributeName('authenticatedRoles')]: DBOS.authenticatedRoles ?? [],
       // isolationLevel: txnInfo.config.isolationLevel, // TODO: Pluggable
     },
     DBOS.span,
@@ -213,15 +214,16 @@ export function registerTransaction<This, Args extends unknown[], Return, Config
       );
     }
 
-    const span = DBOSExecutor.globalInstance!.tracer.startSpan(
+    const tracer = DBOSExecutor.globalInstance!.tracer;
+    const span = tracer.startSpan(
       funcName,
       {
-        operationUUID: DBOS.workflowID,
-        operationType: OperationType.TRANSACTION,
-        operationName: funcName,
-        authenticatedUser: DBOS.authenticatedUser ?? '',
-        assumedRole: DBOS.assumedRole ?? '',
-        authenticatedRoles: DBOS.authenticatedRoles ?? [],
+        [tracer.resolveAttributeName('operationUUID')]: DBOS.workflowID,
+        [tracer.resolveAttributeName('operationType')]: OperationType.TRANSACTION,
+        [tracer.resolveAttributeName('operationName')]: funcName,
+        [tracer.resolveAttributeName('authenticatedUser')]: DBOS.authenticatedUser ?? '',
+        [tracer.resolveAttributeName('assumedRole')]: DBOS.assumedRole ?? '',
+        [tracer.resolveAttributeName('authenticatedRoles')]: DBOS.authenticatedRoles ?? [],
         // isolationLevel: txnInfo.config.isolationLevel, // TODO: Pluggable
       },
       DBOS.span,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -143,12 +143,12 @@ export async function runTransaction<T>(
   const span = tracer.startSpan(
     funcName,
     {
-      [tracer.resolveAttributeName('operationUUID')]: DBOS.workflowID,
-      [tracer.resolveAttributeName('operationType')]: OperationType.TRANSACTION,
-      [tracer.resolveAttributeName('operationName')]: funcName,
-      [tracer.resolveAttributeName('authenticatedUser')]: DBOS.authenticatedUser ?? '',
-      [tracer.resolveAttributeName('assumedRole')]: DBOS.assumedRole ?? '',
-      [tracer.resolveAttributeName('authenticatedRoles')]: DBOS.authenticatedRoles ?? [],
+      operationUUID: DBOS.workflowID,
+      operationType: OperationType.TRANSACTION,
+      operationName: funcName,
+      authenticatedUser: DBOS.authenticatedUser ?? '',
+      assumedRole: DBOS.assumedRole ?? '',
+      authenticatedRoles: DBOS.authenticatedRoles ?? [],
       // isolationLevel: txnInfo.config.isolationLevel, // TODO: Pluggable
     },
     DBOS.span,
@@ -218,12 +218,12 @@ export function registerTransaction<This, Args extends unknown[], Return, Config
     const span = tracer.startSpan(
       funcName,
       {
-        [tracer.resolveAttributeName('operationUUID')]: DBOS.workflowID,
-        [tracer.resolveAttributeName('operationType')]: OperationType.TRANSACTION,
-        [tracer.resolveAttributeName('operationName')]: funcName,
-        [tracer.resolveAttributeName('authenticatedUser')]: DBOS.authenticatedUser ?? '',
-        [tracer.resolveAttributeName('assumedRole')]: DBOS.assumedRole ?? '',
-        [tracer.resolveAttributeName('authenticatedRoles')]: DBOS.authenticatedRoles ?? [],
+        operationUUID: DBOS.workflowID,
+        operationType: OperationType.TRANSACTION,
+        operationName: funcName,
+        authenticatedUser: DBOS.authenticatedUser ?? '',
+        assumedRole: DBOS.assumedRole ?? '',
+        authenticatedRoles: DBOS.authenticatedRoles ?? [],
         // isolationLevel: txnInfo.config.isolationLevel, // TODO: Pluggable
       },
       DBOS.span,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -155,7 +155,7 @@ export interface TelemetryConfig {
  *   Preserves backward compatibility with existing dashboards and the Python
  *   `dbos-transact` SDK.
  * - `'semconv'` — OpenTelemetry-style names under the `dbos.*` namespace (e.g.
- *   `dbos.operation.uuid`, `dbos.application.id`). Follows
+ *   `dbos.operation.workflow_id`, `dbos.application.id`). Follows
  *   https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/.
  */
 export type OtelAttributeFormat = 'legacy' | 'semconv';

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -439,12 +439,12 @@ export class DBOSExecutor {
 
     const span = this.tracer.startSpan(wfname, {
       status: StatusString.PENDING,
-      [this.tracer.resolveAttributeName('operationUUID')]: workflowID,
-      [this.tracer.resolveAttributeName('operationType')]: OperationType.WORKFLOW,
-      [this.tracer.resolveAttributeName('operationName')]: wInfo?.name ?? wf.name,
-      [this.tracer.resolveAttributeName('authenticatedUser')]: pctx?.authenticatedUser ?? '',
-      [this.tracer.resolveAttributeName('authenticatedRoles')]: pctx?.authenticatedRoles ?? [],
-      [this.tracer.resolveAttributeName('assumedRole')]: pctx?.assumedRole ?? '',
+      operationUUID: workflowID,
+      operationType: OperationType.WORKFLOW,
+      operationName: wInfo?.name ?? wf.name,
+      authenticatedUser: pctx?.authenticatedUser ?? '',
+      authenticatedRoles: pctx?.authenticatedRoles ?? [],
+      assumedRole: pctx?.assumedRole ?? '',
     });
 
     let serializationType = wInfo?.workflowConfig?.serialization;
@@ -777,12 +777,12 @@ export class DBOSExecutor {
     const maxRetryIntervalSec = 3600; // Maximum retry interval: 1 hour
 
     const span = this.tracer.startSpan(stepFnName, {
-      [this.tracer.resolveAttributeName('operationUUID')]: wfid,
-      [this.tracer.resolveAttributeName('operationType')]: OperationType.STEP,
-      [this.tracer.resolveAttributeName('operationName')]: stepFnName,
-      [this.tracer.resolveAttributeName('authenticatedUser')]: lctx.authenticatedUser ?? '',
-      [this.tracer.resolveAttributeName('assumedRole')]: lctx.assumedRole ?? '',
-      [this.tracer.resolveAttributeName('authenticatedRoles')]: lctx.authenticatedRoles ?? [],
+      operationUUID: wfid,
+      operationType: OperationType.STEP,
+      operationName: stepFnName,
+      authenticatedUser: lctx.authenticatedUser ?? '',
+      assumedRole: lctx.assumedRole ?? '',
+      authenticatedRoles: lctx.authenticatedRoles ?? [],
       retriesAllowed: stepConfig.retriesAllowed,
       intervalSeconds: stepConfig.intervalSeconds,
       maxAttempts: stepConfig.maxAttempts,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -108,6 +108,12 @@ export interface DBOSConfig {
   addContextMetadata?: boolean;
   otlpTracesEndpoints?: string[];
   otlpLogsEndpoints?: string[];
+  /**
+   * How DBOS span attribute names are emitted to OTLP. Defaults to `'legacy'`
+   * for backward compatibility. Set to `'semconv'` to emit OTel-style names
+   * under the `dbos.*` namespace. See {@link OtelAttributeFormat}.
+   */
+  otelAttributeFormat?: OtelAttributeFormat;
 
   adminPort?: number;
   runAdminServer?: boolean;
@@ -139,7 +145,20 @@ export interface DBOSRuntimeConfig {
 export interface TelemetryConfig {
   logs?: LoggerConfig;
   OTLPExporter?: OTLPExporterConfig;
+  otelAttributeFormat?: OtelAttributeFormat;
 }
+
+/**
+ * How DBOS span attribute names are emitted to OTLP.
+ *
+ * - `'legacy'` (default) — original DBOS names (e.g. `operationUUID`, `applicationID`).
+ *   Preserves backward compatibility with existing dashboards and the Python
+ *   `dbos-transact` SDK.
+ * - `'semconv'` — OpenTelemetry-style names under the `dbos.*` namespace (e.g.
+ *   `dbos.operation.uuid`, `dbos.application.id`). Follows
+ *   https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/.
+ */
+export type OtelAttributeFormat = 'legacy' | 'semconv';
 
 export interface OTLPExporterConfig {
   logsEndpoint?: string[];
@@ -257,7 +276,7 @@ export class DBOSExecutor {
     }
     this.logger = new GlobalLogger(this.telemetryCollector, this.config.telemetry.logs, this.appName);
     this.ctxLogger = new DBOSContextualLogger(this.logger, () => getActiveSpan());
-    this.tracer = new Tracer(this.telemetryCollector);
+    this.tracer = new Tracer(this.telemetryCollector, config.telemetry.otelAttributeFormat);
     this.serializer = config.serializer;
 
     if (systemDatabase) {
@@ -420,12 +439,12 @@ export class DBOSExecutor {
 
     const span = this.tracer.startSpan(wfname, {
       status: StatusString.PENDING,
-      operationUUID: workflowID,
-      operationType: OperationType.WORKFLOW,
-      operationName: wInfo?.name ?? wf.name,
-      authenticatedUser: pctx?.authenticatedUser ?? '',
-      authenticatedRoles: pctx?.authenticatedRoles ?? [],
-      assumedRole: pctx?.assumedRole ?? '',
+      [this.tracer.resolveAttributeName('operationUUID')]: workflowID,
+      [this.tracer.resolveAttributeName('operationType')]: OperationType.WORKFLOW,
+      [this.tracer.resolveAttributeName('operationName')]: wInfo?.name ?? wf.name,
+      [this.tracer.resolveAttributeName('authenticatedUser')]: pctx?.authenticatedUser ?? '',
+      [this.tracer.resolveAttributeName('authenticatedRoles')]: pctx?.authenticatedRoles ?? [],
+      [this.tracer.resolveAttributeName('assumedRole')]: pctx?.assumedRole ?? '',
     });
 
     let serializationType = wInfo?.workflowConfig?.serialization;
@@ -750,12 +769,12 @@ export class DBOSExecutor {
     const maxRetryIntervalSec = 3600; // Maximum retry interval: 1 hour
 
     const span = this.tracer.startSpan(stepFnName, {
-      operationUUID: wfid,
-      operationType: OperationType.STEP,
-      operationName: stepFnName,
-      authenticatedUser: lctx.authenticatedUser ?? '',
-      assumedRole: lctx.assumedRole ?? '',
-      authenticatedRoles: lctx.authenticatedRoles ?? [],
+      [this.tracer.resolveAttributeName('operationUUID')]: wfid,
+      [this.tracer.resolveAttributeName('operationType')]: OperationType.STEP,
+      [this.tracer.resolveAttributeName('operationName')]: stepFnName,
+      [this.tracer.resolveAttributeName('authenticatedUser')]: lctx.authenticatedUser ?? '',
+      [this.tracer.resolveAttributeName('assumedRole')]: lctx.assumedRole ?? '',
+      [this.tracer.resolveAttributeName('authenticatedRoles')]: lctx.authenticatedRoles ?? [],
       retriesAllowed: stepConfig.retriesAllowed,
       intervalSeconds: stepConfig.intervalSeconds,
       maxAttempts: stepConfig.maxAttempts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,6 @@ export { StepConfig } from './step';
 
 export { FunctionName, ConfiguredInstance, MethodParameter } from './decorators';
 
-export { DBOSConfig, DBOSExternalState } from './dbos-executor';
+export { DBOSConfig, DBOSExternalState, OtelAttributeFormat } from './dbos-executor';
 
 export { VersionInfo } from './system_database';

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -16,16 +16,13 @@ import type { OtelAttributeFormat } from '../dbos-executor';
 // on the same attribute schema once `otelAttributeFormat: 'semconv'` is
 // selected on both sides.
 //
-// Design note: the conversion lives in the dedicated `resolveAttributeName`
-// method below, not in `startSpan`/`startSpanWithContext`. Those entry
-// points pass attributes through verbatim. We deliberately do NOT sweep
-// every attributes dict for known legacy keys, because:
-//   1. Callers can pass arbitrary user-defined attributes that happen to
-//      collide with a DBOS legacy name; we don't want to silently rewrite
-//      those.
-//   2. The conversion should be visible at each DBOS-owned call site, not
-//      hidden in a generic helper. Reviewers can grep for
-//      `resolveAttributeName` to see every place a legacy name is touched.
+// `startSpan` / `startSpanWithContext` sweep the supplied attributes dict
+// through `resolveAttributeName`, so call sites can pass legacy DBOS keys
+// directly and have them remapped automatically when
+// `otelAttributeFormat === 'semconv'`. Keys not in this table pass through
+// unchanged. `endSpan` does the same for the few attributes it sets after
+// the span has been created. This mirrors the equivalent loop in
+// `dbos-transact-py`'s `start_span`.
 const LEGACY_TO_SEMCONV: Readonly<Record<string, string>> = {
   operationUUID: 'dbos.operation.workflow_id',
   operationType: 'dbos.operation.type',
@@ -184,16 +181,27 @@ export class Tracer {
    * the span, per `otelAttributeFormat`. Returns the original key for
    * unknown attributes.
    *
-   * Call this explicitly at every DBOS-owned call site that writes a known
-   * legacy attribute name (e.g. `operationUUID`, `requestID`). It is NOT
-   * applied automatically to attributes passed through `startSpan` — see
-   * the design note on `LEGACY_TO_SEMCONV`.
+   * Attributes passed into `startSpan` / `startSpanWithContext` are remapped
+   * automatically via this method, so call sites don't need to invoke it
+   * directly. Exposed for code paths that write attributes after span
+   * creation (e.g. `endSpan`, ad-hoc `setAttribute` calls).
    */
   resolveAttributeName(key: string): string {
     if (this.otelAttributeFormat === 'semconv') {
       return LEGACY_TO_SEMCONV[key] ?? key;
     }
     return key;
+  }
+
+  private remapAttributes(attributes?: Attributes): Attributes | undefined {
+    if (!attributes || this.otelAttributeFormat !== 'semconv') {
+      return attributes;
+    }
+    const remapped: Attributes = {};
+    for (const [k, v] of Object.entries(attributes)) {
+      remapped[LEGACY_TO_SEMCONV[k] ?? k] = v;
+    }
+    return remapped;
   }
 
   startSpanWithContext(spanContext: unknown, name: string, attributes?: Attributes): DBOSSpan {
@@ -203,7 +211,11 @@ export class Tracer {
     const opentelemetry = require('@opentelemetry/api');
     const tracer = opentelemetry.trace.getTracer('dbos-tracer');
     const ctx = opentelemetry.trace.setSpanContext(opentelemetry.context.active(), spanContext as SpanContext);
-    return tracer.startSpan(name, { startTime: performance.now(), attributes: attributes }, ctx) as Span;
+    return tracer.startSpan(
+      name,
+      { startTime: performance.now(), attributes: this.remapAttributes(attributes) },
+      ctx,
+    ) as Span;
   }
 
   startSpan(name: string, attributes?: Attributes, inputSpan?: DBOSSpan): DBOSSpan {
@@ -215,11 +227,12 @@ export class Tracer {
     const { hrTime } = require('@opentelemetry/core');
     const tracer = opentelemetry.trace.getTracer('dbos-tracer');
     const startTime = hrTime(performance.now());
+    const remapped = this.remapAttributes(attributes);
     if (parentSpan) {
       const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parentSpan);
-      return tracer.startSpan(name, { startTime: startTime, attributes: attributes }, ctx) as Span;
+      return tracer.startSpan(name, { startTime: startTime, attributes: remapped }, ctx) as Span;
     } else {
-      return tracer.startSpan(name, { startTime: startTime, attributes: attributes }) as Span;
+      return tracer.startSpan(name, { startTime: startTime, attributes: remapped }) as Span;
     }
   }
 

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -27,7 +27,7 @@ import type { OtelAttributeFormat } from '../dbos-executor';
 //      hidden in a generic helper. Reviewers can grep for
 //      `resolveAttributeName` to see every place a legacy name is touched.
 const LEGACY_TO_SEMCONV: Readonly<Record<string, string>> = {
-  operationUUID: 'dbos.operation.uuid',
+  operationUUID: 'dbos.operation.workflow_id',
   operationType: 'dbos.operation.type',
   operationName: 'dbos.operation.name',
   applicationID: 'dbos.application.id',

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -9,6 +9,39 @@ import type { SpanContext } from '@opentelemetry/api';
 import { TelemetryCollector } from './collector';
 import { globalParams } from '../utils';
 import type { BasicTracerProvider as BasicTracerProviderType } from '@opentelemetry/sdk-trace-base';
+import type { OtelAttributeFormat } from '../dbos-executor';
+
+// Legacy DBOS attribute name -> OpenTelemetry semconv-style equivalent.
+// Names align with `dbos-transact-py` (Python SDK) so the two SDKs converge
+// on the same attribute schema once `otelAttributeFormat: 'semconv'` is
+// selected on both sides.
+//
+// Design note: the conversion lives in the dedicated `resolveAttributeName`
+// method below, not in `startSpan`/`startSpanWithContext`. Those entry
+// points pass attributes through verbatim. We deliberately do NOT sweep
+// every attributes dict for known legacy keys, because:
+//   1. Callers can pass arbitrary user-defined attributes that happen to
+//      collide with a DBOS legacy name; we don't want to silently rewrite
+//      those.
+//   2. The conversion should be visible at each DBOS-owned call site, not
+//      hidden in a generic helper. Reviewers can grep for
+//      `resolveAttributeName` to see every place a legacy name is touched.
+const LEGACY_TO_SEMCONV: Readonly<Record<string, string>> = {
+  operationUUID: 'dbos.operation.uuid',
+  operationType: 'dbos.operation.type',
+  operationName: 'dbos.operation.name',
+  applicationID: 'dbos.application.id',
+  applicationVersion: 'dbos.application.version',
+  executorID: 'dbos.executor.id',
+  queueName: 'dbos.queue.name',
+  authenticatedUser: 'dbos.user.name',
+  authenticatedRoles: 'dbos.user.roles',
+  assumedRole: 'dbos.user.assumed_role',
+  requestID: 'dbos.request.id',
+  requestIP: 'dbos.request.ip',
+  requestURL: 'dbos.request.url',
+  requestMethod: 'dbos.request.method',
+};
 
 // As DBOS OTLP is optional, OTLP objects must only be dynamically imported
 // and only when OTLP is enabled. Importing OTLP types is fine as long
@@ -135,9 +168,32 @@ export function installTraceContextManager(appName: string = 'dbos'): void {
 export class Tracer {
   readonly applicationID: string;
   readonly executorID: string;
-  constructor(private readonly telemetryCollector: TelemetryCollector) {
+  private readonly otelAttributeFormat: OtelAttributeFormat;
+
+  constructor(
+    private readonly telemetryCollector: TelemetryCollector,
+    otelAttributeFormat: OtelAttributeFormat = 'legacy',
+  ) {
     this.applicationID = globalParams.appID;
     this.executorID = globalParams.executorID;
+    this.otelAttributeFormat = otelAttributeFormat;
+  }
+
+  /**
+   * Map a legacy DBOS attribute name to the name that should be emitted on
+   * the span, per `otelAttributeFormat`. Returns the original key for
+   * unknown attributes.
+   *
+   * Call this explicitly at every DBOS-owned call site that writes a known
+   * legacy attribute name (e.g. `operationUUID`, `requestID`). It is NOT
+   * applied automatically to attributes passed through `startSpan` — see
+   * the design note on `LEGACY_TO_SEMCONV`.
+   */
+  resolveAttributeName(key: string): string {
+    if (this.otelAttributeFormat === 'semconv') {
+      return LEGACY_TO_SEMCONV[key] ?? key;
+    }
+    return key;
   }
 
   startSpanWithContext(spanContext: unknown, name: string, attributes?: Attributes): DBOSSpan {
@@ -174,11 +230,12 @@ export class Tracer {
     const { hrTime } = require('@opentelemetry/core');
     const span = inputSpan as Span;
     span.setAttributes({
-      applicationID: this.applicationID,
-      applicationVersion: globalParams.appVersion,
+      [this.resolveAttributeName('applicationID')]: this.applicationID,
+      [this.resolveAttributeName('applicationVersion')]: globalParams.appVersion,
     });
-    if (span.attributes && !('executorID' in span.attributes)) {
-      span.setAttribute('executorID', this.executorID);
+    const executorIDKey = this.resolveAttributeName('executorID');
+    if (span.attributes && !(executorIDKey in span.attributes)) {
+      span.setAttribute(executorIDKey, this.executorID);
     }
     span.end(hrTime(performance.now()));
     // Only push to DBOS's own collector when DBOS manages export.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -384,6 +384,7 @@ describe('dbos-config', () => {
         sysDbPoolSize: undefined,
         systemDatabasePool: undefined,
         systemDatabaseSchemaName: 'dbos',
+        schedulerPollingIntervalMs: undefined,
         serializer: DBOSJSON,
         useListenNotify: true,
         telemetry: {
@@ -396,6 +397,7 @@ describe('dbos-config', () => {
             tracesEndpoint: undefined,
             logsEndpoint: undefined,
           },
+          otelAttributeFormat: 'legacy',
         },
       });
     });
@@ -414,6 +416,7 @@ describe('dbos-config', () => {
         sysDbPoolSize: undefined,
         systemDatabasePool: undefined,
         systemDatabaseSchemaName: 'dbos',
+        schedulerPollingIntervalMs: undefined,
         serializer: DBOSJSON,
         useListenNotify: true,
         telemetry: {
@@ -426,6 +429,7 @@ describe('dbos-config', () => {
             tracesEndpoint: undefined,
             logsEndpoint: undefined,
           },
+          otelAttributeFormat: 'legacy',
         },
       });
     });
@@ -442,6 +446,7 @@ describe('dbos-config', () => {
         sysDbPoolSize: undefined,
         systemDatabasePool: undefined,
         systemDatabaseSchemaName: 'dbos',
+        schedulerPollingIntervalMs: undefined,
         serializer: DBOSJSON,
         useListenNotify: true,
         telemetry: {
@@ -454,6 +459,7 @@ describe('dbos-config', () => {
             tracesEndpoint: undefined,
             logsEndpoint: undefined,
           },
+          otelAttributeFormat: 'legacy',
         },
       });
     });
@@ -468,6 +474,7 @@ describe('dbos-config', () => {
         sysDbPoolSize: undefined,
         systemDatabasePool: undefined,
         systemDatabaseSchemaName: 'dbos',
+        schedulerPollingIntervalMs: undefined,
         serializer: DBOSJSON,
         useListenNotify: true,
         telemetry: {
@@ -480,6 +487,7 @@ describe('dbos-config', () => {
             tracesEndpoint: undefined,
             logsEndpoint: undefined,
           },
+          otelAttributeFormat: 'legacy',
         },
       });
     });

--- a/tests/otel-attribute-format.test.ts
+++ b/tests/otel-attribute-format.test.ts
@@ -12,6 +12,47 @@ import { context, trace } from '@opentelemetry/api';
 import { DBOS } from '../src';
 import { Tracer } from '../src/telemetry/traces';
 import { TelemetryCollector } from '../src/telemetry/collector';
+import { DBOSExecutor } from '../src/dbos-executor';
+
+// Source of truth for the legacy -> semconv mapping. Duplicated from
+// `src/telemetry/traces.ts` on purpose: if the production mapping changes,
+// this test must change too, which forces the cross-SDK schema to be a
+// deliberate edit rather than an accidental drift.
+const EXPECTED_LEGACY_TO_SEMCONV: Readonly<Record<string, string>> = {
+  operationUUID: 'dbos.operation.workflow_id',
+  operationType: 'dbos.operation.type',
+  operationName: 'dbos.operation.name',
+  applicationID: 'dbos.application.id',
+  applicationVersion: 'dbos.application.version',
+  executorID: 'dbos.executor.id',
+  queueName: 'dbos.queue.name',
+  authenticatedUser: 'dbos.user.name',
+  authenticatedRoles: 'dbos.user.roles',
+  assumedRole: 'dbos.user.assumed_role',
+  requestID: 'dbos.request.id',
+  requestIP: 'dbos.request.ip',
+  requestURL: 'dbos.request.url',
+  requestMethod: 'dbos.request.method',
+};
+
+// A representative value for each legacy attribute key, used by the
+// end-to-end sweep tests below.
+const ALL_LEGACY_ATTRS = {
+  operationUUID: 'wf-id',
+  operationType: 'workflow',
+  operationName: 'test-op',
+  applicationID: 'app-id',
+  applicationVersion: 'v1',
+  executorID: 'ex-id',
+  queueName: 'my-queue',
+  authenticatedUser: 'alice',
+  authenticatedRoles: ['admin'],
+  assumedRole: 'admin',
+  requestID: 'rid-1',
+  requestIP: '1.2.3.4',
+  requestURL: '/x',
+  requestMethod: 'GET',
+};
 
 function findSpanByName(spans: readonly ReadableSpan[], name: string): ReadableSpan | undefined {
   return spans.find((s) => s.name === name);
@@ -34,25 +75,18 @@ describe('Tracer.resolveAttributeName', () => {
     await collector.destroy();
   });
 
-  test('legacy format passes legacy keys through unchanged', () => {
+  test('legacy format passes every mapped key through unchanged', () => {
     const tracer = new Tracer(collector, 'legacy');
-    expect(tracer.resolveAttributeName('operationUUID')).toBe('operationUUID');
-    expect(tracer.resolveAttributeName('applicationID')).toBe('applicationID');
-    expect(tracer.resolveAttributeName('requestMethod')).toBe('requestMethod');
+    for (const legacy of Object.keys(EXPECTED_LEGACY_TO_SEMCONV)) {
+      expect(tracer.resolveAttributeName(legacy)).toBe(legacy);
+    }
   });
 
-  test('semconv format remaps legacy keys to dbos.* names', () => {
+  test('semconv format remaps every mapped key to its dbos.* name', () => {
     const tracer = new Tracer(collector, 'semconv');
-    expect(tracer.resolveAttributeName('operationUUID')).toBe('dbos.operation.workflow_id');
-    expect(tracer.resolveAttributeName('applicationID')).toBe('dbos.application.id');
-    expect(tracer.resolveAttributeName('applicationVersion')).toBe('dbos.application.version');
-    expect(tracer.resolveAttributeName('executorID')).toBe('dbos.executor.id');
-    expect(tracer.resolveAttributeName('queueName')).toBe('dbos.queue.name');
-    expect(tracer.resolveAttributeName('authenticatedUser')).toBe('dbos.user.name');
-    expect(tracer.resolveAttributeName('authenticatedRoles')).toBe('dbos.user.roles');
-    expect(tracer.resolveAttributeName('assumedRole')).toBe('dbos.user.assumed_role');
-    expect(tracer.resolveAttributeName('requestID')).toBe('dbos.request.id');
-    expect(tracer.resolveAttributeName('requestMethod')).toBe('dbos.request.method');
+    for (const [legacy, semconv] of Object.entries(EXPECTED_LEGACY_TO_SEMCONV)) {
+      expect(tracer.resolveAttributeName(legacy)).toBe(semconv);
+    }
   });
 
   test('unknown attribute names pass through in either mode', () => {
@@ -96,6 +130,25 @@ describe('otelAttributeFormat: legacy (default)', () => {
     expect(attrs['dbos.application.version']).toBeUndefined();
     expect(attrs['dbos.executor.id']).toBeUndefined();
   });
+
+  test('startSpan emits every mapped legacy key under its original name', () => {
+    memoryExporter.reset();
+
+    const tracer = DBOSExecutor.globalInstance!.tracer;
+    const span = tracer.startSpan('all-attrs-legacy', { ...ALL_LEGACY_ATTRS });
+    tracer.endSpan(span);
+
+    const captured = findSpanByName(memoryExporter.getFinishedSpans(), 'all-attrs-legacy');
+    expect(captured).toBeDefined();
+    const attrs = captured!.attributes;
+
+    for (const legacy of Object.keys(EXPECTED_LEGACY_TO_SEMCONV)) {
+      expect(attrs[legacy]).toBeDefined();
+    }
+    for (const semconv of Object.values(EXPECTED_LEGACY_TO_SEMCONV)) {
+      expect(attrs[semconv]).toBeUndefined();
+    }
+  });
 });
 
 describe('otelAttributeFormat: semconv', () => {
@@ -136,5 +189,22 @@ describe('otelAttributeFormat: semconv', () => {
     expect(attrs.applicationID).toBeUndefined();
     expect(attrs.operationUUID).toBeUndefined();
     expect(attrs.operationType).toBeUndefined();
+  });
+
+  test('startSpan remaps every mapped legacy key to its dbos.* name', () => {
+    memoryExporter.reset();
+
+    const tracer = DBOSExecutor.globalInstance!.tracer;
+    const span = tracer.startSpan('all-attrs-semconv', { ...ALL_LEGACY_ATTRS });
+    tracer.endSpan(span);
+
+    const captured = findSpanByName(memoryExporter.getFinishedSpans(), 'all-attrs-semconv');
+    expect(captured).toBeDefined();
+    const attrs = captured!.attributes;
+
+    for (const [legacy, semconv] of Object.entries(EXPECTED_LEGACY_TO_SEMCONV)) {
+      expect(attrs[legacy]).toBeUndefined();
+      expect(attrs[semconv]).toBeDefined();
+    }
   });
 });

--- a/tests/otel-attribute-format.test.ts
+++ b/tests/otel-attribute-format.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the `otelAttributeFormat` configuration flag.
+ *
+ * When `otelAttributeFormat: 'legacy'` (the default), DBOS span attributes
+ * use their original camelCase names. When `otelAttributeFormat: 'semconv'`,
+ * they're emitted under the OTel-style `dbos.*` namespace.
+ */
+
+import { InMemorySpanExporter, ReadableSpan, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from './nodetraceprovider';
+import { context, trace } from '@opentelemetry/api';
+import { DBOS } from '../src';
+import { Tracer } from '../src/telemetry/traces';
+import { TelemetryCollector } from '../src/telemetry/collector';
+
+function findSpanByName(spans: readonly ReadableSpan[], name: string): ReadableSpan | undefined {
+  return spans.find((s) => s.name === name);
+}
+
+describe('Tracer.resolveAttributeName', () => {
+  test('legacy format passes legacy keys through unchanged', () => {
+    const tracer = new Tracer(new TelemetryCollector(), 'legacy');
+    expect(tracer.resolveAttributeName('operationUUID')).toBe('operationUUID');
+    expect(tracer.resolveAttributeName('applicationID')).toBe('applicationID');
+    expect(tracer.resolveAttributeName('requestMethod')).toBe('requestMethod');
+  });
+
+  test('semconv format remaps legacy keys to dbos.* names', () => {
+    const tracer = new Tracer(new TelemetryCollector(), 'semconv');
+    expect(tracer.resolveAttributeName('operationUUID')).toBe('dbos.operation.uuid');
+    expect(tracer.resolveAttributeName('applicationID')).toBe('dbos.application.id');
+    expect(tracer.resolveAttributeName('applicationVersion')).toBe('dbos.application.version');
+    expect(tracer.resolveAttributeName('executorID')).toBe('dbos.executor.id');
+    expect(tracer.resolveAttributeName('queueName')).toBe('dbos.queue.name');
+    expect(tracer.resolveAttributeName('authenticatedUser')).toBe('dbos.user.name');
+    expect(tracer.resolveAttributeName('authenticatedRoles')).toBe('dbos.user.roles');
+    expect(tracer.resolveAttributeName('assumedRole')).toBe('dbos.user.assumed_role');
+    expect(tracer.resolveAttributeName('requestID')).toBe('dbos.request.id');
+    expect(tracer.resolveAttributeName('requestMethod')).toBe('dbos.request.method');
+  });
+
+  test('unknown attribute names pass through in either mode', () => {
+    for (const fmt of ['legacy', 'semconv'] as const) {
+      const tracer = new Tracer(new TelemetryCollector(), fmt);
+      expect(tracer.resolveAttributeName('custom.user.attribute')).toBe('custom.user.attribute');
+      expect(tracer.resolveAttributeName('cached')).toBe('cached');
+    }
+  });
+});
+
+describe('otelAttributeFormat: legacy (default)', () => {
+  const memoryExporter = new InMemorySpanExporter();
+
+  beforeAll(async () => {
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
+    provider.register();
+    DBOS.setConfig({ name: 'attr-format-legacy', enableOTLP: true });
+    await DBOS.launch();
+  });
+
+  afterAll(async () => {
+    await DBOS.shutdown();
+    trace.disable();
+    context.disable();
+  });
+
+  test('workflow span carries legacy attribute names', async () => {
+    memoryExporter.reset();
+
+    const wf_internal = async () => Promise.resolve();
+    const wf = DBOS.registerWorkflow(wf_internal, { name: 'attr_legacy_wf' });
+    await wf();
+
+    const wfSpan = findSpanByName(memoryExporter.getFinishedSpans(), 'attr_legacy_wf');
+    expect(wfSpan).toBeDefined();
+    const attrs = wfSpan!.attributes;
+    expect(attrs.applicationVersion).toBeDefined();
+    expect(attrs.executorID).toBeDefined();
+    expect(attrs.applicationID).toBeDefined();
+    expect(attrs['dbos.application.version']).toBeUndefined();
+    expect(attrs['dbos.executor.id']).toBeUndefined();
+  });
+});
+
+describe('otelAttributeFormat: semconv', () => {
+  const memoryExporter = new InMemorySpanExporter();
+
+  beforeAll(async () => {
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
+    provider.register();
+    DBOS.setConfig({ name: 'attr-format-semconv', enableOTLP: true, otelAttributeFormat: 'semconv' });
+    await DBOS.launch();
+  });
+
+  afterAll(async () => {
+    await DBOS.shutdown();
+    trace.disable();
+    context.disable();
+  });
+
+  test('workflow span carries dbos.* names instead of legacy ones', async () => {
+    memoryExporter.reset();
+
+    const wf_internal = async () => Promise.resolve();
+    const wf = DBOS.registerWorkflow(wf_internal, { name: 'attr_semconv_wf' });
+    await wf();
+
+    const wfSpan = findSpanByName(memoryExporter.getFinishedSpans(), 'attr_semconv_wf');
+    expect(wfSpan).toBeDefined();
+    const attrs = wfSpan!.attributes;
+    // semconv names present
+    expect(attrs['dbos.application.version']).toBeDefined();
+    expect(attrs['dbos.executor.id']).toBeDefined();
+    expect(attrs['dbos.application.id']).toBeDefined();
+    expect(attrs['dbos.operation.uuid']).toBeDefined();
+    expect(attrs['dbos.operation.type']).toBe('workflow');
+    // legacy names absent
+    expect(attrs.applicationVersion).toBeUndefined();
+    expect(attrs.executorID).toBeUndefined();
+    expect(attrs.applicationID).toBeUndefined();
+    expect(attrs.operationUUID).toBeUndefined();
+    expect(attrs.operationType).toBeUndefined();
+  });
+});

--- a/tests/otel-attribute-format.test.ts
+++ b/tests/otel-attribute-format.test.ts
@@ -17,17 +17,33 @@ function findSpanByName(spans: readonly ReadableSpan[], name: string): ReadableS
   return spans.find((s) => s.name === name);
 }
 
+const wf_legacy_internal = async () => Promise.resolve();
+const attr_legacy_wf = DBOS.registerWorkflow(wf_legacy_internal, { name: 'attr_legacy_wf' });
+
+const wf_semconv_internal = async () => Promise.resolve();
+const attr_semconv_wf = DBOS.registerWorkflow(wf_semconv_internal, { name: 'attr_semconv_wf' });
+
 describe('Tracer.resolveAttributeName', () => {
+  let collector: TelemetryCollector;
+
+  beforeAll(() => {
+    collector = new TelemetryCollector();
+  });
+
+  afterAll(async () => {
+    await collector.destroy();
+  });
+
   test('legacy format passes legacy keys through unchanged', () => {
-    const tracer = new Tracer(new TelemetryCollector(), 'legacy');
+    const tracer = new Tracer(collector, 'legacy');
     expect(tracer.resolveAttributeName('operationUUID')).toBe('operationUUID');
     expect(tracer.resolveAttributeName('applicationID')).toBe('applicationID');
     expect(tracer.resolveAttributeName('requestMethod')).toBe('requestMethod');
   });
 
   test('semconv format remaps legacy keys to dbos.* names', () => {
-    const tracer = new Tracer(new TelemetryCollector(), 'semconv');
-    expect(tracer.resolveAttributeName('operationUUID')).toBe('dbos.operation.uuid');
+    const tracer = new Tracer(collector, 'semconv');
+    expect(tracer.resolveAttributeName('operationUUID')).toBe('dbos.operation.workflow_id');
     expect(tracer.resolveAttributeName('applicationID')).toBe('dbos.application.id');
     expect(tracer.resolveAttributeName('applicationVersion')).toBe('dbos.application.version');
     expect(tracer.resolveAttributeName('executorID')).toBe('dbos.executor.id');
@@ -41,7 +57,7 @@ describe('Tracer.resolveAttributeName', () => {
 
   test('unknown attribute names pass through in either mode', () => {
     for (const fmt of ['legacy', 'semconv'] as const) {
-      const tracer = new Tracer(new TelemetryCollector(), fmt);
+      const tracer = new Tracer(collector, fmt);
       expect(tracer.resolveAttributeName('custom.user.attribute')).toBe('custom.user.attribute');
       expect(tracer.resolveAttributeName('cached')).toBe('cached');
     }
@@ -69,9 +85,7 @@ describe('otelAttributeFormat: legacy (default)', () => {
   test('workflow span carries legacy attribute names', async () => {
     memoryExporter.reset();
 
-    const wf_internal = async () => Promise.resolve();
-    const wf = DBOS.registerWorkflow(wf_internal, { name: 'attr_legacy_wf' });
-    await wf();
+    await attr_legacy_wf();
 
     const wfSpan = findSpanByName(memoryExporter.getFinishedSpans(), 'attr_legacy_wf');
     expect(wfSpan).toBeDefined();
@@ -105,9 +119,7 @@ describe('otelAttributeFormat: semconv', () => {
   test('workflow span carries dbos.* names instead of legacy ones', async () => {
     memoryExporter.reset();
 
-    const wf_internal = async () => Promise.resolve();
-    const wf = DBOS.registerWorkflow(wf_internal, { name: 'attr_semconv_wf' });
-    await wf();
+    await attr_semconv_wf();
 
     const wfSpan = findSpanByName(memoryExporter.getFinishedSpans(), 'attr_semconv_wf');
     expect(wfSpan).toBeDefined();
@@ -116,7 +128,7 @@ describe('otelAttributeFormat: semconv', () => {
     expect(attrs['dbos.application.version']).toBeDefined();
     expect(attrs['dbos.executor.id']).toBeDefined();
     expect(attrs['dbos.application.id']).toBeDefined();
-    expect(attrs['dbos.operation.uuid']).toBeDefined();
+    expect(attrs['dbos.operation.workflow_id']).toBeDefined();
     expect(attrs['dbos.operation.type']).toBe('workflow');
     // legacy names absent
     expect(attrs.applicationVersion).toBeUndefined();


### PR DESCRIPTION
Parallel to [dbos-transact-py#666](https://github.com/dbos-inc/dbos-transact-py/pull/666). Both PRs together close [dbos-transact-py#665](https://github.com/dbos-inc/dbos-transact-py/issues/665).

## Description

DBOS currently emits span attributes with flat camelCase names and no vendor prefix (`operationUUID`, `applicationID`, `requestID`, …). These don't follow [OTel's attribute naming spec](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/), which calls for:

1. A vendor prefix (e.g. `dbos.*`) — without one, generic names like `requestID` and `requestMethod` collide with attributes set by other instrumentation.
2. Dot-separated namespaces (`dbos.operation.uuid`).
3. Lowercase snake_case on the final segment.

This makes it hard for downstream consumers (sampling rules, SQL commenters, log/trace filters, dashboard glob filters) to say "give me everything DBOS-related" — they have to enumerate every legacy attribute name and risk missing future ones.

## Implementation

Adds an opt-in `otelAttributeFormat` config flag to `DBOSConfig`:

```ts
DBOS.setConfig({ ..., otelAttributeFormat: 'semconv' });
```

| Value | Behavior |
|---|---|
| `'legacy'` | (default) Emit original DBOS names. No change for existing users. |
| `'semconv'` | Emit OTel-style names under the `dbos.*` namespace. |

A new `Tracer.resolveAttributeName(key)` translates legacy names through a static mapping table when `semconv` is selected. It's invoked at each DBOS-owned call site that writes a known legacy attribute name:

- `dbos-executor.ts` — workflow span and step span attribute dicts
- `datasource.ts` — transaction span attribute dicts (two call sites)
- `traces.ts` — `applicationID` / `applicationVersion` / `executorID` set in `endSpan`
- `koa-serve/dboskoa.ts` — request-handler span (`requestID`, `requestIP`, `requestURL`, `requestMethod`, `operationType`)

### Mapping

```
operationUUID       -> dbos.operation.workflow_id
operationType       -> dbos.operation.type
operationName       -> dbos.operation.name
applicationID       -> dbos.application.id
applicationVersion  -> dbos.application.version
executorID          -> dbos.executor.id
queueName           -> dbos.queue.name
authenticatedUser   -> dbos.user.name
authenticatedRoles  -> dbos.user.roles
assumedRole         -> dbos.user.assumed_role
requestID           -> dbos.request.id
requestIP           -> dbos.request.ip
requestURL          -> dbos.request.url
requestMethod       -> dbos.request.method
```

The conversion is **deliberately not swept** across attribute dicts passed into `Tracer.startSpan` / `startSpanWithContext`. Those entry points pass attributes through verbatim. The reasons (also in a code comment on `LEGACY_TO_SEMCONV`):

1. Callers can pass arbitrary user-defined attributes that might collide with a DBOS legacy name; we don't want to silently rewrite those.
2. The conversion should be visible at each DBOS-owned call site, not hidden in a generic helper. Reviewers can grep for `resolveAttributeName` to see every place a legacy name is touched.

This matches the equivalent Python PR's design.

## Cross-SDK alignment

The mapping was chosen to converge with the Python SDK so users running both Python and TypeScript services see the same `dbos.*` attribute schema once both flip to `semconv`.

The current legacy names are mostly aligned across SDKs but already drift in two places: Python's `authenticatedUserRoles` / `authenticatedUserAssumedRole` vs TS's `authenticatedRoles` / `assumedRole`. Both sides map their respective name to the same `dbos.user.roles` / `dbos.user.assumed_role`, so opting into `semconv` converges them. The aspirational `// Keys must be the same as in TypeScript Transact` comment in Python's `_context.py` could probably be updated separately.

Some TS-specific attributes (`status`, `cached`, `requiredRoles`, `retriesAllowed`) are not mapped in this PR — they don't have Python counterparts and adding them is incremental work the maintainers can do separately if desired.

## Backward compatibility

- `'legacy'` is the default, so this is fully non-breaking. Existing dashboards, alerts, and log queries continue to work unchanged.
- The flag is process-wide, so a single deploy can flip an entire service to the new names atomically.

## Migration path (suggested)

1. Now: ship `legacy` (default) + `semconv` (opt-in).
2. Future minor: encourage users to test `semconv`. Optionally add a deprecation log for `legacy`.
3. Future major (or at maintainer discretion): flip the default to `semconv`.

I deliberately did **not** add a `'both'` mode (emit both names simultaneously). Happy to add it if maintainers think it's needed for migration; left out for now to keep the surface area small.

## Testing

New file `tests/otel-attribute-format.test.ts`:

- `Tracer.resolveAttributeName` unit tests — legacy passthrough, semconv remap, unknown-attribute passthrough.
- `otelAttributeFormat: legacy` integration test — workflow span carries legacy names, no `dbos.*`.
- `otelAttributeFormat: semconv` integration test — workflow span carries `dbos.*` names, no legacy.

Tests use the existing `InMemorySpanExporter` + `NodeTracerProvider` pattern from `tests/telemetry.test.ts`.

## Notes for reviewers

- Open to feedback on naming — `otelAttributeFormat` could equally be `attributeFormat` or `attributeNaming`. I picked `otelAttributeFormat` because it makes clear that the values are about OTel-semconv compliance.
- The koa middleware change (`packages/koa-serve/src/dboskoa.ts`) wraps the span-attribute construction in `if (DBOS.tracer) { ... }`. The previous code used `DBOS.tracer?.startSpan(...) as Span` which silently produced an `undefined` span if the tracer was missing; the new structure keeps that behavior (no span gets assigned in the missing-tracer case) but no longer pretends via the cast that we have one. If you'd rather keep the original lie, happy to revert.
