### PR TITLE
feat: Relax direct dependency pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "packages/*"
       ],
       "dependencies": {
-        "commander": "12.0.0",
-        "pg": "8.11.3",
-        "serialize-error": "8.1.0",
+        "commander": "^12.0.0",
+        "pg": "^8.11.3",
+        "serialize-error": "^8.1.0",
         "superjson": "^1.13.3",
         "ws": "^8.18.1",
         "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "zod": "^4.3.6"
   },
   "dependencies": {
-    "commander": "12.0.0",
-    "pg": "8.11.3",
-    "serialize-error": "8.1.0",
+    "commander": "^12.0.0",
+    "pg": "^8.11.3",
+    "serialize-error": "^8.1.0",
     "superjson": "^1.13.3",
     "ws": "^8.18.1",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## Summary
- Relax exact runtime dependency pins for `pg`, `commander`, and `serialize-error`
- Keep the existing minimum versions and lockfile-resolved versions unchanged
- Allow downstream projects to install compatible semver updates

## Why
The SDK currently pins `pg` exactly to `8.11.3`, which can force downstream consumers to install or dedupe against an older `pg` version. This caused issues in a project that already uses the latest `pg@8.20.0` release, because this package’s exact pin prevented the app from cleanly resolving a compatible newer `pg` version.

Using a caret range keeps `8.11.3` as the supported lower bound while allowing compatible updates within the same major version.

## Testing
- `npm ci --ignore-scripts`
- `npm ls pg commander serialize-error`
- `npm run build`
