### PR TITLE
Add configurable polling intervals for wait APIs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -45,6 +45,7 @@ module.exports = typescriptEslint.config(
       ],
       '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-empty-object-type': 'off',
     },
   },
 );

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -45,7 +45,6 @@ module.exports = typescriptEslint.config(
       ],
       '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
       '@typescript-eslint/no-floating-promises': 'error',
-      '@typescript-eslint/no-empty-object-type': 'off',
     },
   },
 );

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,8 +23,11 @@ import {
 import { cancellableSleep } from './utils';
 import {
   type GetEventOptions,
+  type PollingOptions,
+  type WaitFirstOptions,
   type SetWorkflowDelayOptions,
   type CancelWorkflowsOptions,
+  resolvePollingIntervalMs,
   resolveTimeoutSeconds,
   resolveDelayEpochMS,
 } from './dbos';
@@ -173,8 +176,15 @@ export class ClientHandle<R> implements WorkflowHandle<R> {
     return status ? toWorkflowStatus(status, this.systemDatabase.getSerializer()) : null;
   }
 
-  async getResult(): Promise<R> {
-    const res = await this.systemDatabase.awaitWorkflowResult(this.workflowID);
+  async getResult(options?: PollingOptions): Promise<R> {
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
+    const res = await this.systemDatabase.awaitWorkflowResult(
+      this.workflowID,
+      undefined,
+      undefined,
+      undefined,
+      pollingIntervalMs,
+    );
     if (res?.cancelled) {
       throw new DBOSAwaitedWorkflowCancelledError(this.workflowID);
     }
@@ -479,7 +489,8 @@ export class DBOSClient {
    */
   async getEvent<T>(workflowID: string, key: string, options?: number | GetEventOptions): Promise<T | null> {
     const timeoutSeconds = resolveTimeoutSeconds(options);
-    const evt = await this.systemDatabase.getEvent(workflowID, key, timeoutSeconds ?? 60);
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
+    const evt = await this.systemDatabase.getEvent(workflowID, key, timeoutSeconds ?? 60, undefined, pollingIntervalMs);
     return (await deserializeValue(evt.serializedValue, evt.serialization, this.serializer)) as T;
   }
 
@@ -556,7 +567,8 @@ export class DBOSClient {
     return listWorkflowSteps(this.systemDatabase, workflowID, true, options);
   }
 
-  async waitFirst(handles: WorkflowHandle<unknown>[]): Promise<WorkflowHandle<unknown>> {
+  async waitFirst(handles: WorkflowHandle<unknown>[], options?: WaitFirstOptions): Promise<WorkflowHandle<unknown>> {
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     if (handles.length === 0) {
       throw new Error('handles must not be empty');
     }
@@ -567,7 +579,11 @@ export class DBOSClient {
       }
       handleMap.set(handle.workflowID, handle);
     }
-    const completedId = await this.systemDatabase.awaitFirstWorkflowId([...handleMap.keys()]);
+    const completedId = await this.systemDatabase.awaitFirstWorkflowId(
+      [...handleMap.keys()],
+      undefined,
+      pollingIntervalMs,
+    );
     return handleMap.get(completedId)!;
   }
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -921,8 +921,9 @@ export class DBOSExecutor {
     workflowUUID: string,
     key: string,
     timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec,
+    pollingIntervalMs?: number,
   ): Promise<T | null> {
-    const evt = await this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds);
+    const evt = await this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds, undefined, pollingIntervalMs);
     return (await deserializeValue(evt.serializedValue, evt.serialization, this.serializer)) as T;
   }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -190,9 +190,37 @@ export interface WriteStreamOptions {
 }
 
 /**
+ * Options for DBOS operations that poll the system database while waiting.
+ */
+export interface PollingOptions {
+  /**
+   * Milliseconds to wait between system database polls. Must be positive and finite.
+   *
+   * This affects DB-backed polling waits. Live in-process workflow handles that await
+   * an already-running promise do not poll.
+   */
+  pollingIntervalMs?: number;
+}
+
+/**
+ * Options for `DBOS.getResult` and workflow handle `getResult`.
+ */
+export interface GetResultOptions extends PollingOptions {
+  /** Timeout in seconds; if the workflow does not complete before the timeout, `null` will be returned */
+  timeoutSeconds?: number;
+  /** Absolute deadline as a UNIX epoch timestamp in milliseconds; if the workflow does not complete before this time, `null` will be returned */
+  deadlineEpochMS?: number;
+}
+
+/**
+ * Options for `DBOS.waitFirst`.
+ */
+export interface WaitFirstOptions extends PollingOptions {}
+
+/**
  * Options for `DBOS.recv`
  */
-export interface RecvOptions {
+export interface RecvOptions extends PollingOptions {
   /** Timeout in seconds; if no message is received before the timeout (default 60 seconds), `null` will be returned */
   timeoutSeconds?: number;
   /** Absolute deadline as a UNIX epoch timestamp in milliseconds; if no message is received before this time, `null` will be returned */
@@ -202,7 +230,7 @@ export interface RecvOptions {
 /**
  * Options for `DBOS.getEvent`
  */
-export interface GetEventOptions {
+export interface GetEventOptions extends PollingOptions {
   /** Timeout in seconds; if no event is received before the timeout (default 60 seconds), `null` will be returned */
   timeoutSeconds?: number;
   /** Absolute deadline as a UNIX epoch timestamp in milliseconds; if no event is received before this time, `null` will be returned */
@@ -238,13 +266,25 @@ export interface SetEventOptions {
   serializationType?: WorkflowSerializationFormat;
 }
 
-export function resolveTimeoutSeconds(options?: number | RecvOptions | GetEventOptions): number | undefined {
+export function resolveTimeoutSeconds(
+  options?: number | RecvOptions | GetEventOptions | GetResultOptions,
+): number | undefined {
   if (options === undefined) return undefined;
   if (typeof options === 'number') return options;
   if (options.deadlineEpochMS !== undefined) {
     return Math.max(0, (options.deadlineEpochMS - Date.now()) / 1000);
   }
   return options.timeoutSeconds;
+}
+
+export function resolvePollingIntervalMs(options?: number | PollingOptions): number | undefined {
+  if (options === undefined || typeof options === 'number') return undefined;
+  const interval = options.pollingIntervalMs;
+  if (interval === undefined) return undefined;
+  if (!Number.isFinite(interval) || interval <= 0) {
+    throw new DBOSError('pollingIntervalMs must be a positive finite number');
+  }
+  return interval;
 }
 
 export function resolveDelayEpochMS(options: number | SetWorkflowDelayOptions): number {
@@ -774,14 +814,16 @@ export class DBOS {
    * @param timeoutSeconds - Maximum time to wait for result; if not provided, the operation does not time out
    * @returns The return value of the workflow, or throws the exception thrown by the workflow, or `null` if times out
    */
-  static async getResult<T>(workflowID: string, timeoutSeconds?: number): Promise<T | null> {
+  static async getResult<T>(workflowID: string, options?: number | GetResultOptions): Promise<T | null> {
     ensureDBOSIsLaunched('getResult');
+    const timeoutSeconds = resolveTimeoutSeconds(options);
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     let timerFuncID: number | undefined = undefined;
     if (DBOS.isWithinWorkflow() && timeoutSeconds !== undefined) {
       // Reserve the function ID synchronously, before any await.
       timerFuncID = functionIDGetIncrement();
     }
-    return await DBOS.getResultInternal(workflowID, timeoutSeconds, timerFuncID, undefined);
+    return await DBOS.getResultInternal(workflowID, timeoutSeconds, timerFuncID, undefined, pollingIntervalMs);
   }
 
   static async getResultInternal<T>(
@@ -789,6 +831,7 @@ export class DBOS {
     timeoutSeconds?: number,
     timerFuncID?: number,
     assignedFuncID?: number,
+    pollingIntervalMs?: number,
   ): Promise<T | null> {
     return await runInternalStep(
       async () => {
@@ -797,6 +840,7 @@ export class DBOS {
           timeoutSeconds,
           DBOS.workflowID,
           timerFuncID,
+          pollingIntervalMs,
         );
         if (!rres) return null;
         if (rres?.cancelled) {
@@ -820,8 +864,12 @@ export class DBOS {
    * @param handles - Non-empty array of workflow handles to wait on
    * @returns The first handle whose workflow has completed
    */
-  static async waitFirst(handles: WorkflowHandle<unknown>[]): Promise<WorkflowHandle<unknown>> {
+  static async waitFirst(
+    handles: WorkflowHandle<unknown>[],
+    options?: WaitFirstOptions,
+  ): Promise<WorkflowHandle<unknown>> {
     ensureDBOSIsLaunched('waitFirst');
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     if (handles.length === 0) {
       throw new Error('handles must not be empty');
     }
@@ -836,7 +884,11 @@ export class DBOS {
     const workflowIds = [...handleMap.keys()];
 
     const completedId = await runInternalStep(async () => {
-      return await DBOSExecutor.globalInstance!.systemDatabase.awaitFirstWorkflowId(workflowIds, DBOS.workflowID);
+      return await DBOSExecutor.globalInstance!.systemDatabase.awaitFirstWorkflowId(
+        workflowIds,
+        DBOS.workflowID,
+        pollingIntervalMs,
+      );
     }, 'DBOS.waitFirst');
 
     return handleMap.get(completedId)!;
@@ -1362,12 +1414,14 @@ export class DBOS {
       const functionID: number = functionIDGetIncrement();
       const timeoutFunctionID: number = functionIDGetIncrement();
       const timeoutSeconds = resolveTimeoutSeconds(options);
+      const pollingIntervalMs = resolvePollingIntervalMs(options);
       const msg = await DBOSExecutor.globalInstance!.systemDatabase.recv(
         DBOS.workflowID!,
         functionID,
         timeoutFunctionID,
         topic,
         timeoutSeconds,
+        pollingIntervalMs,
       );
 
       return (await deserializeValue(msg.serializedValue, msg.serialization, DBOS.#executor.serializer)) as T;
@@ -1426,6 +1480,7 @@ export class DBOS {
   static async getEvent<T>(workflowID: string, key: string, options?: number | GetEventOptions): Promise<T | null> {
     ensureDBOSIsLaunched('getEvent');
     const timeoutSeconds = resolveTimeoutSeconds(options);
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     if (DBOS.isWithinWorkflow()) {
       if (!DBOS.isInWorkflow()) {
         throw new DBOSInvalidWorkflowTransitionError(
@@ -1445,10 +1500,11 @@ export class DBOS {
         key,
         timeoutSeconds ?? DBOSExecutor.defaultNotificationTimeoutSec,
         params,
+        pollingIntervalMs,
       );
       return (await deserializeValue(evt.serializedValue, evt.serialization, DBOS.#executor.serializer)) as T;
     }
-    return DBOS.#executor.getEvent(workflowID, key, timeoutSeconds);
+    return DBOS.#executor.getEvent(workflowID, key, timeoutSeconds, pollingIntervalMs);
   }
 
   /**

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -215,7 +215,7 @@ export interface GetResultOptions extends PollingOptions {
 /**
  * Options for `DBOS.waitFirst`.
  */
-export interface WaitFirstOptions extends PollingOptions {}
+export type WaitFirstOptions = PollingOptions;
 
 /**
  * Options for `DBOS.recv`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-export { DBOS, RecvOptions, GetEventOptions, SetWorkflowDelayOptions } from './dbos';
+export {
+  DBOS,
+  RecvOptions,
+  GetEventOptions,
+  GetResultOptions,
+  PollingOptions,
+  WaitFirstOptions,
+  SetWorkflowDelayOptions,
+} from './dbos';
 
 export { DBOSClient } from './client';
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1703,9 +1703,11 @@ export class SystemDatabase {
     timeoutSeconds?: number,
     callerID?: string,
     timerFuncID?: number,
+    pollingIntervalMs?: number,
   ): Promise<SystemDatabaseStoredResult | undefined> {
     const timeoutms = timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined;
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
+    const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
       let resolveNotification: () => void;
@@ -1758,14 +1760,14 @@ export class SystemDatabase {
             callerID,
             timerFuncID,
             timeoutms,
-            this.dbPollingIntervalResultMs,
+            pollIntervalMs,
           );
           finishTime = endTime;
           timeoutPromise = promise;
           timeoutCancel = cancel;
         } else {
-          let poll = finishTime ? finishTime - ct : this.dbPollingIntervalResultMs;
-          poll = Math.min(this.dbPollingIntervalResultMs, poll);
+          let poll = finishTime ? finishTime - ct : pollIntervalMs;
+          poll = Math.min(pollIntervalMs, poll);
           const { promise, cancel } = cancellableSleep(poll);
           timeoutPromise = promise;
           timeoutCancel = cancel;
@@ -1784,8 +1786,9 @@ export class SystemDatabase {
   }
 
   @dbRetry()
-  async awaitFirstWorkflowId(workflowIds: string[], callerID?: string): Promise<string> {
+  async awaitFirstWorkflowId(workflowIds: string[], callerID?: string, pollingIntervalMs?: number): Promise<string> {
     const placeholders = workflowIds.map((_, i) => `$${i + 1}`).join(', ');
+    const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
       let resolveNotification: () => void;
@@ -1816,7 +1819,7 @@ export class SystemDatabase {
           return rows[0].workflow_uuid;
         }
 
-        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(this.dbPollingIntervalResultMs);
+        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
         try {
           await Promise.race([wakeupPromise, sleepPromise]);
         } finally {
@@ -1939,6 +1942,7 @@ export class SystemDatabase {
     timeoutFunctionID: number,
     topic?: string,
     timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec,
+    pollingIntervalMs?: number,
   ): Promise<{ serializedValue: string | null; serialization: string | null }> {
     topic = topic ?? this.nullTopic;
     const startTime = Date.now();
@@ -1953,6 +1957,7 @@ export class SystemDatabase {
 
     const timeoutms = timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined;
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
+    const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalEventMs;
 
     while (true) {
       // register the key with the global notifications listener.
@@ -1989,14 +1994,14 @@ export class SystemDatabase {
             workflowID,
             timeoutFunctionID,
             timeoutms,
-            this.dbPollingIntervalEventMs,
+            pollIntervalMs,
           );
           timeoutPromise = promise;
           timeoutCancel = cancel;
           finishTime = endTime;
         } else {
-          let poll = finishTime ? finishTime - ct : this.dbPollingIntervalEventMs;
-          poll = Math.min(this.dbPollingIntervalEventMs, poll);
+          let poll = finishTime ? finishTime - ct : pollIntervalMs;
+          poll = Math.min(pollIntervalMs, poll);
           const { promise, cancel } = cancellableSleep(poll);
           timeoutPromise = promise;
           timeoutCancel = cancel;
@@ -2121,6 +2126,7 @@ export class SystemDatabase {
       functionID: number;
       timeoutFunctionID: number;
     },
+    pollingIntervalMs?: number,
   ): Promise<{ serializedValue: string | null; serialization: string | null }> {
     const startTime = Date.now();
     // Check if the operation has been done before for OAOO (only do this inside a workflow).
@@ -2148,6 +2154,7 @@ export class SystemDatabase {
     const payloadKey = `${workflowID}::${key}`;
     const timeoutms = timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined;
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
+    const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalEventMs;
 
     // Register the key with the global notifications listener first... we do not want to look in the DB first
     //  or that would cause a timing hole.
@@ -2192,14 +2199,14 @@ export class SystemDatabase {
             callerWorkflow.workflowID,
             callerWorkflow.timeoutFunctionID ?? -1,
             timeoutms,
-            this.dbPollingIntervalEventMs,
+            pollIntervalMs,
           );
           timeoutPromise = promise;
           timeoutCancel = cancel;
           finishTime = endTime;
         } else {
-          let poll = finishTime ? finishTime - ct : this.dbPollingIntervalEventMs;
-          poll = Math.min(this.dbPollingIntervalEventMs, poll);
+          let poll = finishTime ? finishTime - ct : pollIntervalMs;
+          poll = Math.min(pollIntervalMs, poll);
           const { promise, cancel } = cancellableSleep(poll);
           timeoutPromise = promise;
           timeoutCancel = cancel;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -2,7 +2,7 @@
 import { type SystemDatabase, WorkflowStatusInternal } from './system_database';
 import { ConfiguredInstance } from './decorators';
 import { deserializePositionalArgs, registerSerializationRecipe } from './serialization';
-import { DBOS, runInternalStep } from './dbos';
+import { DBOS, resolvePollingIntervalMs, runInternalStep, type PollingOptions } from './dbos';
 import { DuplicationPolicy, EnqueueOptions } from './system_database';
 import { DBOSExecutor } from './dbos-executor';
 
@@ -220,7 +220,7 @@ export interface WorkflowHandle<R> {
   /**
    * Await workflow completion and return its result.
    */
-  getResult(): Promise<R>;
+  getResult(options?: PollingOptions): Promise<R>;
   /**
    * Return the workflow's ID
    */
@@ -232,7 +232,7 @@ export interface WorkflowHandle<R> {
 }
 
 export interface InternalWFHandle<R> extends WorkflowHandle<R> {
-  getResult(funcIdForGet?: number): Promise<R>;
+  getResult(optionsOrFuncIdForGet?: PollingOptions | number): Promise<R>;
 }
 
 /**
@@ -258,7 +258,9 @@ export class InvokedHandle<R> implements InternalWFHandle<R> {
     return await DBOS.getWorkflowStatus(this.workflowUUID);
   }
 
-  async getResult(funcIdForGet?: number): Promise<R> {
+  async getResult(optionsOrFuncIdForGet?: PollingOptions | number): Promise<R> {
+    const funcIdForGet = typeof optionsOrFuncIdForGet === 'number' ? optionsOrFuncIdForGet : undefined;
+    resolvePollingIntervalMs(optionsOrFuncIdForGet);
     return await runInternalStep(
       async () => {
         return await this.workflowPromise;
@@ -300,8 +302,16 @@ export class RetrievedHandle<R> implements InternalWFHandle<R> {
     return await DBOS.getWorkflowStatus(this.workflowUUID);
   }
 
-  async getResult(funcIdForGet?: number): Promise<R> {
-    return (await DBOS.getResultInternal<R>(this.workflowUUID, undefined, undefined, funcIdForGet)) as Promise<R>;
+  async getResult(optionsOrFuncIdForGet?: PollingOptions | number): Promise<R> {
+    const funcIdForGet = typeof optionsOrFuncIdForGet === 'number' ? optionsOrFuncIdForGet : undefined;
+    const pollingIntervalMs = resolvePollingIntervalMs(optionsOrFuncIdForGet);
+    return (await DBOS.getResultInternal<R>(
+      this.workflowUUID,
+      undefined,
+      undefined,
+      funcIdForGet,
+      pollingIntervalMs,
+    )) as Promise<R>;
   }
 
   async getWorkflowInputs<T extends any[]>(): Promise<T> {

--- a/tests/sysdb_pg.test.ts
+++ b/tests/sysdb_pg.test.ts
@@ -2,7 +2,7 @@
 //  Basically, will it function without notifications, by falling back to polling?
 //  Does the notification work if polling is so slow as to be discounted?
 
-import { DBOS, DBOSConfig } from '../src';
+import { DBOS, DBOSClient, DBOSConfig } from '../src';
 import { DBOSExecutor } from '../src/dbos-executor';
 import { DBOSWorkflowCancelledError } from '../src/error';
 import { sleepms } from '../src/utils';
@@ -22,6 +22,11 @@ class PGSDBTests {
   }
 
   @DBOS.workflow()
+  static async doRecvWithOptions(topic: string, timeout: number, pollingIntervalMs: number) {
+    return await DBOS.recv(topic, { timeoutSeconds: timeout, pollingIntervalMs });
+  }
+
+  @DBOS.workflow()
   static async doSend(wfid: string, topic: string, msg: string, delay?: number) {
     if (delay) await sleepms(delay);
     return await DBOS.send(wfid, msg, topic);
@@ -30,6 +35,11 @@ class PGSDBTests {
   @DBOS.workflow()
   static async doGetEvent(wfid: string, topic: string, timeout: number) {
     return await DBOS.getEvent(wfid, topic, timeout);
+  }
+
+  @DBOS.workflow()
+  static async doGetEventWithOptions(wfid: string, topic: string, timeout: number, pollingIntervalMs: number) {
+    return await DBOS.getEvent(wfid, topic, { timeoutSeconds: timeout, pollingIntervalMs });
   }
 
   @DBOS.workflow()
@@ -47,6 +57,11 @@ class PGSDBTests {
   @DBOS.workflow()
   static async doGetResult(wfid: string, timeout: number) {
     return await DBOS.getResult(wfid, timeout);
+  }
+
+  @DBOS.workflow()
+  static async doGetResultWithOptions(wfid: string, timeout: number, pollingIntervalMs: number) {
+    return await DBOS.getResult(wfid, { timeoutSeconds: timeout, pollingIntervalMs });
   }
 
   @DBOS.workflow()
@@ -283,5 +298,188 @@ describe('sysdb-no-listen-notify', () => {
     await doTheWFDelayedTest();
 
     await doTheWFCancelTest();
+  });
+
+  test('per-call-polling-interval-options', async () => {
+    expect(sysDB().shouldUseDBNotifications).toBe(false);
+    const previousResultInterval = sysDB().dbPollingIntervalResultMs;
+    const previousEventInterval = sysDB().dbPollingIntervalEventMs;
+    sysDB().dbPollingIntervalResultMs = 5000;
+    sysDB().dbPollingIntervalEventMs = 5000;
+
+    const assertQuick = (start: number) => {
+      expect(Date.now() - start).toBeLessThan(1000);
+    };
+
+    try {
+      let ct = Date.now();
+      const resultWorkflowID = randomUUID();
+      const resultHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: resultWorkflowID }).returnAResult(
+        'result',
+        100,
+      );
+      await expect(DBOS.getResult(resultWorkflowID, { pollingIntervalMs: 50 })).resolves.toBe('result');
+      assertQuick(ct);
+      await resultHandle.getResult({ pollingIntervalMs: 50 });
+
+      ct = Date.now();
+      const retrievedWorkflowID = randomUUID();
+      const retrievedHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: retrievedWorkflowID }).returnAResult(
+        'retrieved',
+        100,
+      );
+      await expect(
+        DBOS.retrieveWorkflow<string>(retrievedWorkflowID).getResult({ pollingIntervalMs: 50 }),
+      ).resolves.toBe('retrieved');
+      assertQuick(ct);
+      await retrievedHandle.getResult({ pollingIntervalMs: 50 });
+
+      ct = Date.now();
+      const waitedWorkflowID = randomUUID();
+      const waitedHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: waitedWorkflowID }).returnAResult(
+        'waited',
+        100,
+      );
+      const completed = await DBOS.waitFirst([DBOS.retrieveWorkflow(waitedWorkflowID)], { pollingIntervalMs: 50 });
+      expect(completed.workflowID).toBe(waitedWorkflowID);
+      assertQuick(ct);
+      await waitedHandle.getResult({ pollingIntervalMs: 50 });
+
+      ct = Date.now();
+      const eventWorkflowID = randomUUID();
+      const eventHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: eventWorkflowID }).doSetEvent(
+        'key',
+        'value',
+        100,
+      );
+      await expect(DBOS.getEvent(eventWorkflowID, 'key', { timeoutSeconds: 5, pollingIntervalMs: 50 })).resolves.toBe(
+        'value',
+      );
+      assertQuick(ct);
+      await eventHandle.getResult({ pollingIntervalMs: 50 });
+
+      ct = Date.now();
+      const recvWorkflowID = randomUUID();
+      const recvHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: recvWorkflowID }).doRecvWithOptions(
+        'topic',
+        5,
+        50,
+      );
+      await sleepms(100);
+      await DBOS.send(recvWorkflowID, 'message', 'topic');
+      await expect(recvHandle.getResult({ pollingIntervalMs: 50 })).resolves.toBe('message');
+      assertQuick(ct);
+
+      const workflowGetResultTargetID = randomUUID();
+      const workflowGetResultTarget = await DBOS.startWorkflow(PGSDBTests, {
+        workflowID: workflowGetResultTargetID,
+      }).returnAResult('workflow-get-result', 100);
+      ct = Date.now();
+      const workflowGetResultHandle = await DBOS.startWorkflow(PGSDBTests).doGetResultWithOptions(
+        workflowGetResultTargetID,
+        5,
+        50,
+      );
+      await expect(workflowGetResultHandle.getResult({ pollingIntervalMs: 50 })).resolves.toBe('workflow-get-result');
+      assertQuick(ct);
+      await workflowGetResultTarget.getResult({ pollingIntervalMs: 50 });
+
+      const workflowGetEventTargetID = randomUUID();
+      const workflowGetEventSetter = await DBOS.startWorkflow(PGSDBTests, {
+        workflowID: workflowGetEventTargetID,
+      }).doSetEvent('workflow-key', 'workflow-event', 100);
+      ct = Date.now();
+      const workflowGetEventHandle = await DBOS.startWorkflow(PGSDBTests).doGetEventWithOptions(
+        workflowGetEventTargetID,
+        'workflow-key',
+        5,
+        50,
+      );
+      await expect(workflowGetEventHandle.getResult({ pollingIntervalMs: 50 })).resolves.toBe('workflow-event');
+      assertQuick(ct);
+      await workflowGetEventSetter.getResult({ pollingIntervalMs: 50 });
+
+      const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+      try {
+        ct = Date.now();
+        const clientResultWorkflowID = randomUUID();
+        const clientResultHandle = await DBOS.startWorkflow(PGSDBTests, {
+          workflowID: clientResultWorkflowID,
+        }).returnAResult('client-result', 100);
+        await expect(
+          client.retrieveWorkflow<string>(clientResultWorkflowID).getResult({ pollingIntervalMs: 50 }),
+        ).resolves.toBe('client-result');
+        assertQuick(ct);
+        await clientResultHandle.getResult({ pollingIntervalMs: 50 });
+
+        ct = Date.now();
+        const clientWaitWorkflowID = randomUUID();
+        const clientWaitHandle = await DBOS.startWorkflow(PGSDBTests, {
+          workflowID: clientWaitWorkflowID,
+        }).returnAResult('client-wait', 100);
+        const clientCompleted = await client.waitFirst([client.retrieveWorkflow(clientWaitWorkflowID)], {
+          pollingIntervalMs: 50,
+        });
+        expect(clientCompleted.workflowID).toBe(clientWaitWorkflowID);
+        assertQuick(ct);
+        await clientWaitHandle.getResult({ pollingIntervalMs: 50 });
+
+        ct = Date.now();
+        const clientEventWorkflowID = randomUUID();
+        const clientEventHandle = await DBOS.startWorkflow(PGSDBTests, {
+          workflowID: clientEventWorkflowID,
+        }).doSetEvent('client-key', 'client-event', 100);
+        await expect(
+          client.getEvent(clientEventWorkflowID, 'client-key', { timeoutSeconds: 5, pollingIntervalMs: 50 }),
+        ).resolves.toBe('client-event');
+        assertQuick(ct);
+        await clientEventHandle.getResult({ pollingIntervalMs: 50 });
+      } finally {
+        await client.destroy();
+      }
+    } finally {
+      sysDB().dbPollingIntervalResultMs = previousResultInterval;
+      sysDB().dbPollingIntervalEventMs = previousEventInterval;
+    }
+  });
+
+  test('invalid-polling-interval-options', async () => {
+    const invalidIntervals = [0, -1, Number.NaN, Number.POSITIVE_INFINITY];
+    const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+    try {
+      for (const pollingIntervalMs of invalidIntervals) {
+        await expect(DBOS.getResult(randomUUID(), { timeoutSeconds: 0, pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(DBOS.getEvent(randomUUID(), 'key', { timeoutSeconds: 0, pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(DBOS.waitFirst([DBOS.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(DBOS.retrieveWorkflow(randomUUID()).getResult({ pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        const invalidRecvHandle = await DBOS.startWorkflow(PGSDBTests).doRecvWithOptions(
+          'invalid',
+          0,
+          pollingIntervalMs,
+        );
+        await expect(invalidRecvHandle.getResult({ pollingIntervalMs: 50 })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(client.retrieveWorkflow(randomUUID()).getResult({ pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(client.getEvent(randomUUID(), 'key', { timeoutSeconds: 0, pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(client.waitFirst([client.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+      }
+    } finally {
+      await client.destroy();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add per-call pollingIntervalMs options for DBOS result, waitFirst, recv, and getEvent APIs
- thread the interval through system database polling and durable sleep waits while preserving numeric timeout compatibility
- add coverage for DBOS, workflow handle, and DBOSClient polling options plus validation errors
