### PR TITLE
Cleanup Pollers & CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     services:
       # Postgres service container
       postgres:
-        image: sibedge/postgres-plv8:16.3-3.2.2
+        image: postgres:16
         ports:
           - 5432:5432
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,14 +5651,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {

--- a/packages/create/templates/dbos-drizzle/start_postgres_docker.js
+++ b/packages/create/templates/dbos-drizzle/start_postgres_docker.js
@@ -19,7 +19,7 @@ if (!process.env.PGPASSWORD) {
 
 try {
   execSync(
-    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d sibedge/postgres-plv8`,
+    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d postgres:16`,
   );
   console.log('Waiting for PostgreSQL to start...');
 

--- a/packages/create/templates/dbos-knex/start_postgres_docker.js
+++ b/packages/create/templates/dbos-knex/start_postgres_docker.js
@@ -19,7 +19,7 @@ if (!process.env.PGPASSWORD) {
 
 try {
   execSync(
-    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d sibedge/postgres-plv8`,
+    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d postgres:16`,
   );
   console.log('Waiting for PostgreSQL to start...');
 

--- a/packages/create/templates/dbos-prisma/start_postgres_docker.js
+++ b/packages/create/templates/dbos-prisma/start_postgres_docker.js
@@ -19,7 +19,7 @@ if (!process.env.PGPASSWORD) {
 
 try {
   execSync(
-    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d sibedge/postgres-plv8`,
+    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d postgres:16`,
   );
   console.log('Waiting for PostgreSQL to start...');
 

--- a/packages/create/templates/dbos-typeorm/start_postgres_docker.js
+++ b/packages/create/templates/dbos-typeorm/start_postgres_docker.js
@@ -19,7 +19,7 @@ if (!process.env.PGPASSWORD) {
 
 try {
   execSync(
-    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d sibedge/postgres-plv8`,
+    `docker run --rm --name=dbos-db --env=POSTGRES_PASSWORD="${process.env.PGPASSWORD}" --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p ${port}:5432 -d postgres:16`,
   );
   console.log('Waiting for PostgreSQL to start...');
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1754,25 +1754,14 @@ export class SystemDatabase {
       const ct = Date.now();
       if (finishTime && ct > finishTime) return undefined; // Time's up
 
-      let timeoutPromise: Promise<void> = Promise.resolve();
-      let timeoutCancel: () => void = () => {};
       if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
-        const { promise, cancel, endTime } = await this.#durableSleep(callerID, timerFuncID, timeoutms, pollIntervalMs);
+        const { promise, endTime } = await this.#durableSleep(callerID, timerFuncID, timeoutms, pollIntervalMs);
         finishTime = endTime;
-        timeoutPromise = promise;
-        timeoutCancel = cancel;
+        await promise;
       } else {
         let poll = finishTime ? finishTime - ct : pollIntervalMs;
         poll = Math.min(pollIntervalMs, poll);
-        const { promise, cancel } = cancellableSleep(poll);
-        timeoutPromise = promise;
-        timeoutCancel = cancel;
-      }
-
-      try {
-        await timeoutPromise;
-      } finally {
-        timeoutCancel();
+        await sleepms(poll);
       }
     }
   }
@@ -1797,12 +1786,7 @@ export class SystemDatabase {
         return rows[0].workflow_uuid;
       }
 
-      const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
-      try {
-        await sleepPromise;
-      } finally {
-        sleepCancel();
-      }
+      await sleepms(pollIntervalMs);
     }
   }
 
@@ -1830,12 +1814,7 @@ export class SystemDatabase {
         return;
       }
 
-      const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
-      try {
-        await sleepPromise;
-      } finally {
-        sleepCancel();
-      }
+      await sleepms(pollIntervalMs);
     }
   }
 
@@ -1846,12 +1825,7 @@ export class SystemDatabase {
     cancelInitial();
 
     while (Date.now() < endTime) {
-      const { promise, cancel } = cancellableSleep(Math.min(endTime - Date.now(), sleepConfig.maxTimeoutMS));
-      try {
-        await promise;
-      } finally {
-        cancel();
-      }
+      await sleepms(Math.min(endTime - Date.now(), sleepConfig.maxTimeoutMS));
     }
 
     await this.checkIfCanceled(workflowID);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1755,14 +1755,11 @@ export class SystemDatabase {
       if (finishTime && ct > finishTime) return undefined; // Time's up
 
       if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
-        const { promise, endTime } = await this.#durableSleep(callerID, timerFuncID, timeoutms, pollIntervalMs);
-        finishTime = endTime;
-        await promise;
-      } else {
-        let poll = finishTime ? finishTime - ct : pollIntervalMs;
-        poll = Math.min(pollIntervalMs, poll);
-        await sleepms(poll);
+        finishTime = await this.#durableSleep(callerID, timerFuncID, timeoutms);
       }
+      let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
+      poll = Math.min(pollIntervalMs, poll);
+      await sleepms(poll);
     }
   }
 
@@ -1821,8 +1818,7 @@ export class SystemDatabase {
   // ==================== Sleep ====================
   @dbRetry()
   async durableSleepms(workflowID: string, functionID: number, durationMS: number): Promise<void> {
-    const { cancel: cancelInitial, endTime } = await this.#durableSleep(workflowID, functionID, durationMS);
-    cancelInitial();
+    const endTime = await this.#durableSleep(workflowID, functionID, durationMS);
 
     while (Date.now() < endTime) {
       await sleepms(Math.min(endTime - Date.now(), sleepConfig.maxTimeoutMS));
@@ -1949,29 +1945,16 @@ export class SystemDatabase {
         const ct = Date.now();
         if (finishTime && ct > finishTime) break; // Time's up
 
-        let timeoutPromise: Promise<void> = Promise.resolve();
-        let timeoutCancel: () => void = () => {};
         if (timeoutms) {
-          const { promise, cancel, endTime } = await this.#durableSleep(
-            workflowID,
-            timeoutFunctionID,
-            timeoutms,
-            pollIntervalMs,
-          );
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
-          finishTime = endTime;
-        } else {
-          let poll = finishTime ? finishTime - ct : pollIntervalMs;
-          poll = Math.min(pollIntervalMs, poll);
-          const { promise, cancel } = cancellableSleep(poll);
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
+          finishTime = await this.#durableSleep(workflowID, timeoutFunctionID, timeoutms);
         }
+        let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
+        poll = Math.min(pollIntervalMs, poll);
+        const { promise, cancel } = cancellableSleep(poll);
         try {
-          await Promise.race([messagePromise, timeoutPromise]);
+          await Promise.race([messagePromise, promise]);
         } finally {
-          timeoutCancel();
+          cancel();
         }
       } finally {
         this.notificationsMap.deregisterCallback(cbr);
@@ -2148,30 +2131,21 @@ export class SystemDatabase {
         if (finishTime && ct > finishTime) break; // Time's up
 
         // If we have a callerWorkflow, we want a durable sleep, otherwise, not
-        let timeoutPromise: Promise<void> = Promise.resolve();
-        let timeoutCancel: () => void = () => {};
         if (callerWorkflow && timeoutms) {
-          const { promise, cancel, endTime } = await this.#durableSleep(
+          finishTime = await this.#durableSleep(
             callerWorkflow.workflowID,
             callerWorkflow.timeoutFunctionID ?? -1,
             timeoutms,
-            pollIntervalMs,
           );
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
-          finishTime = endTime;
-        } else {
-          let poll = finishTime ? finishTime - ct : pollIntervalMs;
-          poll = Math.min(pollIntervalMs, poll);
-          const { promise, cancel } = cancellableSleep(poll);
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
         }
+        let poll = finishTime ? finishTime - Date.now() : pollIntervalMs;
+        poll = Math.min(pollIntervalMs, poll);
+        const { promise, cancel } = cancellableSleep(poll);
 
         try {
-          await Promise.race([valuePromise, timeoutPromise]);
+          await Promise.race([valuePromise, promise]);
         } finally {
-          timeoutCancel();
+          cancel();
         }
       } finally {
         this.workflowEventsMap.deregisterCallback(cbr);
@@ -3830,16 +3804,12 @@ export class SystemDatabase {
     }
   }
 
-  async #durableSleep(
-    workflowID: string,
-    functionID: number,
-    durationMS: number,
-    maxSleepPerIteration?: number,
-  ): Promise<{ promise: Promise<void>; cancel: () => void; endTime: number }> {
-    if (maxSleepPerIteration === undefined) maxSleepPerIteration = durationMS;
-
-    const curTime = Date.now();
-    let endTimeMs = curTime + durationMS;
+  // Durably records (or, on recovery, reads back) the wakeup deadline for a sleep or
+  // timeout so it survives recovery. Returns the absolute end time in epoch ms; the
+  // caller is responsible for actually waiting until then. Throws if the workflow has
+  // been cancelled.
+  async #durableSleep(workflowID: string, functionID: number, durationMS: number): Promise<number> {
+    const endTimeMs = Date.now() + durationMS;
 
     const client = await this.pool.connect();
     try {
@@ -3848,26 +3818,22 @@ export class SystemDatabase {
         if (res.functionName !== DBOS_FUNCNAME_SLEEP) {
           throw new DBOSUnexpectedStepError(workflowID, functionID, DBOS_FUNCNAME_SLEEP, res.functionName!);
         }
-        endTimeMs = JSON.parse(res.output!) as number;
-      } else {
-        await this.recordOperationResultInternal(
-          client,
-          workflowID,
-          functionID,
-          DBOS_FUNCNAME_SLEEP,
-          false,
-          Date.now(),
-          Date.now(),
-          {
-            output: DBOSPortableJSON.stringify(endTimeMs),
-            serialization: DBOSPortableJSON.name(),
-          },
-        );
+        return JSON.parse(res.output!) as number;
       }
-      return {
-        ...cancellableSleep(Math.max(Math.min(maxSleepPerIteration, endTimeMs - curTime), 0)),
-        endTime: endTimeMs,
-      };
+      await this.recordOperationResultInternal(
+        client,
+        workflowID,
+        functionID,
+        DBOS_FUNCNAME_SLEEP,
+        false,
+        Date.now(),
+        Date.now(),
+        {
+          output: DBOSPortableJSON.stringify(endTimeMs),
+          serialization: DBOSPortableJSON.name(),
+        },
+      );
+      return endTimeMs;
     } finally {
       client.release();
     }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -626,14 +626,12 @@ export class SystemDatabase {
   readonly notificationsMap: NotificationMap<void> = new NotificationMap();
   readonly workflowEventsMap: NotificationMap<void> = new NotificationMap();
   readonly streamsMap: NotificationMap<void> = new NotificationMap();
-  readonly cancelWakeupMap: NotificationMap<void> = new NotificationMap();
   customPool: boolean = false;
 
   readonly runningWorkflowMap: Map<
     string,
     { promise: Promise<unknown>; queueName?: string; queuePartitionKey?: string }
   > = new Map(); // Map from workflowID to workflow promise, queue name and partition key
-  readonly workflowCancellationMap: Map<string, boolean> = new Map(); // Map from workflowID to its cancellation status.
 
   constructor(
     readonly systemDatabaseUrl: string,
@@ -1090,10 +1088,6 @@ export class SystemDatabase {
          AND status NOT IN ($3, $4)`,
       [StatusString.CANCELLED, workflowIDs, StatusString.SUCCESS, StatusString.ERROR],
     );
-
-    for (const workflowID of workflowIDs) {
-      this.#setWFCancelMap(workflowID);
-    }
   }
 
   @dbRetry()
@@ -1107,10 +1101,6 @@ export class SystemDatabase {
   }
 
   async resumeWorkflows(workflowIDs: string[], queueName?: string): Promise<void> {
-    for (const workflowID of workflowIDs) {
-      this.#clearWFCancelMap(workflowID);
-    }
-
     await this.pool.query(
       `UPDATE "${this.schemaName}".workflow_status
        SET status = $1, queue_name = $2, recovery_attempts = 0,
@@ -1184,7 +1174,6 @@ export class SystemDatabase {
 
     for (const wfid of allIds) {
       this.runningWorkflowMap.delete(wfid);
-      this.workflowCancellationMap.delete(wfid);
     }
   }
 
@@ -1687,7 +1676,6 @@ export class SystemDatabase {
       .finally(() => {
         // Remove itself from pending workflow map.
         this.runningWorkflowMap.delete(workflowID);
-        this.workflowCancellationMap.delete(workflowID);
       });
     this.runningWorkflowMap.set(workflowID, {
       promise: awaitWorkflowPromise,
@@ -1736,77 +1724,55 @@ export class SystemDatabase {
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
-      let resolveNotification: () => void;
-      const statusPromise = new Promise<void>((resolve) => {
-        resolveNotification = resolve;
-      });
-      const irh = this.cancelWakeupMap.registerCallback(workflowID, (_res) => {
-        resolveNotification();
-      });
-      const crh = callerID
-        ? this.cancelWakeupMap.registerCallback(callerID, (_res) => {
-            resolveNotification();
-          })
-        : undefined;
+      if (callerID) await this.checkIfCanceled(callerID);
       try {
-        if (callerID) await this.checkIfCanceled(callerID);
-        try {
-          const { rows } = await this.pool.query<workflow_status>(
-            `SELECT status, output, error, serialization FROM "${this.schemaName}".workflow_status 
-             WHERE workflow_uuid=$1`,
-            [workflowID],
-          );
-          if (rows.length > 0) {
-            const status = rows[0].status;
-            if (status === StatusString.SUCCESS) {
-              return { output: rows[0].output, serialization: rows[0].serialization };
-            } else if (status === StatusString.ERROR) {
-              return { error: rows[0].error, serialization: rows[0].serialization };
-            } else if (status === StatusString.CANCELLED) {
-              return { cancelled: true };
-            } else if (status === StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED) {
-              return { maxRecoveryAttemptsExceeded: true };
-            } else {
-              // Status is not actionable
-            }
+        const { rows } = await this.pool.query<workflow_status>(
+          `SELECT status, output, error, serialization FROM "${this.schemaName}".workflow_status
+           WHERE workflow_uuid=$1`,
+          [workflowID],
+        );
+        if (rows.length > 0) {
+          const status = rows[0].status;
+          if (status === StatusString.SUCCESS) {
+            return { output: rows[0].output, serialization: rows[0].serialization };
+          } else if (status === StatusString.ERROR) {
+            return { error: rows[0].error, serialization: rows[0].serialization };
+          } else if (status === StatusString.CANCELLED) {
+            return { cancelled: true };
+          } else if (status === StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED) {
+            return { maxRecoveryAttemptsExceeded: true };
+          } else {
+            // Status is not actionable
           }
-        } catch (e) {
-          const err = e as Error;
-          this.logger.error(`Exception from system database: ${err}`, err);
-          throw err;
         }
+      } catch (e) {
+        const err = e as Error;
+        this.logger.error(`Exception from system database: ${err}`, err);
+        throw err;
+      }
 
-        const ct = Date.now();
-        if (finishTime && ct > finishTime) return undefined; // Time's up
+      const ct = Date.now();
+      if (finishTime && ct > finishTime) return undefined; // Time's up
 
-        let timeoutPromise: Promise<void> = Promise.resolve();
-        let timeoutCancel: () => void = () => {};
-        if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
-          const { promise, cancel, endTime } = await this.#durableSleep(
-            callerID,
-            timerFuncID,
-            timeoutms,
-            pollIntervalMs,
-          );
-          finishTime = endTime;
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
-        } else {
-          let poll = finishTime ? finishTime - ct : pollIntervalMs;
-          poll = Math.min(pollIntervalMs, poll);
-          const { promise, cancel } = cancellableSleep(poll);
-          timeoutPromise = promise;
-          timeoutCancel = cancel;
-        }
+      let timeoutPromise: Promise<void> = Promise.resolve();
+      let timeoutCancel: () => void = () => {};
+      if (timerFuncID !== undefined && callerID !== undefined && timeoutms !== undefined) {
+        const { promise, cancel, endTime } = await this.#durableSleep(callerID, timerFuncID, timeoutms, pollIntervalMs);
+        finishTime = endTime;
+        timeoutPromise = promise;
+        timeoutCancel = cancel;
+      } else {
+        let poll = finishTime ? finishTime - ct : pollIntervalMs;
+        poll = Math.min(pollIntervalMs, poll);
+        const { promise, cancel } = cancellableSleep(poll);
+        timeoutPromise = promise;
+        timeoutCancel = cancel;
+      }
 
-        try {
-          await Promise.race([statusPromise, timeoutPromise]);
-        } finally {
-          timeoutCancel();
-        }
+      try {
+        await timeoutPromise;
       } finally {
-        this.cancelWakeupMap.deregisterCallback(irh);
-        if (crh) this.cancelWakeupMap.deregisterCallback(crh);
+        timeoutCancel();
       }
     }
   }
@@ -1817,45 +1783,25 @@ export class SystemDatabase {
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (true) {
-      let resolveNotification: () => void;
-      const wakeupPromise = new Promise<void>((resolve) => {
-        resolveNotification = resolve;
-      });
+      if (callerID) await this.checkIfCanceled(callerID);
 
-      // Register cancel callbacks for all target workflows and the caller.
-      const cbHandles = workflowIds.map((wfid) =>
-        this.cancelWakeupMap.registerCallback(wfid, () => resolveNotification!()),
+      const { rows } = await this.pool.query<workflow_status>(
+        `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
+         WHERE workflow_uuid IN (${placeholders})
+           AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')
+         LIMIT 1`,
+        workflowIds,
       );
-      const callerCbHandle = callerID
-        ? this.cancelWakeupMap.registerCallback(callerID, () => resolveNotification!())
-        : undefined;
 
+      if (rows.length > 0) {
+        return rows[0].workflow_uuid;
+      }
+
+      const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
       try {
-        if (callerID) await this.checkIfCanceled(callerID);
-
-        const { rows } = await this.pool.query<workflow_status>(
-          `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
-           WHERE workflow_uuid IN (${placeholders})
-             AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')
-           LIMIT 1`,
-          workflowIds,
-        );
-
-        if (rows.length > 0) {
-          return rows[0].workflow_uuid;
-        }
-
-        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
-        try {
-          await Promise.race([wakeupPromise, sleepPromise]);
-        } finally {
-          sleepCancel();
-        }
+        await sleepPromise;
       } finally {
-        for (const h of cbHandles) {
-          this.cancelWakeupMap.deregisterCallback(h);
-        }
-        if (callerCbHandle) this.cancelWakeupMap.deregisterCallback(callerCbHandle);
+        sleepCancel();
       }
     }
   }
@@ -1866,48 +1812,29 @@ export class SystemDatabase {
     const pollIntervalMs = pollingIntervalMs ?? this.dbPollingIntervalResultMs;
 
     while (remainingWorkflowIds.size > 0) {
-      let resolveNotification: () => void;
-      const wakeupPromise = new Promise<void>((resolve) => {
-        resolveNotification = resolve;
-      });
       const currentWorkflowIds = [...remainingWorkflowIds];
 
-      // Register cancel callbacks for all remaining target workflows and the caller.
-      const cbHandles = currentWorkflowIds.map((wfid) =>
-        this.cancelWakeupMap.registerCallback(wfid, () => resolveNotification!()),
+      if (callerID) await this.checkIfCanceled(callerID);
+
+      const { rows } = await this.pool.query<{ workflow_uuid: string }>(
+        `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
+         WHERE workflow_uuid = ANY($1::text[])
+           AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')`,
+        [currentWorkflowIds],
       );
-      const callerCbHandle = callerID
-        ? this.cancelWakeupMap.registerCallback(callerID, () => resolveNotification!())
-        : undefined;
 
+      for (const row of rows) {
+        remainingWorkflowIds.delete(row.workflow_uuid);
+      }
+      if (remainingWorkflowIds.size === 0) {
+        return;
+      }
+
+      const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
       try {
-        if (callerID) await this.checkIfCanceled(callerID);
-
-        const { rows } = await this.pool.query<{ workflow_uuid: string }>(
-          `SELECT workflow_uuid FROM "${this.schemaName}".workflow_status
-           WHERE workflow_uuid = ANY($1::text[])
-             AND status NOT IN ('${StatusString.PENDING}', '${StatusString.ENQUEUED}', '${StatusString.DELAYED}')`,
-          [currentWorkflowIds],
-        );
-
-        for (const row of rows) {
-          remainingWorkflowIds.delete(row.workflow_uuid);
-        }
-        if (remainingWorkflowIds.size === 0) {
-          return;
-        }
-
-        const { promise: sleepPromise, cancel: sleepCancel } = cancellableSleep(pollIntervalMs);
-        try {
-          await Promise.race([wakeupPromise, sleepPromise]);
-        } finally {
-          sleepCancel();
-        }
+        await sleepPromise;
       } finally {
-        for (const h of cbHandles) {
-          this.cancelWakeupMap.deregisterCallback(h);
-        }
-        if (callerCbHandle) this.cancelWakeupMap.deregisterCallback(callerCbHandle);
+        sleepCancel();
       }
     }
   }
@@ -1915,30 +1842,16 @@ export class SystemDatabase {
   // ==================== Sleep ====================
   @dbRetry()
   async durableSleepms(workflowID: string, functionID: number, durationMS: number): Promise<void> {
-    let cancelled = false;
-    let resolveNotification: () => void;
-    const cancelPromise = new Promise<void>((resolve) => {
-      resolveNotification = () => {
-        cancelled = true;
-        resolve();
-      };
-    });
+    const { cancel: cancelInitial, endTime } = await this.#durableSleep(workflowID, functionID, durationMS);
+    cancelInitial();
 
-    const cbr = this.cancelWakeupMap.registerCallback(workflowID, resolveNotification!);
-    try {
-      const { cancel: cancelInitial, endTime } = await this.#durableSleep(workflowID, functionID, durationMS);
-      cancelInitial();
-
-      while (!cancelled && Date.now() < endTime) {
-        const { promise, cancel } = cancellableSleep(Math.min(endTime - Date.now(), sleepConfig.maxTimeoutMS));
-        try {
-          await Promise.race([cancelPromise, promise]);
-        } finally {
-          cancel();
-        }
+    while (Date.now() < endTime) {
+      const { promise, cancel } = cancellableSleep(Math.min(endTime - Date.now(), sleepConfig.maxTimeoutMS));
+      try {
+        await promise;
+      } finally {
+        cancel();
       }
-    } finally {
-      this.cancelWakeupMap.deregisterCallback(cbr);
     }
 
     await this.checkIfCanceled(workflowID);
@@ -2045,9 +1958,6 @@ export class SystemDatabase {
       });
       const payload = `${workflowID}::${topic}`;
       const cbr = this.notificationsMap.registerCallback(payload, resolveNotification!);
-      const crh = this.cancelWakeupMap.registerCallback(workflowID, (_res) => {
-        resolveNotification();
-      });
 
       try {
         await this.checkIfCanceled(workflowID);
@@ -2091,7 +2001,6 @@ export class SystemDatabase {
         }
       } finally {
         this.notificationsMap.deregisterCallback(cbr);
-        this.cancelWakeupMap.deregisterCallback(crh);
       }
     }
 
@@ -2242,11 +2151,6 @@ export class SystemDatabase {
         resolveNotification = resolve;
       });
       const cbr = this.workflowEventsMap.registerCallback(payloadKey, resolveNotification!);
-      const crh = callerWorkflow?.workflowID
-        ? this.cancelWakeupMap.registerCallback(callerWorkflow.workflowID, (_res) => {
-            resolveNotification();
-          })
-        : undefined;
 
       try {
         if (callerWorkflow?.workflowID) await this.checkIfCanceled(callerWorkflow?.workflowID);
@@ -2297,7 +2201,6 @@ export class SystemDatabase {
         }
       } finally {
         this.workflowEventsMap.deregisterCallback(cbr);
-        if (crh) this.cancelWakeupMap.deregisterCallback(crh);
       }
     }
 
@@ -3946,23 +3849,7 @@ export class SystemDatabase {
     return output;
   }
 
-  #setWFCancelMap(workflowID: string) {
-    if (this.runningWorkflowMap.has(workflowID)) {
-      this.workflowCancellationMap.set(workflowID, true);
-    }
-    this.cancelWakeupMap.callCallbacks(workflowID);
-  }
-
-  #clearWFCancelMap(workflowID: string) {
-    if (this.workflowCancellationMap.has(workflowID)) {
-      this.workflowCancellationMap.delete(workflowID);
-    }
-  }
-
   async #checkIfCanceled(client: PoolClient, workflowID: string): Promise<void> {
-    if (this.workflowCancellationMap.get(workflowID) === true) {
-      throw new DBOSWorkflowCancelledError(workflowID);
-    }
     const statusValue = await this.getWorkflowStatusValue(client, workflowID);
     if (statusValue === StatusString.CANCELLED) {
       throw new DBOSWorkflowCancelledError(workflowID);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1092,12 +1092,7 @@ export class SystemDatabase {
 
   @dbRetry()
   async checkIfCanceled(workflowID: string): Promise<void> {
-    const client = await this.pool.connect();
-    try {
-      await this.#checkIfCanceled(client, workflowID);
-    } finally {
-      client.release();
-    }
+    await this.#checkIfCanceled(this.pool, workflowID);
   }
 
   async resumeWorkflows(workflowIDs: string[], queueName?: string): Promise<void> {
@@ -3576,7 +3571,7 @@ export class SystemDatabase {
     }
   }
 
-  private async getWorkflowStatusValue(client: PoolClient, workflowID: string): Promise<string | undefined> {
+  private async getWorkflowStatusValue(client: PoolClient | Pool, workflowID: string): Promise<string | undefined> {
     const { rows } = await client.query<{ status: string }>(
       `SELECT status FROM "${this.schemaName}".workflow_status WHERE workflow_uuid=$1`,
       [workflowID],
@@ -3797,7 +3792,7 @@ export class SystemDatabase {
     return output;
   }
 
-  async #checkIfCanceled(client: PoolClient, workflowID: string): Promise<void> {
+  async #checkIfCanceled(client: PoolClient | Pool, workflowID: string): Promise<void> {
     const statusValue = await this.getWorkflowStatusValue(client, workflowID);
     if (statusValue === StatusString.CANCELLED) {
       throw new DBOSWorkflowCancelledError(workflowID);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1638,7 +1638,9 @@ describe('queue-time-outs', () => {
     const handle = await DBOS.startWorkflow(DBOSTimeoutTestClass, {
       workflowID,
       queueName: timeoutQueue.name,
-      timeoutMS: 2000, // allow a dequeue interval to pass
+      // Long enough that the parent, which learns of the child's cancellation on its next
+      // result poll (not instantly), observes it well before the parent's own deadline fires.
+      timeoutMS: 4000,
     }).timeoutParentEnqueueWF(100);
     await events_map.get(childID)?.wait();
     await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(childID));

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -339,6 +339,12 @@ describe('workflow-management-tests', () => {
   test('test-cancel-retry-restart', async () => {
     TestEndpoints.tries = 0;
 
+    // A blocked workflow observes cancellation on its next poll, not instantly. Shorten the
+    // poll interval so the cancelled recv below stops promptly (the launch in beforeEach builds
+    // a fresh system database, so this does not leak to other tests).
+    const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
+    sysdb.dbPollingIntervalEventMs = 100;
+
     const workflowID = `test-cancel-resume-fork-${Date.now()}`;
     const handle = await DBOS.startWorkflow(TestEndpoints, { workflowID }).waitingWorkflow(42);
     expect(TestEndpoints.tries).toBe(1);
@@ -353,6 +359,13 @@ describe('workflow-management-tests', () => {
     );
     expect(result.rows[0].attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.CANCELLED);
+
+    // Wait for the cancelled execution to fully stop before resuming. Otherwise the stale
+    // coroutine (still blocked in recv) could consume the message and complete the workflow
+    // itself, instead of the fresh execution that resume is meant to start.
+    while (sysdb.checkForRunningWorkflow(workflowID)) {
+      await sleepms(50);
+    }
 
     await recoverPendingWorkflows(); // Does nothing as the workflow is CANCELLED
     expect(TestEndpoints.tries).toBe(1);

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -2244,17 +2244,6 @@ describe('wf-cancel-tests', () => {
     expect(WFwith2Steps.stepsExecuted).toBe(2);
   });
 
-  test('test-preempt-sleepms', async () => {
-    const wfid = randomUUID();
-    const wfh = await DBOS.startWorkflow(DeepSleep, { workflowID: wfid }).sleepTooLong();
-
-    await expect(DBOS.getResult(wfh.workflowID, 0.2)).resolves.toBeNull();
-    await DBOS.cancelWorkflow(wfid);
-
-    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
-    await expect(wfh.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
-  });
-
   test('test-preempt-getresult', async () => {
     const wfid = randomUUID();
     const wfh = await DBOS.startWorkflow(DeepSleep, { workflowID: wfid }).getResultTooLong();
@@ -2314,12 +2303,6 @@ describe('wf-cancel-tests', () => {
   }
 
   class DeepSleep {
-    @DBOS.workflow()
-    static async sleepTooLong() {
-      await DBOS.sleepms(1000 * 1000);
-      return 'Done';
-    }
-
     @DBOS.workflow()
     static async getResultTooLong() {
       await DBOS.getResult('bogusbogusbogus', 1000);


### PR DESCRIPTION
- Remove a special fast path for preempting polling workflows that were cancelled locally (as in, the cancel function ran in the same process as the workflow). This is not the common case and does not need a complex optimization.
- Update the containers used in CI