### PR TITLE
Custom Logger

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_POOL_SIZE,
 } from './system_database';
 
-import { GlobalLogger } from './telemetry/logs';
+import { DLogger, GlobalLogger } from './telemetry/logs';
 import { randomUUID } from 'node:crypto';
 import {
   type GetWorkflowsInput,
@@ -216,8 +216,9 @@ export class DBOSClient {
     systemDatabaseSchemaName?: string,
     systemDatabasePoolSize?: number,
     systemDatabasePollingConcurrency?: number,
+    logger?: DLogger,
   ) {
-    this.logger = new GlobalLogger();
+    this.logger = new GlobalLogger(undefined, logger ? { logger } : undefined);
     this.systemDatabase = new SystemDatabase(
       systemDatabaseUrl,
       this.logger,
@@ -239,6 +240,7 @@ export class DBOSClient {
    * @param systemDatabaseSchemaName - An optional schema name for the system database. Defaults to `dbos`.
    * @param systemDatabasePoolSize - An optional maximum size for the system database connection pool. Defaults to {@link DEFAULT_POOL_SIZE}.
    * @param systemDatabasePollingConcurrency - An optional maximum number of concurrent polling operations. Defaults to half the pool size (minimum 1).
+   * @param logger - An optional custom logger to which the client directs all its logging, replacing the built-in console logger.
    * @returns A Promise that resolves with the DBOSClient instance.
    */
   static async create({
@@ -248,6 +250,7 @@ export class DBOSClient {
     systemDatabaseSchemaName,
     systemDatabasePoolSize,
     systemDatabasePollingConcurrency,
+    logger,
   }: {
     systemDatabaseUrl: string;
     systemDatabasePool?: Pool;
@@ -255,6 +258,7 @@ export class DBOSClient {
     systemDatabaseSchemaName?: string;
     systemDatabasePoolSize?: number;
     systemDatabasePollingConcurrency?: number;
+    logger?: DLogger;
   }): Promise<DBOSClient> {
     const client = new DBOSClient(
       systemDatabaseUrl,
@@ -263,6 +267,7 @@ export class DBOSClient {
       systemDatabaseSchemaName,
       systemDatabasePoolSize,
       systemDatabasePollingConcurrency,
+      logger,
     );
     return Promise.resolve(client);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -193,6 +193,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
         logLevel: options.logLevel || 'info',
         addContextMetadata: options.addContextMetadata,
         forceConsole,
+        logger: options.logger,
       },
       OTLPExporter: {
         tracesEndpoint: options.otlpTracesEndpoints,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -26,7 +26,7 @@ import {
 import { type StepConfig } from './step';
 import { TelemetryCollector } from './telemetry/collector';
 import { getActiveSpan, runWithTrace, SpanStatusCode, Tracer } from './telemetry/traces';
-import { DBOSContextualLogger, GlobalLogger } from './telemetry/logs';
+import { DBOSContextualLogger, DLogger, GlobalLogger } from './telemetry/logs';
 import { TelemetryExporter } from './telemetry/exporters';
 import { SystemDatabase, type WorkflowStatusInternal, type SystemDatabaseStoredResult } from './system_database';
 import { randomUUID } from 'node:crypto';
@@ -116,6 +116,18 @@ export interface DBOSConfig {
   enableOTLP?: boolean;
   tracingEnabled?: boolean;
   logLevel?: string;
+  /**
+   * A custom logger to which DBOS directs all its internal logging, replacing
+   * the built-in console and OTLP log sinks. See {@link DLogger} for the
+   * contract implementations must follow. When set:
+   * - `logLevel` does not filter calls to it; level routing is its job.
+   * - Logs are not exported over OTLP even if `enableOTLP` is on (traces are
+   *   unaffected).
+   * - DBOS never flushes or closes it; the caller owns its lifecycle.
+   * Only settable programmatically, not from `dbos-config.yaml`; CLI commands
+   * keep using the built-in logger.
+   */
+  logger?: DLogger;
   addContextMetadata?: boolean;
   otlpTracesEndpoints?: string[];
   otlpLogsEndpoints?: string[];
@@ -181,6 +193,7 @@ export interface LoggerConfig {
   silent?: boolean;
   addContextMetadata?: boolean;
   forceConsole?: boolean;
+  logger?: DLogger;
 }
 
 export type DBOSConfigInternal = {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -124,8 +124,6 @@ export interface DBOSConfig {
    * - Logs are not exported over OTLP even if `enableOTLP` is on (traces are
    *   unaffected).
    * - DBOS never flushes or closes it; the caller owns its lifecycle.
-   * Only settable programmatically, not from `dbos-config.yaml`; CLI commands
-   * keep using the built-in logger.
    */
   logger?: DLogger;
   addContextMetadata?: boolean;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -643,7 +643,7 @@ export class DBOS {
     if (lctx?.logger) return lctx.logger;
     const executor = DBOSExecutor.globalInstance;
     if (executor) return executor.logger;
-    return new GlobalLogger(undefined, { logger: DBOS.#dbosConfig?.logger });
+    return new GlobalLogger(undefined, { logger: DBOS.#dbosConfig?.logger, logLevel: DBOS.#dbosConfig?.logLevel });
   }
 
   /** Get the current DBOS Tracer, for starting spans */

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -643,7 +643,7 @@ export class DBOS {
     if (lctx?.logger) return lctx.logger;
     const executor = DBOSExecutor.globalInstance;
     if (executor) return executor.logger;
-    return new GlobalLogger();
+    return new GlobalLogger(undefined, { logger: DBOS.#dbosConfig?.logger });
   }
 
   /** Get the current DBOS Tracer, for starting spans */

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,4 +54,8 @@ export { FunctionName, ConfiguredInstance, MethodParameter } from './decorators'
 
 export { DBOSConfig, DBOSExternalState, OtelAttributeFormat } from './dbos-executor';
 
+export { DLogger, ContextualMetadata, StackTrace } from './telemetry/logs';
+
+export { DBOSSpan } from './telemetry/traces';
+
 export { VersionInfo } from './system_database';

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -48,12 +48,12 @@ enum SeverityNumber {
 /* GLOBAL LOGGER */
 /*****************/
 
-type ContextualMetadata = {
+export type ContextualMetadata = {
   includeContextMetadata?: boolean; // Should the console transport formatter include the context metadata?
   span?: DBOSSpan; // All context metadata should be attributes of the context's span
 };
 
-interface StackTrace {
+export interface StackTrace {
   stack?: string;
 }
 
@@ -68,6 +68,10 @@ export class GlobalLogger {
     appName: string = 'dbos',
   ) {
     this.addContextMetadata = config?.addContextMetadata || false;
+    if (config?.logger) {
+      this.logger = config.logger;
+      return;
+    }
     if (!globalParams.enableOTLP) {
       this.logger = new DBOSConsoleLogger(config ?? {});
       return;
@@ -237,6 +241,23 @@ export class GlobalLogger {
 /* CONTEXT LOGGER */
 /******************/
 
+/**
+ * The logger interface used throughout DBOS. Implement this to supply a custom
+ * logger through `DBOSConfig.logger` (for example, an adapter over Pino,
+ * Winston, or Bunyan).
+ *
+ * Contract for custom implementations:
+ * - Log entries arrive as strings: DBOS stringifies non-string entries before
+ *   delegating, and `error()` receives the message of an `Error` with its
+ *   stack trace in `metadata.stack`.
+ * - When called from a workflow or step, `metadata.span?.attributes` carries
+ *   the operation context (workflow ID, operation name and type, etc.).
+ * - DBOS does not filter by `logLevel` before delegating; level routing is the
+ *   implementation's responsibility.
+ * - DBOS never flushes or closes the logger; the caller owns its lifecycle.
+ * - Implementations must not log back through `DBOS.logger`, which could
+ *   recurse.
+ */
 export interface DLogger {
   info(logEntry: unknown, metadata?: ContextualMetadata): void;
   debug(logEntry: unknown, metadata?: ContextualMetadata): void;

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -243,8 +243,8 @@ export class GlobalLogger {
 
 /**
  * The logger interface used throughout DBOS. Implement this to supply a custom
- * logger through `DBOSConfig.logger` (for example, an adapter over Pino,
- * Winston, or Bunyan).
+ * logger through `DBOSConfig.logger` (for example, an adapter over an existing
+ * logging service).
  *
  * Contract for custom implementations:
  * - Log entries arrive as strings: DBOS stringifies non-string entries before

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -420,6 +420,14 @@ describe('dbos-config', () => {
       expect(internalConfig.systemDatabasePollingConcurrency).toBeUndefined();
     });
 
+    test('translate passes through a custom logger', () => {
+      const myLogger = { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+      let internalConfig = translateDbosConfig({ name: 'dbostest', logger: myLogger });
+      expect(internalConfig.telemetry.logs?.logger).toBe(myLogger);
+      internalConfig = translateDbosConfig({ name: 'dbostest' });
+      expect(internalConfig.telemetry.logs?.logger).toBeUndefined();
+    });
+
     test('translate with force console', () => {
       const internalConfig = translateDbosConfig(
         {

--- a/tests/customlogger.test.ts
+++ b/tests/customlogger.test.ts
@@ -69,6 +69,9 @@ describe('custom-logger', () => {
       DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder, tracingEnabled: true });
       await DBOS.launch();
 
+      // Internal lifecycle logs must also flow through the custom logger.
+      expect(recorder.find('info', 'DBOS launched!')).toBeDefined();
+
       const wfid = randomUUID();
       await DBOS.withNextWorkflowID(wfid, async () => {
         await LoggingWF.loggingWorkflow();
@@ -86,11 +89,13 @@ describe('custom-logger', () => {
       expect(stepEntry?.metadata?.span?.attributes?.operationType).toBe('step');
       expect(stepEntry?.metadata?.span?.attributes?.operationName).toBe('loggingStep');
 
-      // The markers must reach only the custom logger, not a built-in console sink.
+      // Both user markers and internal logs must reach only the custom logger,
+      // not a built-in console sink.
       for (const spy of consoleSpies) {
         for (const call of spy.mock.calls) {
           expect(String(call[0])).not.toContain('marker-in-wf');
           expect(String(call[0])).not.toContain('marker-in-step');
+          expect(String(call[0])).not.toContain('DBOS launched!');
         }
       }
     } finally {

--- a/tests/customlogger.test.ts
+++ b/tests/customlogger.test.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from 'node:crypto';
+import { ContextualMetadata, DBOS, DBOSClient, DLogger, StackTrace } from '../src';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
+
+type RecordedEntry = {
+  level: 'info' | 'debug' | 'warn' | 'error';
+  entry: unknown;
+  metadata?: ContextualMetadata & StackTrace;
+};
+
+class RecorderLogger implements DLogger {
+  readonly entries: RecordedEntry[] = [];
+
+  info(logEntry: unknown, metadata?: ContextualMetadata): void {
+    this.entries.push({ level: 'info', entry: logEntry, metadata });
+  }
+  debug(logEntry: unknown, metadata?: ContextualMetadata): void {
+    this.entries.push({ level: 'debug', entry: logEntry, metadata });
+  }
+  warn(logEntry: unknown, metadata?: ContextualMetadata): void {
+    this.entries.push({ level: 'warn', entry: logEntry, metadata });
+  }
+  error(inputError: unknown, metadata?: ContextualMetadata & StackTrace): void {
+    this.entries.push({ level: 'error', entry: inputError, metadata });
+  }
+
+  find(level: RecordedEntry['level'], entry: unknown): RecordedEntry | undefined {
+    return this.entries.find((e) => e.level === level && e.entry === entry);
+  }
+}
+
+class LoggingWF {
+  @DBOS.step()
+  static async loggingStep() {
+    DBOS.logger.info('marker-in-step');
+    return Promise.resolve(1);
+  }
+
+  @DBOS.workflow()
+  static async loggingWorkflow() {
+    DBOS.logger.info('marker-in-wf');
+    return await LoggingWF.loggingStep();
+  }
+}
+
+describe('custom-logger', () => {
+  let recorder: RecorderLogger;
+
+  beforeAll(async () => {
+    await setUpDBOSTestSysDb(generateDBOSTestConfig());
+  });
+
+  beforeEach(() => {
+    recorder = new RecorderLogger();
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  });
+
+  test('workflow and step logs reach the custom logger with context metadata', async () => {
+    const consoleSpies = [
+      jest.spyOn(console, 'log'),
+      jest.spyOn(console, 'debug'),
+      jest.spyOn(console, 'warn'),
+      jest.spyOn(console, 'error'),
+    ];
+    try {
+      DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder, tracingEnabled: true });
+      await DBOS.launch();
+
+      const wfid = randomUUID();
+      await DBOS.withNextWorkflowID(wfid, async () => {
+        await LoggingWF.loggingWorkflow();
+      });
+
+      const wfEntry = recorder.find('info', 'marker-in-wf');
+      expect(wfEntry).toBeDefined();
+      expect(wfEntry?.metadata?.span?.attributes?.operationUUID).toBe(wfid);
+      expect(wfEntry?.metadata?.span?.attributes?.operationType).toBe('workflow');
+      expect(wfEntry?.metadata?.span?.attributes?.operationName).toBe('loggingWorkflow');
+
+      const stepEntry = recorder.find('info', 'marker-in-step');
+      expect(stepEntry).toBeDefined();
+      expect(stepEntry?.metadata?.span?.attributes?.operationUUID).toBe(wfid);
+      expect(stepEntry?.metadata?.span?.attributes?.operationType).toBe('step');
+      expect(stepEntry?.metadata?.span?.attributes?.operationName).toBe('loggingStep');
+
+      // The markers must reach only the custom logger, not a built-in console sink.
+      for (const spy of consoleSpies) {
+        for (const call of spy.mock.calls) {
+          expect(String(call[0])).not.toContain('marker-in-wf');
+          expect(String(call[0])).not.toContain('marker-in-step');
+        }
+      }
+    } finally {
+      consoleSpies.forEach((s) => s.mockRestore());
+    }
+  });
+
+  test('error entries are normalized to message plus stack metadata', async () => {
+    DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder });
+    await DBOS.launch();
+
+    DBOS.logger.error(new Error('boom'));
+    const entry = recorder.find('error', 'boom');
+    expect(entry).toBeDefined();
+    expect(typeof entry?.metadata?.stack).toBe('string');
+  });
+
+  test('non-string entries are stringified before delegation', async () => {
+    DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder });
+    await DBOS.launch();
+
+    DBOS.logger.info({ a: 1 });
+    const entry = recorder.entries.find(
+      (e) => e.level === 'info' && typeof e.entry === 'string' && e.entry.includes('"a":1'),
+    );
+    expect(entry).toBeDefined();
+  });
+
+  test('logLevel does not filter entries delegated to the custom logger', async () => {
+    DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder, logLevel: 'error' });
+    await DBOS.launch();
+
+    DBOS.logger.debug('debug-marker');
+    expect(recorder.find('debug', 'debug-marker')).toBeDefined();
+  });
+
+  test('DBOS.logger honors the configured logger before launch', () => {
+    DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder });
+    DBOS.logger.info('pre-launch-marker');
+    expect(recorder.find('info', 'pre-launch-marker')).toBeDefined();
+  });
+
+  test('custom logger takes over when OTLP is enabled', async () => {
+    const logSpy = jest.spyOn(console, 'log');
+    try {
+      DBOS.setConfig({ ...generateDBOSTestConfig(), logger: recorder, enableOTLP: true });
+      await DBOS.launch();
+
+      DBOS.logger.info('otlp-marker');
+      expect(recorder.find('info', 'otlp-marker')).toBeDefined();
+      for (const call of logSpy.mock.calls) {
+        expect(String(call[0])).not.toContain('otlp-marker');
+      }
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  test('DBOSClient logs through an injected logger', async () => {
+    const config = generateDBOSTestConfig();
+    const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl!, logger: recorder });
+    try {
+      (client as unknown as { logger: DLogger }).logger.info('client-marker');
+      expect(recorder.find('info', 'client-marker')).toBeDefined();
+    } finally {
+      await client.destroy();
+    }
+  });
+});

--- a/tests/customlogger.test.ts
+++ b/tests/customlogger.test.ts
@@ -138,6 +138,21 @@ describe('custom-logger', () => {
     expect(recorder.find('info', 'pre-launch-marker')).toBeDefined();
   });
 
+  test('DBOS.logger honors the configured logLevel before launch', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    try {
+      DBOS.setConfig({ ...generateDBOSTestConfig(), logLevel: 'error' });
+      DBOS.logger.debug('pre-launch-debug-marker');
+      expect(debugSpy.mock.calls.some((c) => String(c[0]).includes('pre-launch-debug-marker'))).toBe(false);
+
+      DBOS.setConfig({ ...generateDBOSTestConfig(), logLevel: 'debug' });
+      DBOS.logger.debug('pre-launch-debug-marker');
+      expect(debugSpy.mock.calls.some((c) => String(c[0]).includes('pre-launch-debug-marker'))).toBe(true);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
   test('custom logger takes over when OTLP is enabled', async () => {
     const logSpy = jest.spyOn(console, 'log');
     try {


### PR DESCRIPTION
You can now pass in a custom logger to DBOS by implementing the `DLogger` interface. This custom logger is used for all DBOS internal logging.


Closes https://github.com/dbos-inc/dbos-transact-ts/issues/1270