### PR TITLE
feat: Expose queue duplicated error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export { WorkflowQueue } from './wfqueue';
 
 export * as Error from './error';
 
-export { DBOSWorkflowConflictError } from './error';
+export { DBOSWorkflowConflictError, DBOSQueueDuplicatedError } from './error';
 
 export {
   InputSchema,

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -1,0 +1,12 @@
+const { DBOSQueueDuplicatedError } = require('@dbos-inc/dbos-sdk');
+
+describe('public API exports', () => {
+  test('exports DBOSQueueDuplicatedError from the package root', () => {
+    const err = new DBOSQueueDuplicatedError('workflow-id', 'queue-name', 'dedup-id');
+
+    expect(err).toBeInstanceOf(DBOSQueueDuplicatedError);
+    expect(err.workflowID).toBe('workflow-id');
+    expect(err.queue).toBe('queue-name');
+    expect(err.deduplicationID).toBe('dedup-id');
+  });
+});


### PR DESCRIPTION
Related to https://github.com/dbos-inc/dbos-transact-ts/issues/1246

Exposes `DBOSQueueDuplicatedError` to consumer so I can write the following logic.

```ts
import { DBOS, DBOSQueueDuplicatedError } from '@dbos-inc/dbos-sdk'; 

try {
  return await DBOS.startWorkflow(myWorkflow, {
    queueName: 'my-queue',
    enqueueOptions: {
      deduplicationID,
    },
  })(input);
} catch (cause) {
  if (cause instanceof DBOSQueueDuplicatedError) {
    ...
  }
  throw cause;
}
```