### PR TITLE
Add waitAll workflow handle API

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,7 @@ import {
   type GetEventOptions,
   type PollingOptions,
   type WaitFirstOptions,
+  type WaitAllOptions,
   type SetWorkflowDelayOptions,
   type CancelWorkflowsOptions,
   resolvePollingIntervalMs,
@@ -587,12 +588,13 @@ export class DBOSClient {
     return handleMap.get(completedId)!;
   }
 
-  async waitAll<R>(handles: WorkflowHandle<R>[]): Promise<WorkflowHandle<R>[]> {
+  async waitAll<R>(handles: WorkflowHandle<R>[], options?: WaitAllOptions): Promise<WorkflowHandle<R>[]> {
     if (handles.length === 0) {
       return [];
     }
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     const workflowIds = [...new Set(handles.map((handle) => handle.workflowID))];
-    await this.systemDatabase.awaitWorkflowIds(workflowIds);
+    await this.systemDatabase.awaitWorkflowIds(workflowIds, undefined, pollingIntervalMs);
     return handles;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -571,6 +571,15 @@ export class DBOSClient {
     return handleMap.get(completedId)!;
   }
 
+  async waitAll<R>(handles: WorkflowHandle<R>[]): Promise<WorkflowHandle<R>[]> {
+    if (handles.length === 0) {
+      return [];
+    }
+    const workflowIds = [...new Set(handles.map((handle) => handle.workflowID))];
+    await this.systemDatabase.awaitWorkflowIds(workflowIds);
+    return handles;
+  }
+
   /**
    * Read values from a stream as an async generator.
    * This function reads values from a stream identified by the workflowID and key,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -843,6 +843,26 @@ export class DBOS {
   }
 
   /**
+   * Wait for all of the given workflow handles to complete and return them.
+   * Polls the database until each workflow's status is no longer PENDING, ENQUEUED, or DELAYED.
+   * @param handles - Array of workflow handles to wait on
+   * @returns The input handles, in the same order
+   */
+  static async waitAll<R>(handles: WorkflowHandle<R>[]): Promise<WorkflowHandle<R>[]> {
+    ensureDBOSIsLaunched('waitAll');
+    if (handles.length === 0) {
+      return [];
+    }
+    const workflowIds = [...new Set(handles.map((handle) => handle.workflowID))];
+
+    await runInternalStep(async () => {
+      await DBOSExecutor.globalInstance!.systemDatabase.awaitWorkflowIds(workflowIds, DBOS.workflowID);
+    }, 'DBOS.waitAll');
+
+    return handles;
+  }
+
+  /**
    * Create a workflow handle with a given workflow ID.
    * This call always returns a handle, even if the workflow does not exist.
    * The resulting handle will check the database to provide any workflow information.

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -218,6 +218,11 @@ export interface GetResultOptions extends PollingOptions {
 export type WaitFirstOptions = PollingOptions;
 
 /**
+ * Options for `DBOS.waitAll`.
+ */
+export type WaitAllOptions = PollingOptions;
+
+/**
  * Options for `DBOS.recv`
  */
 export interface RecvOptions extends PollingOptions {
@@ -898,17 +903,23 @@ export class DBOS {
    * Wait for all of the given workflow handles to complete and return them.
    * Polls the database until each workflow's status is no longer PENDING, ENQUEUED, or DELAYED.
    * @param handles - Array of workflow handles to wait on
+   * @param options - Optional polling interval
    * @returns The input handles, in the same order
    */
-  static async waitAll<R>(handles: WorkflowHandle<R>[]): Promise<WorkflowHandle<R>[]> {
+  static async waitAll<R>(handles: WorkflowHandle<R>[], options?: WaitAllOptions): Promise<WorkflowHandle<R>[]> {
     ensureDBOSIsLaunched('waitAll');
     if (handles.length === 0) {
       return [];
     }
+    const pollingIntervalMs = resolvePollingIntervalMs(options);
     const workflowIds = [...new Set(handles.map((handle) => handle.workflowID))];
 
     await runInternalStep(async () => {
-      await DBOSExecutor.globalInstance!.systemDatabase.awaitWorkflowIds(workflowIds, DBOS.workflowID);
+      await DBOSExecutor.globalInstance!.systemDatabase.awaitWorkflowIds(
+        workflowIds,
+        DBOS.workflowID,
+        pollingIntervalMs,
+      );
     }, 'DBOS.waitAll');
 
     return handles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   GetResultOptions,
   PollingOptions,
   WaitFirstOptions,
+  WaitAllOptions,
   SetWorkflowDelayOptions,
 } from './dbos';
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1831,6 +1831,57 @@ export class SystemDatabase {
     }
   }
 
+  @dbRetry()
+  async awaitWorkflowIds(workflowIds: string[], callerID?: string): Promise<void> {
+    const remainingWorkflowIds = new Set(workflowIds);
+
+    while (remainingWorkflowIds.size > 0) {
+      let resolveNotification: () => void;
+      const wakeupPromise = new Promise<void>((resolve) => {
+        resolveNotification = resolve;
+      });
+      const currentWorkflowIds = [...remainingWorkflowIds];
+
+      // Register cancel callbacks for all remaining target workflows and the caller.
+      const cbHandles = currentWorkflowIds.map((wfid) =>
+        this.cancelWakeupMap.registerCallback(wfid, () => resolveNotification!()),
+      );
+      const callerCbHandle = callerID
+        ? this.cancelWakeupMap.registerCallback(callerID, () => resolveNotification!())
+        : undefined;
+
+      try {
+        if (callerID) await this.checkIfCanceled(callerID);
+
+        const { rows } = await this.pool.query<{ workflow_uuid: string }>(
+          `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
+           WHERE workflow_uuid = ANY($1::text[])
+             AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')`,
+          [currentWorkflowIds],
+        );
+
+        for (const row of rows) {
+          remainingWorkflowIds.delete(row.workflow_uuid);
+        }
+        if (remainingWorkflowIds.size === 0) {
+          return;
+        }
+
+        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(this.dbPollingIntervalResultMs);
+        try {
+          await Promise.race([wakeupPromise, sleepPromise]);
+        } finally {
+          sleepCancel();
+        }
+      } finally {
+        for (const h of cbHandles) {
+          this.cancelWakeupMap.deregisterCallback(h);
+        }
+        if (callerCbHandle) this.cancelWakeupMap.deregisterCallback(callerCbHandle);
+      }
+    }
+  }
+
   // ==================== Sleep ====================
   @dbRetry()
   async durableSleepms(workflowID: string, functionID: number, durationMS: number): Promise<void> {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1861,8 +1861,9 @@ export class SystemDatabase {
   }
 
   @dbRetry()
-  async awaitWorkflowIds(workflowIds: string[], callerID?: string): Promise<void> {
+  async awaitWorkflowIds(workflowIds: string[], callerID?: string, pollingIntervalMs?: number): Promise<void> {
     const remainingWorkflowIds = new Set(workflowIds);
+    const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (remainingWorkflowIds.size > 0) {
       let resolveNotification: () => void;
@@ -1896,7 +1897,7 @@ export class SystemDatabase {
           return;
         }
 
-        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(this.dbPollingIntervalResultMs);
+        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
         try {
           await Promise.race([wakeupPromise, sleepPromise]);
         } finally {

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -529,8 +529,66 @@ describe('dbos-tests', () => {
       }
     });
 
+    test('test_wait_all', async () => {
+      const handleFast = await DBOS.startWorkflow(WaitFirstTestClass).fastWorkflow();
+      const handleSlow = await DBOS.startWorkflow(WaitFirstTestClass).slowWorkflow();
+      const handles = [handleSlow, handleFast, handleFast];
+
+      const resultHandles = await DBOS.waitAll(handles);
+      expect(resultHandles).toHaveLength(handles.length);
+      expect(resultHandles[0]).toBe(handleSlow);
+      expect(resultHandles[1]).toBe(handleFast);
+      expect(resultHandles[2]).toBe(handleFast);
+      await expect(handleFast.getStatus()).resolves.toMatchObject({ status: StatusString.SUCCESS });
+      await expect(handleSlow.getStatus()).resolves.toMatchObject({ status: StatusString.SUCCESS });
+
+      const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+      try {
+        const handleFast2 = await DBOS.startWorkflow(WaitFirstTestClass).fastWorkflow();
+        const handleSlow2 = await DBOS.startWorkflow(WaitFirstTestClass).slowWorkflow();
+        const clientHandleFast = client.retrieveWorkflow(handleFast2.workflowID);
+        const clientHandleSlow = client.retrieveWorkflow(handleSlow2.workflowID);
+        const clientHandles = [clientHandleSlow, clientHandleFast, clientHandleFast];
+
+        const clientResultHandles = await client.waitAll(clientHandles);
+        expect(clientResultHandles).toHaveLength(clientHandles.length);
+        expect(clientResultHandles[0]).toBe(clientHandleSlow);
+        expect(clientResultHandles[1]).toBe(clientHandleFast);
+        expect(clientResultHandles[2]).toBe(clientHandleFast);
+        await expect(clientHandleFast.getStatus()).resolves.toMatchObject({ status: StatusString.SUCCESS });
+        await expect(clientHandleSlow.getStatus()).resolves.toMatchObject({ status: StatusString.SUCCESS });
+      } finally {
+        await client.destroy();
+      }
+    });
+
     test('test_wait_first_empty', async () => {
       await expect(DBOS.waitFirst([])).rejects.toThrow('handles must not be empty');
+    });
+
+    test('test_wait_all_empty', async () => {
+      await expect(DBOS.waitAll([])).resolves.toEqual([]);
+
+      const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+      try {
+        await expect(client.waitAll([])).resolves.toEqual([]);
+      } finally {
+        await client.destroy();
+      }
+    });
+
+    test('test_wait_all_inside_workflow', async () => {
+      const handleFast = await DBOS.startWorkflow(WaitFirstTestClass).fastWorkflow();
+      const handleSlow = await DBOS.startWorkflow(WaitFirstTestClass).slowWorkflow();
+      const workflowID = randomUUID();
+      const waitHandle = await DBOS.startWorkflow(WaitFirstTestClass, { workflowID }).waitAllWorkflow([
+        handleSlow.workflowID,
+        handleFast.workflowID,
+      ]);
+
+      await expect(waitHandle.getResult()).resolves.toEqual([handleSlow.workflowID, handleFast.workflowID]);
+      const steps = await DBOS.listWorkflowSteps(workflowID);
+      expect(steps?.map((step) => step.name)).toContain('DBOS.waitAll');
     });
 
     // This test should run last in the block as it changes some global state
@@ -637,6 +695,13 @@ class WaitFirstTestClass {
   static async slowWorkflow() {
     await DBOS.sleep(2);
     return 'slow';
+  }
+
+  @DBOS.workflow()
+  static async waitAllWorkflow(workflowIDs: string[]) {
+    const handles = workflowIDs.map((workflowID) => DBOS.retrieveWorkflow<string>(workflowID));
+    const resultHandles = await DBOS.waitAll(handles);
+    return resultHandles.map((handle) => handle.workflowID);
   }
 }
 

--- a/tests/sysdb_pg.test.ts
+++ b/tests/sysdb_pg.test.ts
@@ -387,6 +387,17 @@ describe('sysdb-no-listen-notify', () => {
       await waitedHandle.getResult({ pollingIntervalMs: 50 });
 
       ct = Date.now();
+      const waitAllWorkflowID = randomUUID();
+      const waitAllHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: waitAllWorkflowID }).returnAResult(
+        'wait-all',
+        100,
+      );
+      const waitAllResult = await DBOS.waitAll([DBOS.retrieveWorkflow(waitAllWorkflowID)], { pollingIntervalMs: 50 });
+      expect(waitAllResult.map((handle) => handle.workflowID)).toEqual([waitAllWorkflowID]);
+      assertQuick(ct);
+      await waitAllHandle.getResult({ pollingIntervalMs: 50 });
+
+      ct = Date.now();
       const eventWorkflowID = randomUUID();
       const eventHandle = await DBOS.startWorkflow(PGSDBTests, { workflowID: eventWorkflowID }).doSetEvent(
         'key',
@@ -466,6 +477,18 @@ describe('sysdb-no-listen-notify', () => {
         await clientWaitHandle.getResult({ pollingIntervalMs: 50 });
 
         ct = Date.now();
+        const clientWaitAllWorkflowID = randomUUID();
+        const clientWaitAllHandle = await DBOS.startWorkflow(PGSDBTests, {
+          workflowID: clientWaitAllWorkflowID,
+        }).returnAResult('client-wait-all', 100);
+        const clientWaitAllResult = await client.waitAll([client.retrieveWorkflow(clientWaitAllWorkflowID)], {
+          pollingIntervalMs: 50,
+        });
+        expect(clientWaitAllResult.map((handle) => handle.workflowID)).toEqual([clientWaitAllWorkflowID]);
+        assertQuick(ct);
+        await clientWaitAllHandle.getResult({ pollingIntervalMs: 50 });
+
+        ct = Date.now();
         const clientEventWorkflowID = randomUUID();
         const clientEventHandle = await DBOS.startWorkflow(PGSDBTests, {
           workflowID: clientEventWorkflowID,
@@ -498,6 +521,9 @@ describe('sysdb-no-listen-notify', () => {
         await expect(DBOS.waitFirst([DBOS.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
           'pollingIntervalMs must be a positive finite number',
         );
+        await expect(DBOS.waitAll([DBOS.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
         await expect(DBOS.retrieveWorkflow(randomUUID()).getResult({ pollingIntervalMs })).rejects.toThrow(
           'pollingIntervalMs must be a positive finite number',
         );
@@ -516,6 +542,9 @@ describe('sysdb-no-listen-notify', () => {
           'pollingIntervalMs must be a positive finite number',
         );
         await expect(client.waitFirst([client.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
+          'pollingIntervalMs must be a positive finite number',
+        );
+        await expect(client.waitAll([client.retrieveWorkflow(randomUUID())], { pollingIntervalMs })).rejects.toThrow(
           'pollingIntervalMs must be a positive finite number',
         );
       }

--- a/tests/sysdb_pg.test.ts
+++ b/tests/sysdb_pg.test.ts
@@ -50,6 +50,13 @@ class PGSDBTests {
   }
 
   @DBOS.workflow()
+  static async doWaitAll(wfids: string[]) {
+    const handles = wfids.map((wfid) => DBOS.retrieveWorkflow<string>(wfid));
+    const resultHandles = await DBOS.waitAll(handles);
+    return resultHandles.map((handle) => handle.workflowID);
+  }
+
+  @DBOS.workflow()
   static async doRecvFromChild() {
     await PGSDBTests.doSend(DBOS.workflowID!, 'topic', 'msg');
     const ct = Date.now();
@@ -283,5 +290,39 @@ describe('sysdb-no-listen-notify', () => {
     await doTheWFDelayedTest();
 
     await doTheWFCancelTest();
+  });
+
+  test('wait-all-without-listen-notify', async () => {
+    expect(sysDB().shouldUseDBNotifications).toBe(false);
+    const previousResultInterval = sysDB().dbPollingIntervalResultMs;
+    sysDB().dbPollingIntervalResultMs = 100;
+
+    try {
+      const wfid1 = randomUUID();
+      const wfid2 = randomUUID();
+      const handle1 = await DBOS.startWorkflow(PGSDBTests, { workflowID: wfid1 }).returnAResult('one', 100);
+      const handle2 = await DBOS.startWorkflow(PGSDBTests, { workflowID: wfid2 }).returnAResult('two', 200);
+      let ct = Date.now();
+      const resultHandles = await DBOS.waitAll([DBOS.retrieveWorkflow(wfid2), DBOS.retrieveWorkflow(wfid1)]);
+
+      expect(resultHandles.map((handle) => handle.workflowID)).toEqual([wfid2, wfid1]);
+      expect(Date.now() - ct).toBeLessThan(2000);
+      await expect(handle1.getStatus()).resolves.toMatchObject({ status: 'SUCCESS' });
+      await expect(handle2.getStatus()).resolves.toMatchObject({ status: 'SUCCESS' });
+
+      const wfid3 = randomUUID();
+      const wfid4 = randomUUID();
+      const handle3 = await DBOS.startWorkflow(PGSDBTests, { workflowID: wfid3 }).returnAResult('three', 100);
+      const handle4 = await DBOS.startWorkflow(PGSDBTests, { workflowID: wfid4 }).returnAResult('four', 200);
+      ct = Date.now();
+      const waitHandle = await DBOS.startWorkflow(PGSDBTests).doWaitAll([wfid4, wfid3]);
+
+      await expect(waitHandle.getResult()).resolves.toEqual([wfid4, wfid3]);
+      expect(Date.now() - ct).toBeLessThan(2000);
+      await expect(handle3.getStatus()).resolves.toMatchObject({ status: 'SUCCESS' });
+      await expect(handle4.getStatus()).resolves.toMatchObject({ status: 'SUCCESS' });
+    } finally {
+      sysDB().dbPollingIntervalResultMs = previousResultInterval;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add DBOS.waitAll(handles) and DBOSClient.waitAll(handles)
- add a batched SystemDatabase.awaitWorkflowIds helper that waits until all unique workflow IDs are no longer PENDING, ENQUEUED, or DELAYED
- preserve input handle order and duplicate handles in the returned array
- add DBOS, DBOSClient, workflow-internal, empty input, duplicate handle, and no-LISTEN/NOTIFY polling coverage

## Why this is a DBOS API instead of userland
High fan-out workflows often need to wait for many child workflows to leave active states, but doing this with Promise.all(handles.map(h => h.getResult())) creates one pending result waiter per child. In polling-backed environments, that can multiply DBOS metadata polling and put avoidable pressure on the system database pool before the results are even needed.

A userland loop around DBOS.waitFirst can reduce concurrent waiters, but DBOS can implement this more efficiently and safely as a first-class API. The library can batch all remaining workflow IDs into one metadata query per poll, remove every completed workflow discovered in that query, share the existing wakeup/cancellation path, preserve durable internal-step semantics when called from a workflow, and make the intended high fan-out pattern obvious to users.
