### PR TITLE
Configurable Poller Concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,14 +5651,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -214,26 +214,31 @@ export class DBOSClient {
     systemDatabasePool: Pool | undefined,
     readonly serializer: DBOSSerializer,
     systemDatabaseSchemaName?: string,
+    systemDatabasePoolSize?: number,
+    pollingConcurrency?: number,
   ) {
     this.logger = new GlobalLogger();
     this.systemDatabase = new SystemDatabase(
       systemDatabaseUrl,
       this.logger,
       serializer,
-      DEFAULT_POOL_SIZE,
+      systemDatabasePoolSize ?? DEFAULT_POOL_SIZE,
       systemDatabasePool,
       systemDatabaseSchemaName,
       // The client does not run a background notifications listener
       false,
-      // Polling concurrency is left to default (half the pool)
-      undefined,
+      pollingConcurrency,
     );
   }
 
   /**
    * Creates a new instance of the DBOSClient.
-   * @param databaseUrl - The connection string for the database. This should include the hostname, port, username, password, and database name.
-   * @param systemDatabase - An optional name for the system database. If not provided, it defaults to the application database name with a `_dbos_sys` suffix.
+   * @param systemDatabaseUrl - The connection string for the system database. This should include the hostname, port, username, password, and database name.
+   * @param systemDatabasePool - An optional pre-configured connection pool to use for the system database. If provided, `systemDatabasePoolSize` is ignored.
+   * @param serializer - An optional serializer for workflow inputs and outputs. Defaults to JSON serialization.
+   * @param systemDatabaseSchemaName - An optional schema name for the system database. Defaults to `dbos`.
+   * @param systemDatabasePoolSize - An optional maximum size for the system database connection pool. Defaults to {@link DEFAULT_POOL_SIZE}.
+   * @param pollingConcurrency - An optional maximum number of concurrent polling operations. Defaults to half the pool size (minimum 1).
    * @returns A Promise that resolves with the DBOSClient instance.
    */
   static async create({
@@ -241,17 +246,23 @@ export class DBOSClient {
     systemDatabasePool,
     serializer,
     systemDatabaseSchemaName,
+    systemDatabasePoolSize,
+    pollingConcurrency,
   }: {
     systemDatabaseUrl: string;
     systemDatabasePool?: Pool;
     serializer?: DBOSSerializer;
     systemDatabaseSchemaName?: string;
+    systemDatabasePoolSize?: number;
+    pollingConcurrency?: number;
   }): Promise<DBOSClient> {
     const client = new DBOSClient(
       systemDatabaseUrl,
       systemDatabasePool,
       serializer ?? DBOSJSON,
       systemDatabaseSchemaName,
+      systemDatabasePoolSize,
+      pollingConcurrency,
     );
     return Promise.resolve(client);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -224,8 +224,8 @@ export class DBOSClient {
       systemDatabaseSchemaName,
       // The client does not run a background notifications listener
       false,
-      // Maximum polling concurrency for the client: half its pool.
-      Math.floor(DEFAULT_POOL_SIZE / 2),
+      // Polling concurrency is left to default (half the pool)
+      undefined,
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -224,9 +224,8 @@ export class DBOSClient {
       systemDatabaseSchemaName,
       // The client does not run a background notifications listener
       false,
-      // The client is short-lived and has no control-plane work to protect, so
-      // its polling reads are not throttled.
-      0,
+      // Maximum polling concurrency for the client: half its pool.
+      Math.floor(DEFAULT_POOL_SIZE / 2),
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -224,6 +224,9 @@ export class DBOSClient {
       systemDatabaseSchemaName,
       // The client does not run a background notifications listener
       false,
+      // The client is short-lived and has no control-plane work to protect, so
+      // its polling reads are not throttled.
+      0,
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -215,7 +215,7 @@ export class DBOSClient {
     readonly serializer: DBOSSerializer,
     systemDatabaseSchemaName?: string,
     systemDatabasePoolSize?: number,
-    pollingConcurrency?: number,
+    systemDatabasePollingConcurrency?: number,
   ) {
     this.logger = new GlobalLogger();
     this.systemDatabase = new SystemDatabase(
@@ -227,7 +227,7 @@ export class DBOSClient {
       systemDatabaseSchemaName,
       // The client does not run a background notifications listener
       false,
-      pollingConcurrency,
+      systemDatabasePollingConcurrency,
     );
   }
 
@@ -238,7 +238,7 @@ export class DBOSClient {
    * @param serializer - An optional serializer for workflow inputs and outputs. Defaults to JSON serialization.
    * @param systemDatabaseSchemaName - An optional schema name for the system database. Defaults to `dbos`.
    * @param systemDatabasePoolSize - An optional maximum size for the system database connection pool. Defaults to {@link DEFAULT_POOL_SIZE}.
-   * @param pollingConcurrency - An optional maximum number of concurrent polling operations. Defaults to half the pool size (minimum 1).
+   * @param systemDatabasePollingConcurrency - An optional maximum number of concurrent polling operations. Defaults to half the pool size (minimum 1).
    * @returns A Promise that resolves with the DBOSClient instance.
    */
   static async create({
@@ -247,14 +247,14 @@ export class DBOSClient {
     serializer,
     systemDatabaseSchemaName,
     systemDatabasePoolSize,
-    pollingConcurrency,
+    systemDatabasePollingConcurrency,
   }: {
     systemDatabaseUrl: string;
     systemDatabasePool?: Pool;
     serializer?: DBOSSerializer;
     systemDatabaseSchemaName?: string;
     systemDatabasePoolSize?: number;
-    pollingConcurrency?: number;
+    systemDatabasePollingConcurrency?: number;
   }): Promise<DBOSClient> {
     const client = new DBOSClient(
       systemDatabaseUrl,
@@ -262,7 +262,7 @@ export class DBOSClient {
       serializer ?? DBOSJSON,
       systemDatabaseSchemaName,
       systemDatabasePoolSize,
-      pollingConcurrency,
+      systemDatabasePollingConcurrency,
     );
     return Promise.resolve(client);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
     name: options.name,
     systemDatabaseUrl,
     sysDbPoolSize: options.systemDatabasePoolSize,
+    systemDatabasePollingConcurrency: options.systemDatabasePollingConcurrency,
     systemDatabasePool: options.systemDatabasePool,
     systemDatabaseSchemaName: options.systemDatabaseSchemaName ?? 'dbos',
     serializer: options.serializer ?? DBOSJSON,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -101,6 +101,17 @@ export interface DBOSConfig {
   systemDatabasePoolSize?: number;
   systemDatabasePool?: Pool;
   systemDatabaseSchemaName?: string;
+  /**
+   * Maximum number of DB-backed polling reads (from wait operations such as
+   * `getResult`, `recv`, and `getEvent`) that may run concurrently against the
+   * system database pool. This keeps high-fan-out polling from checking out
+   * every pool client and starving control-plane operations such as
+   * enqueue/dequeue, status writes, recovery, and cancellation.
+   *
+   * Defaults to half the system database pool size (minimum 1). Set to a
+   * non-positive value to disable the limiter.
+   */
+  systemDatabasePollingConcurrency?: number;
 
   enableOTLP?: boolean;
   tracingEnabled?: boolean;
@@ -177,6 +188,7 @@ export type DBOSConfigInternal = {
 
   systemDatabaseUrl: string;
   sysDbPoolSize?: number;
+  systemDatabasePollingConcurrency?: number;
   systemDatabasePool?: Pool;
   systemDatabaseSchemaName: string;
   serializer: DBOSSerializer;
@@ -292,6 +304,7 @@ export class DBOSExecutor {
         this.config.systemDatabasePool,
         this.systemDBSchemaName,
         this.config.useListenNotify,
+        this.config.systemDatabasePollingConcurrency,
       );
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -655,11 +655,6 @@ export class SystemDatabase {
     this.schemaName = schemaName;
     this.shouldUseDBNotifications = useListenNotify;
 
-    // Default the polling limit to half the pool (minimum 1), reserving the
-    // rest of the pool for control-plane operations. An explicit value wins; a
-    // non-positive value disables the limiter.
-    const pollingLimit = pollingConcurrency ?? Math.max(1, Math.floor(sysDbPoolSize / 2));
-    this.pollLimiter = new Semaphore(pollingLimit);
     if (systemDatabasePool) {
       this.pool = systemDatabasePool;
       this.customPool = true;
@@ -672,6 +667,12 @@ export class SystemDatabase {
       };
       this.pool = new Pool(systemPoolConfig);
     }
+
+    // Default the polling limit to half the pool (minimum 1), reserving the rest
+    // of the pool for control-plane operations.
+    const effectivePoolSize = this.pool.options.max ?? sysDbPoolSize;
+    const pollingLimit = pollingConcurrency ?? Math.max(1, Math.floor(effectivePoolSize / 2));
+    this.pollLimiter = new Semaphore(pollingLimit);
 
     this.pool.on('error', (err: Error) => {
       this.logger.warn(`Unexpected error in pool: ${err}`);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1731,6 +1731,15 @@ export class SystemDatabase {
     return this.pollLimiter.runExclusive(query);
   }
 
+  /**
+   * Cancellation check for use inside polling wait loops: the status read runs
+   * under the polling limiter so it counts against the same concurrency budget
+   * as the rest of the loop's reads.
+   */
+  async #checkIfCanceledLimited(workflowID: string): Promise<void> {
+    await this.#pollWithLimiter(() => this.#checkIfCanceled(this.pool, workflowID));
+  }
+
   @dbRetry()
   async awaitWorkflowResult(
     workflowID: string,
@@ -1744,7 +1753,7 @@ export class SystemDatabase {
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
-      if (callerID) await this.checkIfCanceled(callerID);
+      if (callerID) await this.#checkIfCanceledLimited(callerID);
       try {
         const { rows } = await this.#pollWithLimiter(() =>
           this.pool.query<workflow_status>(
@@ -1791,7 +1800,7 @@ export class SystemDatabase {
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
-      if (callerID) await this.checkIfCanceled(callerID);
+      if (callerID) await this.#checkIfCanceledLimited(callerID);
 
       const { rows } = await this.#pollWithLimiter(() =>
         this.pool.query<workflow_status>(
@@ -1819,7 +1828,7 @@ export class SystemDatabase {
     while (remainingWorkflowIds.size > 0) {
       const currentWorkflowIds = [...remainingWorkflowIds];
 
-      if (callerID) await this.checkIfCanceled(callerID);
+      if (callerID) await this.#checkIfCanceledLimited(callerID);
 
       const { rows } = await this.#pollWithLimiter(() =>
         this.pool.query<{ workflow_uuid: string }>(
@@ -1956,7 +1965,7 @@ export class SystemDatabase {
       const cbr = this.notificationsMap.registerCallback(payload, resolveNotification!);
 
       try {
-        await this.checkIfCanceled(workflowID);
+        await this.#checkIfCanceledLimited(workflowID);
 
         // Check if the key is already in the DB, then wait for the notification if it isn't.
         const initRecvRows = (
@@ -2138,7 +2147,7 @@ export class SystemDatabase {
       const cbr = this.workflowEventsMap.registerCallback(payloadKey, resolveNotification!);
 
       try {
-        if (callerWorkflow?.workflowID) await this.checkIfCanceled(callerWorkflow?.workflowID);
+        if (callerWorkflow?.workflowID) await this.#checkIfCanceledLimited(callerWorkflow?.workflowID);
         // Check if the key is already in the DB, then wait for the notification if it isn't.
         const initRecvRows = (
           await this.#pollWithLimiter(() =>

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -24,7 +24,7 @@ import {
   queues,
   SysDBSerializationFormat,
 } from '../schemas/system_db_schema';
-import { globalParams, cancellableSleep, INTERNAL_QUEUE_NAME, sleepConfig, sleepms } from './utils';
+import { globalParams, cancellableSleep, INTERNAL_QUEUE_NAME, Semaphore, sleepConfig, sleepms } from './utils';
 import { GlobalLogger } from './telemetry/logs';
 import { WorkflowQueue } from './wfqueue';
 import { randomUUID } from 'crypto';
@@ -629,6 +629,13 @@ export class SystemDatabase {
   readonly cancelWakeupMap: NotificationMap<void> = new NotificationMap();
   customPool: boolean = false;
 
+  /**
+   * Caps how many DB-backed polling reads (from wait operations) may run
+   * concurrently against the pool, so a polling storm cannot check out every
+   * client and starve control-plane operations. See {@link #pollWithLimiter}.
+   */
+  readonly pollLimiter: Semaphore;
+
   readonly runningWorkflowMap: Map<
     string,
     { promise: Promise<unknown>; queueName?: string; queuePartitionKey?: string }
@@ -643,9 +650,16 @@ export class SystemDatabase {
     systemDatabasePool?: Pool,
     schemaName: string = 'dbos',
     useListenNotify: boolean = true,
+    pollingConcurrency?: number,
   ) {
     this.schemaName = schemaName;
     this.shouldUseDBNotifications = useListenNotify;
+
+    // Default the polling limit to half the pool (minimum 1), reserving the
+    // rest of the pool for control-plane operations. An explicit value wins; a
+    // non-positive value disables the limiter.
+    const pollingLimit = pollingConcurrency ?? Math.max(1, Math.floor(sysDbPoolSize / 2));
+    this.pollLimiter = new Semaphore(pollingLimit);
     if (systemDatabasePool) {
       this.pool = systemDatabasePool;
       this.customPool = true;
@@ -1723,6 +1737,16 @@ export class SystemDatabase {
     }
   }
 
+  /**
+   * Run a DB-backed polling read under the polling concurrency limiter, so that
+   * high-fan-out wait loops cannot check out every pool client and starve
+   * control-plane operations. Only polling reads should go through here;
+   * control-plane work hits the pool directly and bypasses the limiter.
+   */
+  #pollWithLimiter<T>(query: () => Promise<T>): Promise<T> {
+    return this.pollLimiter.runExclusive(query);
+  }
+
   @dbRetry()
   async awaitWorkflowResult(
     workflowID: string,
@@ -1751,10 +1775,12 @@ export class SystemDatabase {
       try {
         if (callerID) await this.checkIfCanceled(callerID);
         try {
-          const { rows } = await this.pool.query<workflow_status>(
-            `SELECT status, output, error, serialization FROM "${this.schemaName}".workflow_status 
+          const { rows } = await this.#pollWithLimiter(() =>
+            this.pool.query<workflow_status>(
+              `SELECT status, output, error, serialization FROM "${this.schemaName}".workflow_status
              WHERE workflow_uuid=$1`,
-            [workflowID],
+              [workflowID],
+            ),
           );
           if (rows.length > 0) {
             const status = rows[0].status;
@@ -1833,12 +1859,14 @@ export class SystemDatabase {
       try {
         if (callerID) await this.checkIfCanceled(callerID);
 
-        const { rows } = await this.pool.query<workflow_status>(
-          `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
+        const { rows } = await this.#pollWithLimiter(() =>
+          this.pool.query<workflow_status>(
+            `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
            WHERE workflow_uuid IN (${placeholders})
              AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')
            LIMIT 1`,
-          workflowIds,
+            workflowIds,
+          ),
         );
 
         if (rows.length > 0) {
@@ -2002,9 +2030,11 @@ export class SystemDatabase {
 
         // Check if the key is already in the DB, then wait for the notification if it isn't.
         const initRecvRows = (
-          await this.pool.query<notifications>(
-            `SELECT topic FROM "${this.schemaName}".notifications WHERE destination_uuid=$1 AND topic=$2 AND consumed = false;`,
-            [workflowID, topic],
+          await this.#pollWithLimiter(() =>
+            this.pool.query<notifications>(
+              `SELECT topic FROM "${this.schemaName}".notifications WHERE destination_uuid=$1 AND topic=$2 AND consumed = false;`,
+              [workflowID, topic],
+            ),
           )
         ).rows;
 
@@ -2200,11 +2230,13 @@ export class SystemDatabase {
         if (callerWorkflow?.workflowID) await this.checkIfCanceled(callerWorkflow?.workflowID);
         // Check if the key is already in the DB, then wait for the notification if it isn't.
         const initRecvRows = (
-          await this.pool.query<workflow_events>(
-            `SELECT key, value, serialization
+          await this.#pollWithLimiter(() =>
+            this.pool.query<workflow_events>(
+              `SELECT key, value, serialization
              FROM "${this.schemaName}".workflow_events
              WHERE workflow_uuid=$1 AND key=$2;`,
-            [workflowID, key],
+              [workflowID, key],
+            ),
           )
         ).rows;
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1752,6 +1752,12 @@ export class SystemDatabase {
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
+    // Record the durable timeout deadline once before polling. #durableSleep persists it on the
+    // first call and reads back the same value on recovery, so it never changes across iterations.
+    if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
+      finishTime = await this.#durableSleep(callerID, timerFuncID, timeoutms);
+    }
+
     while (true) {
       if (callerID) await this.#checkIfCanceledLimited(callerID);
       try {
@@ -1785,9 +1791,6 @@ export class SystemDatabase {
       const ct = Date.now();
       if (finishTime && ct > finishTime) return undefined; // Time's up
 
-      if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
-        finishTime = await this.#durableSleep(callerID, timerFuncID, timeoutms);
-      }
       let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
       poll = Math.min(pollIntervalMs, poll);
       await sleepms(poll);
@@ -1955,6 +1958,12 @@ export class SystemDatabase {
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalEventMs;
 
+    // Record the durable timeout deadline once before polling. #durableSleep persists it on the
+    // first call and reads back the same value on recovery, so it never changes across iterations.
+    if (timeoutms) {
+      finishTime = await this.#durableSleep(workflowID, timeoutFunctionID, timeoutms);
+    }
+
     while (true) {
       // register the key with the global notifications listener.
       let resolveNotification: () => void;
@@ -1982,9 +1991,6 @@ export class SystemDatabase {
         const ct = Date.now();
         if (finishTime && ct > finishTime) break; // Time's up
 
-        if (timeoutms) {
-          finishTime = await this.#durableSleep(workflowID, timeoutFunctionID, timeoutms);
-        }
         let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
         poll = Math.min(pollIntervalMs, poll);
         const { promise, cancel } = cancellableSleep(poll);
@@ -2137,6 +2143,17 @@ export class SystemDatabase {
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalEventMs;
 
+    // If we have a callerWorkflow, we want a durable sleep, otherwise, not. Record the durable
+    // timeout deadline once before polling. #durableSleep persists it on the first call and reads
+    // back the same value on recovery, so it never changes across iterations.
+    if (callerWorkflow && timeoutms) {
+      finishTime = await this.#durableSleep(
+        callerWorkflow.workflowID,
+        callerWorkflow.timeoutFunctionID ?? -1,
+        timeoutms,
+      );
+    }
+
     // Register the key with the global notifications listener first... we do not want to look in the DB first
     //  or that would cause a timing hole.
     while (true) {
@@ -2169,14 +2186,6 @@ export class SystemDatabase {
         const ct = Date.now();
         if (finishTime && ct > finishTime) break; // Time's up
 
-        // If we have a callerWorkflow, we want a durable sleep, otherwise, not
-        if (callerWorkflow && timeoutms) {
-          finishTime = await this.#durableSleep(
-            callerWorkflow.workflowID,
-            callerWorkflow.timeoutFunctionID ?? -1,
-            timeoutms,
-          );
-        }
         let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
         poll = Math.min(pollIntervalMs, poll);
         const { promise, cancel } = cancellableSleep(poll);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1912,11 +1912,13 @@ export class SystemDatabase {
       try {
         if (callerID) await this.checkIfCanceled(callerID);
 
-        const { rows } = await this.pool.query<{ workflow_uuid: string }>(
-          `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
+        const { rows } = await this.#pollWithLimiter(() =>
+          this.pool.query<{ workflow_uuid: string }>(
+            `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
            WHERE workflow_uuid = ANY($1::text[])
              AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')`,
-          [currentWorkflowIds],
+            [currentWorkflowIds],
+          ),
         );
 
         for (const row of rows) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,6 +101,59 @@ export function cancellableSleep(ms: number) {
 }
 
 /**
+ * A minimal counting semaphore used to cap how many operations may run
+ * concurrently. Acquirers that arrive while the limit is exhausted queue in
+ * FIFO order and are woken as permits are released.
+ *
+ * A non-positive limit disables the semaphore: acquire resolves immediately and
+ * release is a no-op, so the limiter adds no overhead when it is turned off.
+ */
+export class Semaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+  private readonly enabled: boolean;
+
+  constructor(limit: number) {
+    this.enabled = Number.isFinite(limit) && limit > 0;
+    this.available = this.enabled ? limit : 0;
+  }
+
+  /** Acquire a permit, waiting if necessary. Resolves once a permit is held. */
+  acquire(): Promise<void> {
+    if (!this.enabled) return Promise.resolve();
+    if (this.available > 0) {
+      this.available--;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  /** Release a previously acquired permit, waking the next waiter if any. */
+  release(): void {
+    if (!this.enabled) return;
+    const next = this.waiters.shift();
+    if (next) {
+      // Hand the permit directly to the next waiter without touching `available`.
+      next();
+    } else {
+      this.available++;
+    }
+  }
+
+  /** Run `fn` while holding a permit, releasing it on every resolution path. */
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+}
+
+/**
  * Sleep for `ms` milliseconds, resolving early (without throwing) when
  * `signal` aborts. The abort listener is detached on every resolution path,
  * so calling this in a tight loop against a long-lived signal does not

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -7,6 +7,7 @@ import { spawnSync } from 'child_process';
 import { DBOSQueueDuplicatedError, DBOSAwaitedWorkflowCancelledError } from '../src/error';
 import { randomUUID } from 'crypto';
 import { DBOSConfig } from '../src/dbos-executor';
+import { DEFAULT_POOL_SIZE } from '../src/system_database';
 
 // Re-register the database-backed queue used by these tests every time DBOS
 // is launched. Many tests in this file launch with their own setup, so this
@@ -118,6 +119,38 @@ describe('DBOSClient', () => {
 
   afterEach(async () => {
     await DBOS.shutdown();
+  });
+
+  test('create-passes-through-pool-size-and-polling-concurrency', async () => {
+    // No DBOS.launch() needed: create only constructs the SystemDatabase, whose
+    // pool connects lazily, so we can inspect the wiring without touching the DB.
+    const client = await DBOSClient.create({
+      systemDatabaseUrl,
+      systemDatabaseSchemaName: 'custom_schema',
+      systemDatabasePoolSize: 8,
+      pollingConcurrency: 3,
+    });
+    try {
+      const sysdb = client['systemDatabase'];
+      expect(sysdb.pool.options.max).toBe(8);
+      expect(sysdb.schemaName).toBe('custom_schema');
+      // The semaphore is initialized with the requested `pollingConcurrency` (3),
+      // not the half-the-pool default (which would be 4 for a pool size of 8).
+      expect(sysdb.pollLimiter['available']).toBe(3);
+    } finally {
+      await client.destroy();
+    }
+
+    // When the optional parameters are omitted, the defaults apply: the default
+    // pool size and a polling concurrency of half the pool.
+    const defaultClient = await DBOSClient.create({ systemDatabaseUrl });
+    try {
+      const sysdb = defaultClient['systemDatabase'];
+      expect(sysdb.pool.options.max).toBe(DEFAULT_POOL_SIZE);
+      expect(sysdb.pollLimiter['available']).toBe(Math.floor(DEFAULT_POOL_SIZE / 2));
+    } finally {
+      await defaultClient.destroy();
+    }
   });
 
   test('enqueue-timeout-simple', async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -128,13 +128,13 @@ describe('DBOSClient', () => {
       systemDatabaseUrl,
       systemDatabaseSchemaName: 'custom_schema',
       systemDatabasePoolSize: 8,
-      pollingConcurrency: 3,
+      systemDatabasePollingConcurrency: 3,
     });
     try {
       const sysdb = client['systemDatabase'];
       expect(sysdb.pool.options.max).toBe(8);
       expect(sysdb.schemaName).toBe('custom_schema');
-      // The semaphore is initialized with the requested `pollingConcurrency` (3),
+      // The semaphore is initialized with the requested `systemDatabasePollingConcurrency` (3),
       // not the half-the-pool default (which would be 4 for a pool size of 8).
       expect(sysdb.pollLimiter['available']).toBe(3);
     } finally {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -402,6 +402,24 @@ describe('dbos-config', () => {
       });
     });
 
+    test('translate passes through systemDatabasePollingConcurrency', () => {
+      let internalConfig = translateDbosConfig({
+        name: 'dbostest',
+        systemDatabasePoolSize: 50,
+        systemDatabasePollingConcurrency: 8,
+      });
+      expect(internalConfig.sysDbPoolSize).toBe(50);
+      expect(internalConfig.systemDatabasePollingConcurrency).toBe(8);
+      // When unset, translation leaves it undefined; the default (half the pool)
+      // is materialized later in the SystemDatabase constructor.
+      internalConfig = translateDbosConfig({
+        name: 'dbostest',
+        systemDatabasePoolSize: 50,
+      });
+      expect(internalConfig.sysDbPoolSize).toBe(50);
+      expect(internalConfig.systemDatabasePollingConcurrency).toBeUndefined();
+    });
+
     test('translate with force console', () => {
       const internalConfig = translateDbosConfig(
         {

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -663,7 +663,7 @@ describe('dbos-tests', () => {
       assert.equal(await DBOS.getEvent(handle.workflowID, key), value);
       const steps = await DBOS.listWorkflowSteps(handle.workflowID);
       assert.ok(steps);
-      assert.equal(steps.length, 2);
+      assert.equal(steps.length, 3);
       assert.ok(steps[0].name.includes('DBOS.setEvent'));
       assert.ok(steps[1].name.includes('DBOS.recv'));
       assert.equal(steps[1].output, message);
@@ -698,7 +698,7 @@ describe('dbos-tests', () => {
       assert.ok(badClientSteps);
       assert.ok(badClientSteps[1].name.includes('DBOS.recv'));
       assert.equal(badClientSteps[1].output, jsonSerializer.stringify(message));
-      assert.equal(badClientSteps.length, 2);
+      assert.equal(badClientSteps.length, 3);
       await badClient.destroy();
     });
   });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { interruptibleSleep, waitForAbort } from '../src/utils';
+import { interruptibleSleep, Semaphore, waitForAbort } from '../src/utils';
 
 describe('interruptibleSleep', () => {
   it('resolves after the timeout when the signal is never aborted', async () => {
@@ -70,5 +70,63 @@ describe('waitForAbort', () => {
     const start = Date.now();
     await waitForAbort(controller.signal);
     expect(Date.now() - start).toBeLessThan(50);
+  });
+});
+
+describe('Semaphore', () => {
+  // Track concurrent runners and assert the high-water mark never exceeds the limit.
+  async function runUnderLimiter(limit: number, tasks: number) {
+    const sem = new Semaphore(limit);
+    let inFlight = 0;
+    let peak = 0;
+    await Promise.all(
+      Array.from({ length: tasks }, () =>
+        sem.runExclusive(async () => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          // Yield a few times so overlapping runners would be observed if permitted.
+          await new Promise((r) => setTimeout(r, 10));
+          inFlight--;
+        }),
+      ),
+    );
+    return peak;
+  }
+
+  it('never runs more than `limit` operations concurrently', async () => {
+    expect(await runUnderLimiter(3, 20)).toBe(3);
+    expect(await runUnderLimiter(1, 10)).toBe(1);
+  });
+
+  it('is an unbounded passthrough when the limit is non-positive', async () => {
+    expect(await runUnderLimiter(0, 8)).toBe(8);
+    expect(await runUnderLimiter(-5, 8)).toBe(8);
+  });
+
+  it('releases the permit even when the task throws', async () => {
+    const sem = new Semaphore(1);
+    await expect(sem.runExclusive(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    // If the permit leaked, this second acquire would hang forever.
+    let ran = false;
+    await sem.runExclusive(() => {
+      ran = true;
+      return Promise.resolve();
+    });
+    expect(ran).toBe(true);
+  });
+
+  it('hands permits to waiters in FIFO order', async () => {
+    const sem = new Semaphore(1);
+    const order: number[] = [];
+    await sem.acquire(); // hold the only permit
+    const waiters = [1, 2, 3].map((i) =>
+      sem.acquire().then(() => {
+        order.push(i);
+        sem.release();
+      }),
+    );
+    sem.release(); // wake the queue
+    await Promise.all(waiters);
+    expect(order).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
Use a semaphore to limit the concurrency of polling operations (`getResult`, `waitAll`, `waitFirst`, `recv`, `getEvent`) to a configurable fraction of the system database pool size, preventing connection starvation when there are many concurrent pollers.

Benchmark results for latency of control-plane operations with 10K concurrent pollers:

  | Percentile | Before | After |
  | ---------- | -----: | ----: |
  | p50        |    5ms |   2ms |
  | p99        |  109ms |   3ms |
  | p99.9      |  833ms |   6ms |

Fixes https://github.com/dbos-inc/dbos-transact-ts/issues/1267