### PR TITLE
Singleton Workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "name": "@dbos-inc/dbos-sdk",
       "version": "0.0.0-placeholder",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "name": "@dbos-inc/dbos-sdk",
       "version": "0.0.0-placeholder",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],

--- a/src/client.ts
+++ b/src/client.ts
@@ -292,7 +292,7 @@ export class DBOSClient {
 
     let finalID: string;
     if (options.duplicationPolicy === 'return-existing') {
-      finalID = await this.#initReturnExisting(internalStatus, options);
+      finalID = await this.#initSingletonWorkflow(internalStatus, options);
     } else {
       await this.systemDatabase.initWorkflowStatus(internalStatus, null);
       finalID = internalStatus.workflowUUID;
@@ -307,7 +307,7 @@ export class DBOSClient {
    * dedup slot, and returns its UUID. Falls back to retry if the slot was cleared between
    * INSERT and lookup (the prior workflow completed or was cancelled mid-flight).
    */
-  async #initReturnExisting(internalStatus: WorkflowStatusInternal, options: ClientEnqueueOptions): Promise<string> {
+  async #initSingletonWorkflow(internalStatus: WorkflowStatusInternal, options: ClientEnqueueOptions): Promise<string> {
     if (!options.deduplicationID) {
       throw new DBOSInvalidWorkflowTransitionError("`duplicationPolicy: 'return-existing'` requires `deduplicationID`");
     }
@@ -381,7 +381,7 @@ export class DBOSClient {
 
     let finalID: string;
     if (options.duplicationPolicy === 'return-existing') {
-      finalID = await this.#initReturnExisting(internalStatus, options);
+      finalID = await this.#initSingletonWorkflow(internalStatus, options);
     } else {
       await this.systemDatabase.initWorkflowStatus(internalStatus, null);
       finalID = internalStatus.workflowUUID;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import {
   SystemDatabase,
+  type DuplicationPolicy,
   type WorkflowStatusInternal,
   type WorkflowScheduleInternal,
   type VersionInfo,
@@ -38,7 +39,11 @@ import {
   toWorkflowStatus,
 } from './workflow_management';
 import { DBOSExecutor } from './dbos-executor';
-import { DBOSAwaitedWorkflowCancelledError } from './error';
+import {
+  DBOSAwaitedWorkflowCancelledError,
+  DBOSInvalidWorkflowTransitionError,
+  DBOSQueueDuplicatedError,
+} from './error';
 import { Pool } from 'pg';
 import {
   type WorkflowSchedule,
@@ -119,6 +124,15 @@ export interface ClientEnqueueOptions {
    * The workflow will be in DELAYED status until the delay expires, then transition to ENQUEUED.
    */
   delaySeconds?: number;
+  /**
+   * How to handle a collision with another workflow that has the same `deduplicationID`
+   * on the same queue.
+   *   `'reject'` (default): throw `DBOSQueueDuplicatedError`.
+   *   `'return-existing'`: return a handle to the existing workflow instead of throwing.
+   *     Requires `deduplicationID`. Arguments passed by the colliding caller are discarded
+   *     and the handle resolves with the original workflow's result.
+   */
+  duplicationPolicy?: DuplicationPolicy;
 }
 
 /**
@@ -276,9 +290,40 @@ export class DBOSClient {
       delayUntilEpochMS,
     };
 
-    await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+    let finalID: string;
+    if (options.duplicationPolicy === 'return-existing') {
+      finalID = await this.#initReturnExisting(internalStatus, options);
+    } else {
+      await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+      finalID = internalStatus.workflowUUID;
+    }
 
-    return new ClientHandle<Awaited<ReturnType<T>>>(this.systemDatabase, workflowUUID);
+    return new ClientHandle<Awaited<ReturnType<T>>>(this.systemDatabase, finalID);
+  }
+
+  /**
+   * Insert the workflow status row under the `'return-existing'` duplication policy: a retry
+   * loop that catches `DBOSQueueDuplicatedError`, looks up the active workflow holding the
+   * dedup slot, and returns its UUID. Falls back to retry if the slot was cleared between
+   * INSERT and lookup (the prior workflow completed or was cancelled mid-flight).
+   */
+  async #initReturnExisting(internalStatus: WorkflowStatusInternal, options: ClientEnqueueOptions): Promise<string> {
+    if (!options.deduplicationID) {
+      throw new DBOSInvalidWorkflowTransitionError("`duplicationPolicy: 'return-existing'` requires `deduplicationID`");
+    }
+    while (true) {
+      try {
+        await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+        return internalStatus.workflowUUID;
+      } catch (e) {
+        if (!(e instanceof DBOSQueueDuplicatedError)) throw e;
+        const existingID = await this.systemDatabase.getDeduplicatedWorkflow(
+          options.queueName,
+          options.deduplicationID,
+        );
+        if (existingID) return existingID;
+      }
+    }
   }
 
   /**
@@ -334,9 +379,15 @@ export class DBOSClient {
       delayUntilEpochMS,
     };
 
-    await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+    let finalID: string;
+    if (options.duplicationPolicy === 'return-existing') {
+      finalID = await this.#initReturnExisting(internalStatus, options);
+    } else {
+      await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+      finalID = internalStatus.workflowUUID;
+    }
 
-    return new ClientHandle<T>(this.systemDatabase, workflowUUID);
+    return new ClientHandle<T>(this.systemDatabase, finalID);
   }
 
   /**

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -519,6 +519,7 @@ export class DBOSExecutor {
           { error: sererr.serializedValue, serialization: sererr.serialization },
         );
       }
+      this.tracer.endSpan(span);
       throw e;
     }
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -505,9 +505,14 @@ export class DBOSExecutor {
       });
       serializationType = ires.serialization === DBOSPortableJSON.name() ? 'portable' : undefined;
     } catch (e) {
-      // For singleton enqueues we don't pre-record the dedup error: the singleton wrapper
-      // will catch it, attach to the existing workflow, and record the child mapping itself.
-      if (e instanceof DBOSQueueDuplicatedError && callerID && callerFunctionID && !params.singleton) {
+      // For 'return-existing' enqueues we don't pre-record the dedup error: the wrapper will
+      // catch it, attach to the existing workflow, and record the child mapping itself.
+      if (
+        e instanceof DBOSQueueDuplicatedError &&
+        callerID &&
+        callerFunctionID &&
+        params.duplicationPolicy !== 'return-existing'
+      ) {
         const sererr = await serializeResError(e, this.serializer, undefined); // This is a step result
         await this.systemDatabase.recordOperationResult(
           callerID,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -505,7 +505,9 @@ export class DBOSExecutor {
       });
       serializationType = ires.serialization === DBOSPortableJSON.name() ? 'portable' : undefined;
     } catch (e) {
-      if (e instanceof DBOSQueueDuplicatedError && callerID && callerFunctionID) {
+      // For singleton enqueues we don't pre-record the dedup error: the singleton wrapper
+      // will catch it, attach to the existing workflow, and record the child mapping itself.
+      if (e instanceof DBOSQueueDuplicatedError && callerID && callerFunctionID && !params.singleton) {
         const sererr = await serializeResError(e, this.serializer, undefined); // This is a step result
         await this.systemDatabase.recordOperationResult(
           callerID,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -163,6 +163,10 @@ export interface StartWorkflowParams {
   queueName?: string;
   timeoutMS?: number | null;
   enqueueOptions?: EnqueueOptions;
+  // If true, treat this as a singleton workflow. Requires `queueName` and `enqueueOptions.deduplicationID`.
+  // On collision, returns a handle to the existing workflow instead of throwing; the colliding caller's
+  // arguments are discarded and the handle resolves with the original workflow's result.
+  singleton?: boolean;
 }
 
 /**
@@ -1235,7 +1239,7 @@ export class DBOS {
     }
 
     const regOps = getRegisteredOperations(target);
-    const isSingleton = params?.enqueueOptions?.singleton;
+    const isSingleton = params?.singleton;
 
     const handler: ProxyHandler<object> = {
       apply(target, _thisArg, args) {
@@ -1754,13 +1758,11 @@ export class DBOS {
     params: StartWorkflowParams,
   ): Promise<WorkflowHandle<Return>> {
     if (!params.queueName) {
-      throw new DBOSInvalidWorkflowTransitionError('`enqueueOptions.singleton` requires `params.queueName`');
+      throw new DBOSInvalidWorkflowTransitionError('`singleton` requires `params.queueName`');
     }
     const dedupID = params.enqueueOptions?.deduplicationID;
     if (!dedupID) {
-      throw new DBOSInvalidWorkflowTransitionError(
-        '`enqueueOptions.singleton` requires `params.enqueueOptions.deduplicationID`',
-      );
+      throw new DBOSInvalidWorkflowTransitionError('`singleton` requires `params.enqueueOptions.deduplicationID`');
     }
     const queueName = params.queueName;
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1235,8 +1235,7 @@ export class DBOS {
     }
 
     const regOps = getRegisteredOperations(target);
-
-    const invoke = params?.enqueueOptions?.singleton ? DBOS.#invokeSingletonWorkflow : DBOS.#invokeWorkflow;
+    const isSingleton = params?.enqueueOptions?.singleton;
 
     const handler: ProxyHandler<object> = {
       apply(target, _thisArg, args) {
@@ -1246,14 +1245,19 @@ export class DBOS {
           const name = typeof target === 'function' ? target.name : target.toString();
           throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
         }
-        return invoke(instance, regOp, args, params);
+        return isSingleton
+          ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
+          : DBOS.#invokeWorkflow(instance, regOp, args, params);
       },
       get(target, p, receiver) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const func = Reflect.get(target, p, receiver);
         const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
         if (regOp) {
-          return (...args: unknown[]) => invoke(instance, regOp, args, params);
+          return (...args: unknown[]) =>
+            isSingleton
+              ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
+              : DBOS.#invokeWorkflow(instance, regOp, args, params);
         }
 
         const name = typeof p === 'string' ? p : String(p);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1236,85 +1236,7 @@ export class DBOS {
 
     const regOps = getRegisteredOperations(target);
 
-    const handler: ProxyHandler<object> = {
-      apply(target, _thisArg, args) {
-        const regOp = getFunctionRegistration(target);
-        if (!regOp) {
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          const name = typeof target === 'function' ? target.name : target.toString();
-          throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
-        }
-        return DBOS.#invokeWorkflow(instance, regOp, args, params);
-      },
-      get(target, p, receiver) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const func = Reflect.get(target, p, receiver);
-        const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
-        if (regOp) {
-          return (...args: unknown[]) => DBOS.#invokeWorkflow(instance, regOp, args, params);
-        }
-
-        const name = typeof p === 'string' ? p : String(p);
-        throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
-      },
-    };
-
-    return new Proxy(target, handler);
-  }
-
-  /**
-   * Enqueue a singleton workflow, returning a handle to either the newly-enqueued
-   * workflow or to an already-running workflow with the same deduplication ID.
-   *
-   * Requires `params.queueName` and `params.enqueueOptions.deduplicationID`. If a
-   * workflow with that deduplication ID is already running on the queue, the existing
-   * workflow's handle is returned. Otherwise, a new workflow is enqueued.
-   *
-   * The call retries indefinitely until it either claims the slot or attaches to a
-   * live workflow, so callers always receive a handle to an active workflow.
-   *
-   * The full syntax is:
-   * `handle = await DBOS.enqueueSingletonWorkflow(<target function>, <params>)(<args>);`
-   * @param func - The function to start.
-   * @param params - `StartWorkflowParams`; must specify `queueName` and `enqueueOptions.deduplicationID`.
-   * @returns `WorkflowHandle` for the singleton workflow.
-   */
-  static enqueueSingletonWorkflow<Args extends unknown[], Return>(
-    target: (...args: Args) => Promise<Return>,
-    params: StartWorkflowParams,
-  ): (...args: Args) => Promise<WorkflowHandle<Return>>;
-  /**
-   * Enqueue a singleton workflow on a `ConfiguredInstance`. See the function-target
-   * overload for details.
-   * The full syntax is:
-   * `handle = await DBOS.enqueueSingletonWorkflow(<target object>, <params>).<target method>(<args>);`
-   */
-  static enqueueSingletonWorkflow<T extends ConfiguredInstance>(
-    target: T,
-    params: StartWorkflowParams,
-  ): InvokeFunctionsAsyncInst<T>;
-  /**
-   * Enqueue a singleton workflow on a class. See the function-target overload for details.
-   * The full syntax is:
-   * `handle = await DBOS.enqueueSingletonWorkflow(<target class>, <params>).<target method>(<args>);`
-   */
-  static enqueueSingletonWorkflow<T extends object>(
-    targetClass: T,
-    params: StartWorkflowParams,
-  ): InvokeFunctionsAsync<T>;
-  static enqueueSingletonWorkflow(
-    target: UntypedAsyncFunction | ConfiguredInstance | object,
-    params: StartWorkflowParams,
-  ): unknown {
-    ensureDBOSIsLaunched('workflows');
-    const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
-    if (instance && typeof instance !== 'function' && !(instance instanceof ConfiguredInstance)) {
-      throw new DBOSInvalidWorkflowTransitionError(
-        'Attempt to call `enqueueSingletonWorkflow` on an object that is not a `ConfiguredInstance`',
-      );
-    }
-
-    const regOps = getRegisteredOperations(target);
+    const invoke = params?.enqueueOptions?.singleton ? DBOS.#invokeSingletonWorkflow : DBOS.#invokeWorkflow;
 
     const handler: ProxyHandler<object> = {
       apply(target, _thisArg, args) {
@@ -1324,14 +1246,14 @@ export class DBOS {
           const name = typeof target === 'function' ? target.name : target.toString();
           throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
         }
-        return DBOS.#invokeSingletonWorkflow(instance, regOp, args, params);
+        return invoke(instance, regOp, args, params);
       },
       get(target, p, receiver) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const func = Reflect.get(target, p, receiver);
         const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
         if (regOp) {
-          return (...args: unknown[]) => DBOS.#invokeSingletonWorkflow(instance, regOp, args, params);
+          return (...args: unknown[]) => invoke(instance, regOp, args, params);
         }
 
         const name = typeof p === 'string' ? p : String(p);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -107,6 +107,7 @@ import { randomUUID } from 'node:crypto';
 import { StepConfig } from './step';
 import { Conductor } from './conductor/conductor';
 import {
+  DuplicationPolicy,
   EnqueueOptions,
   DBOS_STREAM_CLOSED_SENTINEL,
   DBOS_FUNCNAME_WRITESTREAM,
@@ -163,10 +164,13 @@ export interface StartWorkflowParams {
   queueName?: string;
   timeoutMS?: number | null;
   enqueueOptions?: EnqueueOptions;
-  // If true, treat this as a singleton workflow. Requires `queueName` and `enqueueOptions.deduplicationID`.
-  // On collision, returns a handle to the existing workflow instead of throwing; the colliding caller's
-  // arguments are discarded and the handle resolves with the original workflow's result.
-  singleton?: boolean;
+  // How to handle a collision with another workflow that has the same
+  // `enqueueOptions.deduplicationID` on the same queue.
+  //   'reject' (default): throw `DBOSQueueDuplicatedError`.
+  //   'return-existing': return a handle to the existing workflow instead of throwing.
+  //     Requires `queueName` and `enqueueOptions.deduplicationID`. Arguments passed by the
+  //     colliding caller are discarded and the handle resolves with the original workflow's result.
+  duplicationPolicy?: DuplicationPolicy;
 }
 
 /**
@@ -1239,7 +1243,7 @@ export class DBOS {
     }
 
     const regOps = getRegisteredOperations(target);
-    const isSingleton = params?.singleton;
+    const returnExisting = params?.duplicationPolicy === 'return-existing';
 
     const handler: ProxyHandler<object> = {
       apply(target, _thisArg, args) {
@@ -1249,8 +1253,8 @@ export class DBOS {
           const name = typeof target === 'function' ? target.name : target.toString();
           throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
         }
-        return isSingleton
-          ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
+        return returnExisting
+          ? DBOS.#invokeReturnExistingWorkflow(instance, regOp, args, params)
           : DBOS.#invokeWorkflow(instance, regOp, args, params);
       },
       get(target, p, receiver) {
@@ -1259,8 +1263,8 @@ export class DBOS {
         const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
         if (regOp) {
           return (...args: unknown[]) =>
-            isSingleton
-              ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
+            returnExisting
+              ? DBOS.#invokeReturnExistingWorkflow(instance, regOp, args, params)
               : DBOS.#invokeWorkflow(instance, regOp, args, params);
         }
 
@@ -1719,7 +1723,7 @@ export class DBOS {
         deadlineEpochMS:
           params.timeoutMS === null || ppctx?.workflowTimeoutMS === null ? undefined : ppctx?.deadlineEpochMS,
         enqueueOptions: params.enqueueOptions,
-        singleton: params.singleton,
+        duplicationPolicy: params.duplicationPolicy,
       };
 
       return await invokeRegOp(wfParams, pwfid, funcId);
@@ -1730,7 +1734,7 @@ export class DBOS {
         enqueueOptions: params.enqueueOptions,
         configuredInstance: instance,
         timeoutMS,
-        singleton: params.singleton,
+        duplicationPolicy: params.duplicationPolicy,
       };
 
       return await invokeRegOp(wfParams, undefined, undefined);
@@ -1753,23 +1757,27 @@ export class DBOS {
     }
   }
 
-  static async #invokeSingletonWorkflow<This, Args extends unknown[], Return>(
+  static async #invokeReturnExistingWorkflow<This, Args extends unknown[], Return>(
     $this: This,
     regOP: MethodRegistrationBase,
     args: Args,
     params: StartWorkflowParams,
   ): Promise<WorkflowHandle<Return>> {
     if (!params.queueName) {
-      throw new DBOSInvalidWorkflowTransitionError('`singleton` requires `params.queueName`');
+      throw new DBOSInvalidWorkflowTransitionError(
+        "`duplicationPolicy: 'return-existing'` requires `params.queueName`",
+      );
     }
     const dedupID = params.enqueueOptions?.deduplicationID;
     if (!dedupID) {
-      throw new DBOSInvalidWorkflowTransitionError('`singleton` requires `params.enqueueOptions.deduplicationID`');
+      throw new DBOSInvalidWorkflowTransitionError(
+        "`duplicationPolicy: 'return-existing'` requires `params.enqueueOptions.deduplicationID`",
+      );
     }
     const queueName = params.queueName;
 
-    // Reserve the parent's child-funcID once, before any await. Each loop iteration
-    // passes it through so invokeSingletonWorkflow consumes a single funcID instead of one per try.
+    // Reserve the parent's child-funcID once, before any await. Each loop iteration passes it
+    // through so the return-existing retry loop consumes a single funcID instead of one per try.
     const childFuncId = DBOS.isInWorkflow() ? functionIDGetIncrement() : undefined;
 
     // Resolve the workflow ID once: if the caller supplied one explicitly or via

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1804,7 +1804,7 @@ export class DBOS {
               DBOS.workflowID!,
               childFuncId,
               regOP.name,
-              false,
+              true,
               now,
               now,
               { childWorkflowID: existingID },

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1772,9 +1772,15 @@ export class DBOS {
     // passes it through so invokeSingletonWorkflow consumes a single funcID instead of one per try.
     const childFuncId = DBOS.isInWorkflow() ? functionIDGetIncrement() : undefined;
 
+    // Resolve the workflow ID once: if the caller supplied one explicitly or via
+    // `withNextWorkflowID`, reuse it on every iteration.
+    const resolvedWorkflowID = getNextWFID(params.workflowID);
+    const callParams: StartWorkflowParams =
+      resolvedWorkflowID !== undefined ? { ...params, workflowID: resolvedWorkflowID } : params;
+
     while (true) {
       try {
-        return await DBOS.#invokeWorkflow<This, Args, Return>($this, regOP, args, params, childFuncId);
+        return await DBOS.#invokeWorkflow<This, Args, Return>($this, regOP, args, callParams, childFuncId);
       } catch (e) {
         if (!(e instanceof DBOSQueueDuplicatedError)) {
           throw e;
@@ -1785,8 +1791,7 @@ export class DBOS {
         );
         if (existingID) {
           // Record the parent->child mapping at the reserved funcID so that on replay
-          // the parent short-circuits to the same child instead of re-evaluating the
-          // (potentially-different) live dedup state.
+          // the parent uses the same child.
           if (childFuncId !== undefined) {
             const now = Date.now();
             await DBOSExecutor.globalInstance!.systemDatabase.recordOperationResult(

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -41,6 +41,7 @@ import {
   DBOSAwaitedWorkflowExceededMaxRecoveryAttempts,
   DBOSUnexpectedStepError,
   DBOSInvalidQueuePriorityError,
+  DBOSQueueDuplicatedError,
 } from './error';
 import {
   getDbosConfig,
@@ -1262,6 +1263,86 @@ export class DBOS {
   }
 
   /**
+   * Enqueue a singleton workflow, returning a handle to either the newly-enqueued
+   * workflow or to an already-running workflow with the same deduplication ID.
+   *
+   * Requires `params.queueName` and `params.enqueueOptions.deduplicationID`. If a
+   * workflow with that deduplication ID is already running on the queue, the existing
+   * workflow's handle is returned. Otherwise, a new workflow is enqueued.
+   *
+   * The call retries indefinitely until it either claims the slot or attaches to a
+   * live workflow, so callers always receive a handle to an active workflow.
+   *
+   * The full syntax is:
+   * `handle = await DBOS.enqueueSingletonWorkflow(<target function>, <params>)(<args>);`
+   * @param func - The function to start.
+   * @param params - `StartWorkflowParams`; must specify `queueName` and `enqueueOptions.deduplicationID`.
+   * @returns `WorkflowHandle` for the singleton workflow.
+   */
+  static enqueueSingletonWorkflow<Args extends unknown[], Return>(
+    target: (...args: Args) => Promise<Return>,
+    params: StartWorkflowParams,
+  ): (...args: Args) => Promise<WorkflowHandle<Return>>;
+  /**
+   * Enqueue a singleton workflow on a `ConfiguredInstance`. See the function-target
+   * overload for details.
+   * The full syntax is:
+   * `handle = await DBOS.enqueueSingletonWorkflow(<target object>, <params>).<target method>(<args>);`
+   */
+  static enqueueSingletonWorkflow<T extends ConfiguredInstance>(
+    target: T,
+    params: StartWorkflowParams,
+  ): InvokeFunctionsAsyncInst<T>;
+  /**
+   * Enqueue a singleton workflow on a class. See the function-target overload for details.
+   * The full syntax is:
+   * `handle = await DBOS.enqueueSingletonWorkflow(<target class>, <params>).<target method>(<args>);`
+   */
+  static enqueueSingletonWorkflow<T extends object>(
+    targetClass: T,
+    params: StartWorkflowParams,
+  ): InvokeFunctionsAsync<T>;
+  static enqueueSingletonWorkflow(
+    target: UntypedAsyncFunction | ConfiguredInstance | object,
+    params: StartWorkflowParams,
+  ): unknown {
+    ensureDBOSIsLaunched('workflows');
+    const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
+    if (instance && typeof instance !== 'function' && !(instance instanceof ConfiguredInstance)) {
+      throw new DBOSInvalidWorkflowTransitionError(
+        'Attempt to call `enqueueSingletonWorkflow` on an object that is not a `ConfiguredInstance`',
+      );
+    }
+
+    const regOps = getRegisteredOperations(target);
+
+    const handler: ProxyHandler<object> = {
+      apply(target, _thisArg, args) {
+        const regOp = getFunctionRegistration(target);
+        if (!regOp) {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          const name = typeof target === 'function' ? target.name : target.toString();
+          throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
+        }
+        return DBOS.#invokeSingletonWorkflow(instance, regOp, args, params);
+      },
+      get(target, p, receiver) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const func = Reflect.get(target, p, receiver);
+        const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
+        if (regOp) {
+          return (...args: unknown[]) => DBOS.#invokeSingletonWorkflow(instance, regOp, args, params);
+        }
+
+        const name = typeof p === 'string' ? p : String(p);
+        throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
+      },
+    };
+
+    return new Proxy(target, handler);
+  }
+
+  /**
    * Send `message` on optional `topic` to the workflow with `destinationID`
    *  This can be done from inside or outside of DBOS workflow functions
    *  Use the optional `idempotencyKey` to guarantee that the message is sent exactly once
@@ -1737,6 +1818,43 @@ export class DBOS {
         regOP.name,
         `${regOP.name} is not a registered DBOS workflow, step, or transaction function`,
       );
+    }
+  }
+
+  static async #invokeSingletonWorkflow<This, Args extends unknown[], Return>(
+    $this: This,
+    regOP: MethodRegistrationBase,
+    args: Args,
+    params: StartWorkflowParams,
+  ): Promise<WorkflowHandle<Return>> {
+    if (!params.queueName) {
+      throw new DBOSInvalidWorkflowTransitionError('`enqueueSingletonWorkflow` requires `params.queueName`');
+    }
+    const dedupID = params.enqueueOptions?.deduplicationID;
+    if (!dedupID) {
+      throw new DBOSInvalidWorkflowTransitionError(
+        '`enqueueSingletonWorkflow` requires `params.enqueueOptions.deduplicationID`',
+      );
+    }
+    const queueName = params.queueName;
+
+    while (true) {
+      try {
+        return await DBOS.#invokeWorkflow<This, Args, Return>($this, regOP, args, params);
+      } catch (e) {
+        if (!(e instanceof DBOSQueueDuplicatedError)) {
+          throw e;
+        }
+        const existingID = await DBOSExecutor.globalInstance!.systemDatabase.getDeduplicatedWorkflow(
+          queueName,
+          dedupID,
+        );
+        if (existingID) {
+          return new RetrievedHandle<Return>(DBOSExecutor.globalInstance!.systemDatabase, existingID);
+        }
+        // The prior workflow's deduplication_id was cleared between our INSERT and
+        // the lookup (it completed or was cancelled). Loop and try to claim the slot.
+      }
     }
   }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1243,7 +1243,7 @@ export class DBOS {
     }
 
     const regOps = getRegisteredOperations(target);
-    const returnExisting = params?.duplicationPolicy === 'return-existing';
+    const singletonWorkflow = params?.duplicationPolicy === 'return-existing';
 
     const handler: ProxyHandler<object> = {
       apply(target, _thisArg, args) {
@@ -1253,8 +1253,8 @@ export class DBOS {
           const name = typeof target === 'function' ? target.name : target.toString();
           throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
         }
-        return returnExisting
-          ? DBOS.#invokeReturnExistingWorkflow(instance, regOp, args, params)
+        return singletonWorkflow
+          ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
           : DBOS.#invokeWorkflow(instance, regOp, args, params);
       },
       get(target, p, receiver) {
@@ -1263,8 +1263,8 @@ export class DBOS {
         const regOp = getFunctionRegistration(func) ?? regOps.find((op) => op.name === p);
         if (regOp) {
           return (...args: unknown[]) =>
-            returnExisting
-              ? DBOS.#invokeReturnExistingWorkflow(instance, regOp, args, params)
+            singletonWorkflow
+              ? DBOS.#invokeSingletonWorkflow(instance, regOp, args, params)
               : DBOS.#invokeWorkflow(instance, regOp, args, params);
         }
 
@@ -1757,7 +1757,7 @@ export class DBOS {
     }
   }
 
-  static async #invokeReturnExistingWorkflow<This, Args extends unknown[], Return>(
+  static async #invokeSingletonWorkflow<This, Args extends unknown[], Return>(
     $this: This,
     regOP: MethodRegistrationBase,
     args: Args,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1754,12 +1754,12 @@ export class DBOS {
     params: StartWorkflowParams,
   ): Promise<WorkflowHandle<Return>> {
     if (!params.queueName) {
-      throw new DBOSInvalidWorkflowTransitionError('`enqueueSingletonWorkflow` requires `params.queueName`');
+      throw new DBOSInvalidWorkflowTransitionError('`enqueueOptions.singleton` requires `params.queueName`');
     }
     const dedupID = params.enqueueOptions?.deduplicationID;
     if (!dedupID) {
       throw new DBOSInvalidWorkflowTransitionError(
-        '`enqueueSingletonWorkflow` requires `params.enqueueOptions.deduplicationID`',
+        '`enqueueOptions.singleton` requires `params.enqueueOptions.deduplicationID`',
       );
     }
     const queueName = params.queueName;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1766,9 +1766,13 @@ export class DBOS {
     }
     const queueName = params.queueName;
 
+    // Reserve the parent's child-funcID once, before any await. Each loop iteration
+    // passes it through so invokeSingletonWorkflow consumes a single funcID instead of one per try.
+    const childFuncId = DBOS.isInWorkflow() ? functionIDGetIncrement() : undefined;
+
     while (true) {
       try {
-        return await DBOS.#invokeWorkflow<This, Args, Return>($this, regOP, args, params);
+        return await DBOS.#invokeWorkflow<This, Args, Return>($this, regOP, args, params, childFuncId);
       } catch (e) {
         if (!(e instanceof DBOSQueueDuplicatedError)) {
           throw e;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1764,14 +1764,12 @@ export class DBOS {
     params: StartWorkflowParams,
   ): Promise<WorkflowHandle<Return>> {
     if (!params.queueName) {
-      throw new DBOSInvalidWorkflowTransitionError(
-        "`duplicationPolicy: 'return-existing'` requires `params.queueName`",
-      );
+      throw new DBOSInvalidWorkflowTransitionError("`duplicationPolicy: 'return-existing'` requires a `queueName`");
     }
     const dedupID = params.enqueueOptions?.deduplicationID;
     if (!dedupID) {
       throw new DBOSInvalidWorkflowTransitionError(
-        "`duplicationPolicy: 'return-existing'` requires `params.enqueueOptions.deduplicationID`",
+        "`duplicationPolicy: 'return-existing'` requires `enqueueOptions.deduplicationID`",
       );
     }
     const queueName = params.queueName;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1719,6 +1719,7 @@ export class DBOS {
         deadlineEpochMS:
           params.timeoutMS === null || ppctx?.workflowTimeoutMS === null ? undefined : ppctx?.deadlineEpochMS,
         enqueueOptions: params.enqueueOptions,
+        singleton: params.singleton,
       };
 
       return await invokeRegOp(wfParams, pwfid, funcId);
@@ -1729,6 +1730,7 @@ export class DBOS {
         enqueueOptions: params.enqueueOptions,
         configuredInstance: instance,
         timeoutMS,
+        singleton: params.singleton,
       };
 
       return await invokeRegOp(wfParams, undefined, undefined);
@@ -1782,6 +1784,21 @@ export class DBOS {
           dedupID,
         );
         if (existingID) {
+          // Record the parent->child mapping at the reserved funcID so that on replay
+          // the parent short-circuits to the same child instead of re-evaluating the
+          // (potentially-different) live dedup state.
+          if (childFuncId !== undefined) {
+            const now = Date.now();
+            await DBOSExecutor.globalInstance!.systemDatabase.recordOperationResult(
+              DBOS.workflowID!,
+              childFuncId,
+              regOP.name,
+              false,
+              now,
+              now,
+              { childWorkflowID: existingID },
+            );
+          }
           return new RetrievedHandle<Return>(DBOSExecutor.globalInstance!.systemDatabase, existingID);
         }
         // The prior workflow's deduplication_id was cleared between our INSERT and

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -724,6 +724,7 @@ export class SystemDatabase {
         await this.updateWorkflowStatus(client, initStatus.workflowUUID, StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED, {
           where: { status: StatusString.PENDING },
           throwOnFailure: false,
+          update: { resetDeduplicationID: true },
         });
         throw new DBOSMaxRecoveryAttemptsExceededError(initStatus.workflowUUID, options.maxRetries);
       }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -191,10 +191,6 @@ export interface EnqueueOptions {
   applicationVersion?: string;
   // Number of seconds to delay the workflow before it starts executing. The workflow will be in DELAYED status until the delay expires.
   delaySeconds?: number;
-  // If true, treat this as a singleton workflow. Requires `deduplicationID` and a queueName.
-  // On collision, returns a handle to the existing workflow instead of throwing; the colliding
-  // caller's arguments are discarded and the handle resolves with the original workflow's result.
-  singleton?: boolean;
 }
 
 export interface ExistenceCheck {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -191,10 +191,9 @@ export interface EnqueueOptions {
   applicationVersion?: string;
   // Number of seconds to delay the workflow before it starts executing. The workflow will be in DELAYED status until the delay expires.
   delaySeconds?: number;
-  // If true, treat this as a singleton workflow. Requires `deduplicationID` (and a queueName on the start params).
-  // If a workflow with the given deduplication ID is already running, the start call returns a handle to that
-  // existing workflow instead of throwing. The call retries indefinitely until it claims the slot or attaches
-  // to a live workflow.
+  // If true, treat this as a singleton workflow. Requires `deduplicationID` and a queueName.
+  // On collision, returns a handle to the existing workflow instead of throwing; the colliding
+  // caller's arguments are discarded and the handle resolves with the original workflow's result.
   singleton?: boolean;
 }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -191,6 +191,11 @@ export interface EnqueueOptions {
   applicationVersion?: string;
   // Number of seconds to delay the workflow before it starts executing. The workflow will be in DELAYED status until the delay expires.
   delaySeconds?: number;
+  // If true, treat this as a singleton workflow. Requires `deduplicationID` (and a queueName on the start params).
+  // If a workflow with the given deduplication ID is already running, the start call returns a handle to that
+  // existing workflow instead of throwing. The call retries indefinitely until it claims the slot or attaches
+  // to a live workflow.
+  singleton?: boolean;
 }
 
 export interface ExistenceCheck {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -193,6 +193,13 @@ export interface EnqueueOptions {
   delaySeconds?: number;
 }
 
+// How to handle a collision with another workflow that has the same `enqueueOptions.deduplicationID`
+// on the same queue.
+//   'reject' (default): throw `DBOSQueueDuplicatedError`.
+//   'return-existing': return a handle to the existing workflow; arguments passed by the colliding
+//     caller are discarded and the handle resolves with the original workflow's result.
+export type DuplicationPolicy = 'reject' | 'return-existing';
+
 export interface ExistenceCheck {
   exists: boolean;
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -3,7 +3,7 @@ import { type SystemDatabase, WorkflowStatusInternal } from './system_database';
 import { ConfiguredInstance } from './decorators';
 import { deserializePositionalArgs, registerSerializationRecipe } from './serialization';
 import { DBOS, runInternalStep } from './dbos';
-import { EnqueueOptions } from './system_database';
+import { DuplicationPolicy, EnqueueOptions } from './system_database';
 import { DBOSExecutor } from './dbos-executor';
 
 export interface WorkflowParams {
@@ -14,10 +14,10 @@ export interface WorkflowParams {
   timeoutMS?: number | null;
   deadlineEpochMS?: number;
   enqueueOptions?: EnqueueOptions; // Options for the workflow queue
-  // Set when the caller is `DBOS.startWorkflow({singleton: true})`. Tells the executor not to
-  // pre-record the dedup error at the parent's funcID — the singleton wrapper will record the
+  // How to react to a collision on `enqueueOptions.deduplicationID`. When 'return-existing', the
+  // executor skips its dedup-error pre-recording at the parent's funcID — the wrapper records the
   // child mapping itself after attaching to the existing workflow.
-  singleton?: boolean;
+  duplicationPolicy?: DuplicationPolicy;
 }
 
 export const DEFAULT_MAX_RECOVERY_ATTEMPTS = 100;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -14,6 +14,10 @@ export interface WorkflowParams {
   timeoutMS?: number | null;
   deadlineEpochMS?: number;
   enqueueOptions?: EnqueueOptions; // Options for the workflow queue
+  // Set when the caller is `DBOS.startWorkflow({singleton: true})`. Tells the executor not to
+  // pre-record the dedup error at the parent's funcID — the singleton wrapper will record the
+  // child mapping itself after attaching to the existing workflow.
+  singleton?: boolean;
 }
 
 export const DEFAULT_MAX_RECOVERY_ATTEMPTS = 100;

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -138,7 +138,7 @@ describe('singleton workflows', () => {
         enqueueOptions: { deduplicationID: dedupID, singleton: true },
       }).gatedWorkflow('second');
 
-      expect(calls).toBeGreaterThanOrEqual(2);
+      expect(calls).toBe(2);
       expect(wfh2.workflowID).toBe(wfh1.workflowID);
 
       SingletonTest.resolveEvent();

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1,5 +1,6 @@
 import { DBOS } from '../src';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSQueueDuplicatedError } from '../src/error';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
 
 const testPolling = { minPollingIntervalMs: 100 };
@@ -270,5 +271,49 @@ describe('singleton workflows', () => {
     // Sanity: parent B is not used in fork checks, but its output and step
     // count are still asserted via earlier resultB / markerStepRuns checks.
     expect(parentBID).toBeDefined();
+  });
+
+  // Regression test: a withNextWorkflowID reservation must survive across the singleton
+  // retry loop. Otherwise iter 1 consumes idAssignedForNextWorkflow, iter 2 falls back
+  // to a random UUID, and an iter-2 win silently creates a workflow with the wrong ID.
+  test('singleton honors withNextWorkflowID across retry iterations', async () => {
+    const dedupID = 'reservation_dedup_id';
+    const reservedChildID = 'my-reserved-child-id';
+
+    // Force iter 1's INSERT to fail with a dedup violation, then succeed on iter 2.
+    // Pair with getDeduplicatedWorkflow returning null so the wrapper falls through
+    // to "loop and try to claim the slot."
+    const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
+    const originalInit = sysdb.initWorkflowStatus.bind(sysdb);
+    const originalLookup = sysdb.getDeduplicatedWorkflow.bind(sysdb);
+    let initCalls = 0;
+    sysdb.initWorkflowStatus = async (...args) => {
+      initCalls++;
+      if (initCalls === 1) {
+        throw new DBOSQueueDuplicatedError(args[0].workflowUUID, SingletonTest.queue.name, dedupID);
+      }
+      return originalInit(...args);
+    };
+    sysdb.getDeduplicatedWorkflow = () => Promise.resolve(null);
+
+    try {
+      const handle = await DBOS.withNextWorkflowID(reservedChildID, () =>
+        DBOS.startWorkflow(SingletonTest, {
+          queueName: SingletonTest.queue.name,
+          enqueueOptions: { deduplicationID: dedupID },
+          singleton: true,
+        }).gatedWorkflow('reserved'),
+      );
+
+      // The new workflow created by iter 2 must use the reserved ID.
+      expect(handle.workflowID).toBe(reservedChildID);
+      expect(initCalls).toBe(2);
+
+      SingletonTest.resolveEvent();
+      expect(await handle.getResult()).toBe('reserved-done');
+    } finally {
+      sysdb.initWorkflowStatus = originalInit;
+      sysdb.getDeduplicatedWorkflow = originalLookup;
+    }
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -53,12 +53,14 @@ describe('singleton workflows', () => {
 
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
-      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
     }).gatedWorkflow('first');
 
     const wfh2 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
-      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
     }).gatedWorkflow('second');
 
     expect(wfh2.workflowID).toBe(wfh1.workflowID);
@@ -76,7 +78,8 @@ describe('singleton workflows', () => {
 
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
-      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
     }).gatedWorkflow('first');
 
     SingletonTest.resolveEvent();
@@ -86,7 +89,8 @@ describe('singleton workflows', () => {
 
     const wfh2 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
-      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
     }).gatedWorkflow('second');
 
     expect(wfh2.workflowID).not.toBe(wfh1.workflowID);
@@ -99,7 +103,7 @@ describe('singleton workflows', () => {
     await expect(
       DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
-        enqueueOptions: { singleton: true },
+        singleton: true,
       }).gatedWorkflow('x'),
     ).rejects.toThrow(/deduplicationID/);
   });
@@ -107,7 +111,8 @@ describe('singleton workflows', () => {
   test('missing queueName throws', async () => {
     await expect(
       DBOS.startWorkflow(SingletonTest, {
-        enqueueOptions: { deduplicationID: 'some_id', singleton: true },
+        enqueueOptions: { deduplicationID: 'some_id' },
+        singleton: true,
       }).gatedWorkflow('y'),
     ).rejects.toThrow(/queueName/);
   });
@@ -120,7 +125,8 @@ describe('singleton workflows', () => {
 
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
-      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
     }).gatedWorkflow('first');
 
     const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
@@ -135,7 +141,8 @@ describe('singleton workflows', () => {
     try {
       const wfh2 = await DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
-        enqueueOptions: { deduplicationID: dedupID, singleton: true },
+        enqueueOptions: { deduplicationID: dedupID },
+        singleton: true,
       }).gatedWorkflow('second');
 
       expect(calls).toBe(2);

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1,4 +1,4 @@
-import { DBOS } from '../src';
+import { DBOS, DBOSClient } from '../src';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
 import { DBOSQueueDuplicatedError } from '../src/error';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
@@ -7,9 +7,12 @@ const testPolling = { minPollingIntervalMs: 100 };
 
 describe('singleton workflows', () => {
   let config: DBOSConfig;
+  let systemDatabaseUrl: string;
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
+    expect(config.systemDatabaseUrl).toBeDefined();
+    systemDatabaseUrl = config.systemDatabaseUrl!;
     await setUpDBOSTestSysDb(config);
     DBOS.setConfig(config);
   });
@@ -314,6 +317,62 @@ describe('singleton workflows', () => {
     } finally {
       sysdb.initWorkflowStatus = originalInit;
       sysdb.getDeduplicatedWorkflow = originalLookup;
+    }
+  });
+
+  test('client enqueue with duplicationPolicy: return-existing attaches', async () => {
+    const dedupID = `client_return_existing_${Date.now()}`;
+    const client = await DBOSClient.create({ systemDatabaseUrl });
+
+    try {
+      const handle1 = await client.enqueue<typeof SingletonTest.gatedWorkflow>(
+        {
+          workflowName: 'gatedWorkflow',
+          workflowClassName: 'SingletonTest',
+          queueName: SingletonTest.queue.name,
+          deduplicationID: dedupID,
+          duplicationPolicy: 'return-existing',
+        },
+        'first',
+      );
+
+      const handle2 = await client.enqueue<typeof SingletonTest.gatedWorkflow>(
+        {
+          workflowName: 'gatedWorkflow',
+          workflowClassName: 'SingletonTest',
+          queueName: SingletonTest.queue.name,
+          deduplicationID: dedupID,
+          duplicationPolicy: 'return-existing',
+        },
+        'second',
+      );
+
+      expect(handle2.workflowID).toBe(handle1.workflowID);
+
+      SingletonTest.resolveEvent();
+      expect(await handle1.getResult()).toBe('first-done');
+      expect(await handle2.getResult()).toBe('first-done');
+    } finally {
+      await client.destroy();
+    }
+  });
+
+  test('client enqueue with duplicationPolicy: return-existing requires deduplicationID', async () => {
+    const client = await DBOSClient.create({ systemDatabaseUrl });
+    try {
+      await expect(
+        client.enqueue<typeof SingletonTest.gatedWorkflow>(
+          {
+            workflowName: 'gatedWorkflow',
+            workflowClassName: 'SingletonTest',
+            queueName: SingletonTest.queue.name,
+            duplicationPolicy: 'return-existing',
+          },
+          'x',
+        ),
+      ).rejects.toThrow(/deduplicationID/);
+    } finally {
+      await client.destroy();
     }
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1,0 +1,114 @@
+import { DBOS } from '../src';
+import { DBOSConfig } from '../src/dbos-executor';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
+
+const testPolling = { minPollingIntervalMs: 100 };
+
+describe('singleton workflows', () => {
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestSysDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    SingletonTest.resetEvent();
+    await DBOS.launch();
+    await DBOS.registerQueue(SingletonTest.queue.name, {
+      onConflict: 'always_update',
+      ...SingletonTest.queue.config,
+    });
+  });
+
+  afterEach(async () => {
+    SingletonTest.resolveEvent();
+    await DBOS.shutdown();
+  });
+
+  class SingletonTest {
+    static queue = {
+      name: 'singleton_queue',
+      config: { concurrency: 1, ...testPolling },
+    };
+
+    static resolveEvent: () => void = () => {};
+    static workflowEvent: Promise<void> = Promise.resolve();
+    static resetEvent() {
+      SingletonTest.workflowEvent = new Promise<void>((resolve) => {
+        SingletonTest.resolveEvent = resolve;
+      });
+    }
+
+    @DBOS.workflow()
+    static async gatedWorkflow(input: string): Promise<string> {
+      await SingletonTest.workflowEvent;
+      return `${input}-done`;
+    }
+  }
+
+  test('collision returns existing handle', async () => {
+    const dedupID = 'collision_id';
+
+    const wfh1 = await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+    }).gatedWorkflow('first');
+
+    const wfh2 = await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+    }).gatedWorkflow('second');
+
+    expect(wfh2.workflowID).toBe(wfh1.workflowID);
+
+    SingletonTest.resolveEvent();
+
+    const result1 = await wfh1.getResult();
+    const result2 = await wfh2.getResult();
+    expect(result1).toBe('first-done');
+    expect(result2).toBe('first-done');
+  });
+
+  test('fresh enqueue after completion starts a new workflow', async () => {
+    const dedupID = 'fresh_id';
+
+    const wfh1 = await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+    }).gatedWorkflow('first');
+
+    SingletonTest.resolveEvent();
+    expect(await wfh1.getResult()).toBe('first-done');
+
+    SingletonTest.resetEvent();
+
+    const wfh2 = await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+    }).gatedWorkflow('second');
+
+    expect(wfh2.workflowID).not.toBe(wfh1.workflowID);
+
+    SingletonTest.resolveEvent();
+    expect(await wfh2.getResult()).toBe('second-done');
+  });
+
+  test('missing deduplicationID throws', async () => {
+    await expect(
+      DBOS.startWorkflow(SingletonTest, {
+        queueName: SingletonTest.queue.name,
+        enqueueOptions: { singleton: true },
+      }).gatedWorkflow('x'),
+    ).rejects.toThrow(/deduplicationID/);
+  });
+
+  test('missing queueName throws', async () => {
+    await expect(
+      DBOS.startWorkflow(SingletonTest, {
+        enqueueOptions: { deduplicationID: 'some_id', singleton: true },
+      }).gatedWorkflow('y'),
+    ).rejects.toThrow(/queueName/);
+  });
+});

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -35,6 +35,7 @@ describe('singleton workflows', () => {
 
     static resolveEvent: () => void = () => {};
     static workflowEvent: Promise<void> = Promise.resolve();
+    static markerStepRuns = 0;
     static resetEvent() {
       SingletonTest.workflowEvent = new Promise<void>((resolve) => {
         SingletonTest.resolveEvent = resolve;
@@ -45,6 +46,23 @@ describe('singleton workflows', () => {
     static async gatedWorkflow(input: string): Promise<string> {
       await SingletonTest.workflowEvent;
       return `${input}-done`;
+    }
+
+    @DBOS.workflow()
+    static async parentWithSingleton(dedupID: string): Promise<string> {
+      const handle = await DBOS.startWorkflow(SingletonTest, {
+        queueName: SingletonTest.queue.name,
+        enqueueOptions: { deduplicationID: dedupID },
+        singleton: true,
+      }).gatedWorkflow('attached');
+      await DBOS.runStep(
+        () => {
+          SingletonTest.markerStepRuns++;
+          return Promise.resolve('after-singleton');
+        },
+        { name: 'marker_step' },
+      );
+      return handle.workflowID;
     }
   }
 
@@ -154,5 +172,70 @@ describe('singleton workflows', () => {
     } finally {
       sysdb.getDeduplicatedWorkflow = original;
     }
+  });
+
+  // Regression test: when called from inside a parent workflow, the singleton retry
+  // loop must consume exactly one parent funcID, not one per iteration. Otherwise
+  // subsequent operations land at funcIDs that don't match what replay expects.
+  test('singleton from within a parent workflow consumes one funcID across retries', async () => {
+    const dedupID = 'parent_singleton_id';
+
+    // Pre-enqueue a child that holds the dedup slot.
+    await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID },
+      singleton: true,
+    }).gatedWorkflow('blocking');
+
+    SingletonTest.markerStepRuns = 0;
+
+    // Force the dedup lookup to miss once so the retry loop iterates twice on the
+    // original run.
+    const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
+    const original = sysdb.getDeduplicatedWorkflow.bind(sysdb);
+    let calls = 0;
+    sysdb.getDeduplicatedWorkflow = async (qn: string, dID: string) => {
+      calls++;
+      if (calls === 1) return null;
+      return original(qn, dID);
+    };
+
+    let parentID: string;
+    try {
+      const parentHandle = await DBOS.startWorkflow(SingletonTest).parentWithSingleton(dedupID);
+      await parentHandle.getResult();
+      parentID = parentHandle.workflowID;
+    } finally {
+      sysdb.getDeduplicatedWorkflow = original;
+    }
+
+    expect(SingletonTest.markerStepRuns).toBe(1);
+
+    const steps = await DBOS.listWorkflowSteps(parentID);
+    // Singleton attach doesn't record a child mapping, so the parent's only
+    // recorded operation is marker_step.
+    expect(steps?.length).toBe(1);
+    const markerStep = steps?.find((s) => s.name === 'marker_step');
+    expect(markerStep).toBeDefined();
+    // With the fix the singleton consumes one funcID (0) and marker_step lands
+    // at functionID 1. Without the fix the retry burns an extra funcID and
+    // marker_step lands at functionID 2.
+    expect(markerStep!.functionID).toBe(1);
+
+    // Fork past the final recorded step. Replay should reuse the cached
+    // marker_step output rather than re-executing it. Without the funcID fix,
+    // the original run recorded marker_step at functionID 2, but replay (no
+    // mock) burns only one funcID for the singleton and probes functionID 1 —
+    // missing the cache and re-running the step body, which would bump
+    // markerStepRuns.
+    const forkedHandle = await DBOS.forkWorkflow(parentID, markerStep!.functionID + 1);
+    await forkedHandle.getResult();
+    expect(SingletonTest.markerStepRuns).toBe(1);
+
+    const forkedSteps = await DBOS.listWorkflowSteps(forkedHandle.workflowID);
+    expect(forkedSteps?.length).toBe(1);
+    const forkedMarkerStep = forkedSteps?.find((s) => s.name === 'marker_step');
+    expect(forkedMarkerStep).toBeDefined();
+    expect(forkedMarkerStep!.functionID).toBe(markerStep!.functionID);
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1,5 +1,5 @@
 import { DBOS } from '../src';
-import { DBOSConfig } from '../src/dbos-executor';
+import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
 
 const testPolling = { minPollingIntervalMs: 100 };
@@ -110,5 +110,42 @@ describe('singleton workflows', () => {
         enqueueOptions: { deduplicationID: 'some_id', singleton: true },
       }).gatedWorkflow('y'),
     ).rejects.toThrow(/queueName/);
+  });
+
+  // Exercises the loop: the dedup_id was cleared between our failed INSERT
+  // and the lookup (i.e. the prior workflow completed mid-flight). We force
+  // the lookup to return null on its first call so the loop must retry.
+  test('retries when dedup lookup races with prior completion', async () => {
+    const dedupID = 'race_id';
+
+    const wfh1 = await DBOS.startWorkflow(SingletonTest, {
+      queueName: SingletonTest.queue.name,
+      enqueueOptions: { deduplicationID: dedupID, singleton: true },
+    }).gatedWorkflow('first');
+
+    const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
+    const original = sysdb.getDeduplicatedWorkflow.bind(sysdb);
+    let calls = 0;
+    sysdb.getDeduplicatedWorkflow = async (queueName: string, dID: string) => {
+      calls++;
+      if (calls === 1) return null;
+      return original(queueName, dID);
+    };
+
+    try {
+      const wfh2 = await DBOS.startWorkflow(SingletonTest, {
+        queueName: SingletonTest.queue.name,
+        enqueueOptions: { deduplicationID: dedupID, singleton: true },
+      }).gatedWorkflow('second');
+
+      expect(calls).toBeGreaterThanOrEqual(2);
+      expect(wfh2.workflowID).toBe(wfh1.workflowID);
+
+      SingletonTest.resolveEvent();
+      expect(await wfh1.getResult()).toBe('first-done');
+      expect(await wfh2.getResult()).toBe('first-done');
+    } finally {
+      sysdb.getDeduplicatedWorkflow = original;
+    }
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -54,7 +54,7 @@ describe('singleton workflows', () => {
       const handle = await DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
         enqueueOptions: { deduplicationID: dedupID },
-        singleton: true,
+        duplicationPolicy: 'return-existing',
       }).gatedWorkflow(childInput);
       const result = await handle.getResult();
       await DBOS.runStep(
@@ -74,13 +74,13 @@ describe('singleton workflows', () => {
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('first');
 
     const wfh2 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('second');
 
     expect(wfh2.workflowID).toBe(wfh1.workflowID);
@@ -99,7 +99,7 @@ describe('singleton workflows', () => {
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('first');
 
     SingletonTest.resolveEvent();
@@ -110,7 +110,7 @@ describe('singleton workflows', () => {
     const wfh2 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('second');
 
     expect(wfh2.workflowID).not.toBe(wfh1.workflowID);
@@ -123,7 +123,7 @@ describe('singleton workflows', () => {
     await expect(
       DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
-        singleton: true,
+        duplicationPolicy: 'return-existing',
       }).gatedWorkflow('x'),
     ).rejects.toThrow(/deduplicationID/);
   });
@@ -132,7 +132,7 @@ describe('singleton workflows', () => {
     await expect(
       DBOS.startWorkflow(SingletonTest, {
         enqueueOptions: { deduplicationID: 'some_id' },
-        singleton: true,
+        duplicationPolicy: 'return-existing',
       }).gatedWorkflow('y'),
     ).rejects.toThrow(/queueName/);
   });
@@ -146,7 +146,7 @@ describe('singleton workflows', () => {
     const wfh1 = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('first');
 
     const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
@@ -162,7 +162,7 @@ describe('singleton workflows', () => {
       const wfh2 = await DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
         enqueueOptions: { deduplicationID: dedupID },
-        singleton: true,
+        duplicationPolicy: 'return-existing',
       }).gatedWorkflow('second');
 
       expect(calls).toBe(2);
@@ -187,7 +187,7 @@ describe('singleton workflows', () => {
     const firstChildHandle = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
-      singleton: true,
+      duplicationPolicy: 'return-existing',
     }).gatedWorkflow('first');
 
     SingletonTest.markerStepRuns = 0;
@@ -301,7 +301,7 @@ describe('singleton workflows', () => {
         DBOS.startWorkflow(SingletonTest, {
           queueName: SingletonTest.queue.name,
           enqueueOptions: { deduplicationID: dedupID },
-          singleton: true,
+          duplicationPolicy: 'return-existing',
         }).gatedWorkflow('reserved'),
       );
 

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -181,7 +181,7 @@ describe('singleton workflows', () => {
     const dedupID = 'parent_singleton_id';
 
     // Pre-enqueue a child that holds the dedup slot.
-    await DBOS.startWorkflow(SingletonTest, {
+    const blockingHandle = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
       singleton: true,
@@ -212,9 +212,13 @@ describe('singleton workflows', () => {
     expect(SingletonTest.markerStepRuns).toBe(1);
 
     const steps = await DBOS.listWorkflowSteps(parentID);
-    // Singleton attach doesn't record a child mapping, so the parent's only
-    // recorded operation is marker_step.
-    expect(steps?.length).toBe(1);
+    // The parent records two operations: the singleton attach (with
+    // childWorkflowID pointing at the blocking child) at functionID 0, and
+    // marker_step at functionID 1.
+    expect(steps?.length).toBe(2);
+    const attachStep = steps?.find((s) => s.childWorkflowID === blockingHandle.workflowID);
+    expect(attachStep).toBeDefined();
+    expect(attachStep!.functionID).toBe(0);
     const markerStep = steps?.find((s) => s.name === 'marker_step');
     expect(markerStep).toBeDefined();
     // With the fix the singleton consumes one funcID (0) and marker_step lands
@@ -233,7 +237,10 @@ describe('singleton workflows', () => {
     expect(SingletonTest.markerStepRuns).toBe(1);
 
     const forkedSteps = await DBOS.listWorkflowSteps(forkedHandle.workflowID);
-    expect(forkedSteps?.length).toBe(1);
+    expect(forkedSteps?.length).toBe(2);
+    const forkedAttachStep = forkedSteps?.find((s) => s.childWorkflowID === blockingHandle.workflowID);
+    expect(forkedAttachStep).toBeDefined();
+    expect(forkedAttachStep!.functionID).toBe(attachStep!.functionID);
     const forkedMarkerStep = forkedSteps?.find((s) => s.name === 'marker_step');
     expect(forkedMarkerStep).toBeDefined();
     expect(forkedMarkerStep!.functionID).toBe(markerStep!.functionID);

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -49,12 +49,13 @@ describe('singleton workflows', () => {
     }
 
     @DBOS.workflow()
-    static async parentWithSingleton(dedupID: string): Promise<string> {
+    static async parentWithSingleton(dedupID: string, childInput: string): Promise<string> {
       const handle = await DBOS.startWorkflow(SingletonTest, {
         queueName: SingletonTest.queue.name,
         enqueueOptions: { deduplicationID: dedupID },
         singleton: true,
-      }).gatedWorkflow('attached');
+      }).gatedWorkflow(childInput);
+      const result = await handle.getResult();
       await DBOS.runStep(
         () => {
           SingletonTest.markerStepRuns++;
@@ -62,7 +63,7 @@ describe('singleton workflows', () => {
         },
         { name: 'marker_step' },
       );
-      return handle.workflowID;
+      return result;
     }
   }
 
@@ -180,12 +181,13 @@ describe('singleton workflows', () => {
   test('singleton from within a parent workflow consumes one funcID across retries', async () => {
     const dedupID = 'parent_singleton_id';
 
-    // Pre-enqueue a child that holds the dedup slot.
-    const blockingHandle = await DBOS.startWorkflow(SingletonTest, {
+    // First child holds the dedup slot. Subsequent attaches should resolve
+    // to this child's output regardless of what input they passed.
+    const firstChildHandle = await DBOS.startWorkflow(SingletonTest, {
       queueName: SingletonTest.queue.name,
       enqueueOptions: { deduplicationID: dedupID },
       singleton: true,
-    }).gatedWorkflow('blocking');
+    }).gatedWorkflow('first');
 
     SingletonTest.markerStepRuns = 0;
 
@@ -200,49 +202,72 @@ describe('singleton workflows', () => {
       return original(qn, dID);
     };
 
-    let parentID: string;
+    let parentAID: string;
+    let parentBID: string;
+    let resultA: string;
+    let resultB: string;
     try {
-      const parentHandle = await DBOS.startWorkflow(SingletonTest).parentWithSingleton(dedupID);
-      await parentHandle.getResult();
-      parentID = parentHandle.workflowID;
+      // Start two parents in flight with different child inputs. Both should
+      // attach to the blocking child via the same dedup slot and end up
+      // returning that child's output ('first-done'), not the input they
+      // themselves passed.
+      const parentA = await DBOS.startWorkflow(SingletonTest).parentWithSingleton(dedupID, 'second');
+      const parentB = await DBOS.startWorkflow(SingletonTest).parentWithSingleton(dedupID, 'third');
+      parentAID = parentA.workflowID;
+      parentBID = parentB.workflowID;
+
+      // Release the gate so the blocking child can complete; then both
+      // parents' `await handle.getResult()` resolves.
+      SingletonTest.resolveEvent();
+      resultA = await parentA.getResult();
+      resultB = await parentB.getResult();
     } finally {
       sysdb.getDeduplicatedWorkflow = original;
     }
 
-    expect(SingletonTest.markerStepRuns).toBe(1);
+    // Each parent attaches to the first child and returns its output.
+    expect(resultA).toBe('first-done');
+    expect(resultB).toBe('first-done');
 
-    const steps = await DBOS.listWorkflowSteps(parentID);
-    // The parent records two operations: the singleton attach (with
-    // childWorkflowID pointing at the blocking child) at functionID 0, and
-    // marker_step at functionID 1.
-    expect(steps?.length).toBe(2);
-    const attachStep = steps?.find((s) => s.childWorkflowID === blockingHandle.workflowID);
+    // marker_step ran exactly once per parent.
+    expect(SingletonTest.markerStepRuns).toBe(2);
+
+    const steps = await DBOS.listWorkflowSteps(parentAID);
+    // Parent A records three operations: the singleton attach (childWorkflowID
+    // points at the blocking child), the awaited child result, and marker_step.
+    expect(steps?.length).toBe(3);
+    const attachStep = steps?.find(
+      (s) => s.name !== 'marker_step' && s.childWorkflowID === firstChildHandle.workflowID,
+    );
     expect(attachStep).toBeDefined();
+    // With the fix the singleton consumes one funcID (0). Without the fix the
+    // retry burns an extra funcID and the attach lands later.
     expect(attachStep!.functionID).toBe(0);
     const markerStep = steps?.find((s) => s.name === 'marker_step');
     expect(markerStep).toBeDefined();
-    // With the fix the singleton consumes one funcID (0) and marker_step lands
-    // at functionID 1. Without the fix the retry burns an extra funcID and
-    // marker_step lands at functionID 2.
-    expect(markerStep!.functionID).toBe(1);
+    expect(markerStep!.functionID).toBe(2);
 
-    // Fork past the final recorded step. Replay should reuse the cached
-    // marker_step output rather than re-executing it. Without the funcID fix,
-    // the original run recorded marker_step at functionID 2, but replay (no
-    // mock) burns only one funcID for the singleton and probes functionID 1 —
-    // missing the cache and re-running the step body, which would bump
-    // markerStepRuns.
-    const forkedHandle = await DBOS.forkWorkflow(parentID, markerStep!.functionID + 1);
-    await forkedHandle.getResult();
-    expect(SingletonTest.markerStepRuns).toBe(1);
+    // Fork parent A past its final step. Replay should reuse all three cached
+    // operations — singleton attach, awaited result, marker_step — rather than
+    // re-executing them.
+    const forkedHandle = await DBOS.forkWorkflow<string>(parentAID, markerStep!.functionID + 1);
+    const forkedResult = await forkedHandle.getResult();
+    expect(forkedResult).toBe('first-done');
+    expect(SingletonTest.markerStepRuns).toBe(2);
 
     const forkedSteps = await DBOS.listWorkflowSteps(forkedHandle.workflowID);
-    expect(forkedSteps?.length).toBe(2);
-    const forkedAttachStep = forkedSteps?.find((s) => s.childWorkflowID === blockingHandle.workflowID);
+    expect(forkedSteps?.length).toBe(3);
+    const forkedAttachStep = forkedSteps?.find(
+      (s) => s.name !== 'marker_step' && s.childWorkflowID === firstChildHandle.workflowID,
+    );
     expect(forkedAttachStep).toBeDefined();
     expect(forkedAttachStep!.functionID).toBe(attachStep!.functionID);
     const forkedMarkerStep = forkedSteps?.find((s) => s.name === 'marker_step');
     expect(forkedMarkerStep).toBeDefined();
     expect(forkedMarkerStep!.functionID).toBe(markerStep!.functionID);
+
+    // Sanity: parent B is not used in fork checks, but its output and step
+    // count are still asserted via earlier resultB / markerStepRuns checks.
+    expect(parentBID).toBeDefined();
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -228,6 +228,7 @@ describe('singleton workflows', () => {
     // Each parent attaches to the first child and returns its output.
     expect(resultA).toBe('first-done');
     expect(resultB).toBe('first-done');
+    expect(await firstChildHandle.getResult()).toBe('first-done');
 
     // marker_step ran exactly once per parent.
     expect(SingletonTest.markerStepRuns).toBe(2);


### PR DESCRIPTION
You can now call a workflow as a "singleton" using a deduplicationID by setting `deduplicationPolicy` to `return-existing`:

```ts
const handle = DBOS.startWorkflow(Example, {
  enqueueOptions: { deduplicationID: 'some_id' },
  duplicationPolicy: 'return-existing',
}).exampleWorkflow('y'),
```

If another workflow already exists with that deduplicationID, this returns a handle to that workflow instead of throwing an exception. Thus, only one "instance" of this workflow can run at once.

Closes https://github.com/dbos-inc/dbos-transact-ts/issues/1246 and https://github.com/dbos-inc/dbos-transact-ts/issues/1107