### PR TITLE
Improve Cancellation Semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ packages/**/package-lock.json
 CLAUDE.md
 tests/temp-dist/
 tests/temp-tests/
+.claude/
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## What is DBOS?
 
-DBOS provides lightweight durable workflows built on top of Postgres
+DBOS provides lightweight durable workflows built on top of Postgres.
 Instead of managing your own workflow orchestrator or task queue system, you can use DBOS to add durable workflows and queues to your program in just a few lines of code.
 
 To get started, follow the [quickstart](https://docs.dbos.dev/quickstart) to install this open-source library and connect it to a Postgres database.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## What is DBOS?
 
-DBOS provides lightweight durable workflows built on top of Postgres.
+DBOS provides lightweight durable workflows built on top of Postgres
 Instead of managing your own workflow orchestrator or task queue system, you can use DBOS to add durable workflows and queues to your program in just a few lines of code.
 
 To get started, follow the [quickstart](https://docs.dbos.dev/quickstart) to install this open-source library and connect it to a Postgres database.

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -799,9 +799,7 @@ export class SystemDatabase {
   async recordWorkflowOutput(workflowID: string, status: WorkflowStatusInternal): Promise<void> {
     const client = await this.pool.connect();
     try {
-      await this.updateWorkflowStatus(client, workflowID, StatusString.SUCCESS, {
-        update: { output: status.output, resetDeduplicationID: true, setCompletedAt: true },
-      });
+      await this.#recordWorkflowOutcome(client, workflowID, StatusString.SUCCESS, { output: status.output });
     } finally {
       client.release();
     }
@@ -811,11 +809,39 @@ export class SystemDatabase {
   async recordWorkflowError(workflowID: string, status: WorkflowStatusInternal): Promise<void> {
     const client = await this.pool.connect();
     try {
-      await this.updateWorkflowStatus(client, workflowID, StatusString.ERROR, {
-        update: { error: status.error, resetDeduplicationID: true, setCompletedAt: true },
-      });
+      await this.#recordWorkflowOutcome(client, workflowID, StatusString.ERROR, { error: status.error });
     } finally {
       client.release();
+    }
+  }
+
+  // Record a workflow's terminal outcome (SUCCESS or ERROR), but never overwrite
+  // the terminal CANCELLED status: a workflow can be cancelled during its final
+  // step, and if so it must not be able to subsequently complete. If the
+  // workflow is cancelled, abort the function so it does not complete. This
+  // mirrors the cancellation check done before each step.
+  async #recordWorkflowOutcome(
+    client: PoolClient,
+    workflowID: string,
+    status: (typeof StatusString)[keyof typeof StatusString],
+    outcome: { output?: string | null; error?: string | null },
+  ): Promise<void> {
+    let cancelled = false;
+    try {
+      await client.query('BEGIN');
+      await this.updateWorkflowStatus(client, workflowID, status, {
+        update: { ...outcome, resetDeduplicationID: true, setCompletedAt: true },
+        where: { notStatus: StatusString.CANCELLED },
+        throwOnFailure: false,
+      });
+      cancelled = (await this.getWorkflowStatusValue(client, workflowID)) === StatusString.CANCELLED;
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    }
+    if (cancelled) {
+      throw new DBOSWorkflowCancelledError(workflowID);
     }
   }
 
@@ -3668,6 +3694,7 @@ export class SystemDatabase {
       };
       where?: {
         status?: (typeof StatusString)[keyof typeof StatusString];
+        notStatus?: (typeof StatusString)[keyof typeof StatusString];
       };
       throwOnFailure?: boolean;
     } = {},
@@ -3731,6 +3758,10 @@ export class SystemDatabase {
     if (where.status) {
       const param = args.push(where.status);
       whereClause += ` AND status=$${param}`;
+    }
+    if (where.notStatus) {
+      const param = args.push(where.notStatus);
+      whereClause += ` AND status!=$${param}`;
     }
 
     const result = await client.query<workflow_status>(

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -348,6 +348,11 @@ describe('dbos-tests', () => {
       });
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.CANCELLED);
+      // The child is cancelled by its own inherited deadline, independently of the parent.
+      // Wait for it to settle before reading its status to avoid a race with that cancellation.
+      await expect(DBOS.retrieveWorkflow(childID).getResult()).rejects.toThrow(
+        new DBOSAwaitedWorkflowCancelledError(childID),
+      );
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -363,6 +368,11 @@ describe('dbos-tests', () => {
       await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.CANCELLED);
+      // The child is cancelled by its own inherited deadline, independently of the parent.
+      // Wait for it to settle before reading its status to avoid a race with that cancellation.
+      await expect(DBOS.retrieveWorkflow(childID).getResult()).rejects.toThrow(
+        new DBOSAwaitedWorkflowCancelledError(childID),
+      );
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -380,6 +390,11 @@ describe('dbos-tests', () => {
       });
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.CANCELLED);
+      // The child is cancelled by its own inherited deadline, independently of the parent.
+      // Wait for it to settle before reading its status to avoid a race with that cancellation.
+      await expect(DBOS.retrieveWorkflow(childID).getResult()).rejects.toThrow(
+        new DBOSAwaitedWorkflowCancelledError(childID),
+      );
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -395,6 +410,11 @@ describe('dbos-tests', () => {
       await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.CANCELLED);
+      // The child is cancelled by its own inherited deadline, independently of the parent.
+      // Wait for it to settle before reading its status to avoid a race with that cancellation.
+      await expect(DBOS.retrieveWorkflow(childID).getResult()).rejects.toThrow(
+        new DBOSAwaitedWorkflowCancelledError(childID),
+      );
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -621,9 +621,14 @@ describe('queued-wf-tests-simple', () => {
     });
     await expect(regularHandle.getResult()).resolves.toBeUndefined();
 
-    // Complete the blocked workflow
+    // Unblock the cancelled workflow's body. Even though it now runs to
+    // completion, CANCELLED is terminal: it must not overwrite CANCELLED with
+    // SUCCESS, and awaiting its result must raise.
     TestCancelQueues.blockingEvent.set();
     await expect(blockedHandle.getResult()).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
+    await expect(blockedHandle.getStatus()).resolves.toMatchObject({
+      status: StatusString.CANCELLED,
+    });
 
     // Verify all queue entries eventually get cleaned up
     expect(await queueEntriesAreCleanedUp()).toBe(true);

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -2088,7 +2088,8 @@ describe('test-fork', () => {
     await ResumeForkQueueWorkflow.step1Started.wait();
     await DBOS.cancelWorkflow(wfid);
     ResumeForkQueueWorkflow.step1Gate.set();
-    await expect(handle.getResult()).rejects.toThrow();
+    await expect(handle.getResult()).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
+    await expect(DBOS.getWorkflowStatus(wfid)).resolves.toMatchObject({ status: StatusString.CANCELLED });
     expect(ResumeForkQueueWorkflow.stepOneCount).toBe(1);
     expect(ResumeForkQueueWorkflow.stepTwoCount).toBe(0);
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -396,6 +396,32 @@ describe('workflow-management-tests', () => {
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);
   });
 
+  test('test-cancel-after-final-step', async () => {
+    // A workflow cancelled after its final step completes (but before it
+    // finishes) must not be able to complete successfully. CANCELLED is terminal.
+    TestEndpoints.stepsCompleted = 0;
+    const input = 5;
+    const wfid = randomUUID();
+
+    const cancelledHandle = await DBOS.startWorkflow(TestEndpoints, { workflowID: wfid }).cancelAfterFinalStepWorkflow(
+      input,
+    );
+    await TestEndpoints.mainThreadEvent.wait();
+    await DBOS.cancelWorkflow(wfid);
+    TestEndpoints.workflowEvent.set();
+
+    // The workflow must not complete successfully.
+    await expect(cancelledHandle.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
+    expect(TestEndpoints.stepsCompleted).toBe(1);
+    await expect(DBOS.getWorkflowStatus(wfid)).resolves.toMatchObject({ status: StatusString.CANCELLED });
+
+    // Resuming it should let it complete successfully.
+    const handle = await DBOS.resumeWorkflow<number>(wfid);
+    await expect(handle.getResult()).resolves.toBe(input);
+    await expect(DBOS.getWorkflowStatus(wfid)).resolves.toMatchObject({ status: StatusString.SUCCESS });
+    expect(TestEndpoints.stepsCompleted).toBe(1); // cancelStep was already recorded, not re-run
+  });
+
   test('getworkflows-with-completed-at', async () => {
     // Successful workflow gets completedAt set.
     const beforeSuccess = new Date().toISOString();
@@ -514,6 +540,26 @@ describe('workflow-management-tests', () => {
     @DBOS.step()
     static async stepOne() {
       return Promise.resolve();
+    }
+
+    static stepsCompleted = 0;
+    static workflowEvent = new Event();
+    static mainThreadEvent = new Event();
+
+    @DBOS.step()
+    static async cancelStep() {
+      TestEndpoints.stepsCompleted += 1;
+      return Promise.resolve();
+    }
+
+    @DBOS.workflow()
+    static async cancelAfterFinalStepWorkflow(x: number) {
+      // The only step runs and records its output...
+      await TestEndpoints.cancelStep();
+      // ...then the workflow is cancelled before it returns.
+      TestEndpoints.mainThreadEvent.set();
+      await TestEndpoints.workflowEvent.wait();
+      return x;
     }
   }
 });


### PR DESCRIPTION
Cancellation should be a terminal state. Eliminate a race condition where a workflow cancelled right before it completed would transition to "SUCCESS" or "ERROR". Now, workflows can only leave CANCELLED by being explicitly resumed.