### PR TITLE
Step Timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "name": "@dbos-inc/dbos-sdk",
       "version": "0.0.0-placeholder",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],

--- a/packages/create/templates/dbos-drizzle/package.json
+++ b/packages/create/templates/dbos-drizzle/package.json
@@ -13,7 +13,7 @@
     "@dbos-inc/eslint-plugin": "^3.3.4",
     "@types/jest": "^29.5.12",
     "@types/supertest": "^2.0.16",
-    "drizzle-kit": "^0.31.4",
+    "drizzle-kit": "^0.31.10",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@dbos-inc/dbos-sdk": "file:../../../..",
     "@dbos-inc/drizzle-datasource": "file:../../../drizzle-datasource",
-    "drizzle-orm": "^0.44.3",
+    "drizzle-orm": "^0.45.2",
     "express": "^4.21.2"
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,6 +11,11 @@ export interface StepStatus {
   stepID: number;
   currentAttempt?: number;
   maxAttempts?: number;
+  /**
+   * If the step is configured with `timeoutMS`: fires when the current attempt's timeout expires,
+   * so the step can cancel its underlying operation. A fresh signal is issued for each retry attempt.
+   */
+  timeoutSignal?: AbortSignal;
 }
 
 export interface DBOSContextOptions {
@@ -143,6 +148,7 @@ export async function runInStepContext<R>(
   stepID: number,
   maxAttempts: number | undefined,
   currentAttempt: number | undefined,
+  timeoutSignal: AbortSignal | undefined,
   callback: () => Promise<R>,
 ) {
   // Check we are in a workflow context and not in a step / transaction already
@@ -153,6 +159,7 @@ export async function runInStepContext<R>(
     stepID: stepID,
     currentAttempt: currentAttempt,
     maxAttempts: currentAttempt ? maxAttempts : undefined,
+    timeoutSignal: timeoutSignal,
   };
 
   return await runWithParentContext(

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -24,7 +24,7 @@ import {
   WorkflowSerializationFormat,
 } from './workflow';
 
-import { type StepConfig } from './step';
+import { type StepConfig, validateStepConfig } from './step';
 import { TelemetryCollector } from './telemetry/collector';
 import { getActiveSpan, runWithTrace, SpanStatusCode, Tracer } from './telemetry/traces';
 import { DBOSContextualLogger, DLogger, GlobalLogger } from './telemetry/logs';
@@ -791,6 +791,7 @@ export class DBOSExecutor {
     if (stepConfig === undefined) {
       throw new DBOSNotRegisteredError(stepFnName);
     }
+    validateStepConfig(stepConfig, stepFnName);
 
     // Intentionally advance the function ID before any awaits, then work with a copy of the context.
     const funcID = functionIDGetIncrement();

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -816,13 +816,23 @@ export class DBOSExecutor {
       timeoutMS: stepConfig.timeoutMS,
     });
 
+    // For errors that propagate without being recorded as the step's outcome (e.g. workflow cancellation):
+    // mark the span failed and end it before rethrowing.
+    const endSpanAndRethrow = (e: unknown): never => {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (e as Error).message });
+      this.tracer.endSpan(span);
+      throw e;
+    };
+
     // Check if this execution previously happened, returning its original result if it did.
-    const checkr = await this.systemDatabase.getOperationResultAndThrowIfCancelled(wfid, funcID);
+    const checkr = await this.systemDatabase
+      .getOperationResultAndThrowIfCancelled(wfid, funcID)
+      .catch(endSpanAndRethrow);
     if (checkr) {
       if (checkr.functionName !== stepFnName) {
-        throw new DBOSUnexpectedStepError(wfid, funcID, stepFnName, checkr.functionName ?? '?');
+        endSpanAndRethrow(new DBOSUnexpectedStepError(wfid, funcID, stepFnName, checkr.functionName ?? '?'));
       }
-      const check = await DBOSExecutor.reviveResultOrError<R>(checkr, this.serializer);
+      const check = await DBOSExecutor.reviveResultOrError<R>(checkr, this.serializer).catch(endSpanAndRethrow);
       span.setAttribute('cached', true);
       span.setStatus({ code: SpanStatusCode.OK });
       this.tracer.endSpan(span);
@@ -883,7 +893,7 @@ export class DBOSExecutor {
       }
       while (result === dbosNull && attemptNum++ < (maxAttempts ?? 3)) {
         // Outside the try so workflow cancellation propagates immediately instead of consuming the remaining attempts
-        await this.systemDatabase.checkIfCanceled(wfid);
+        await this.systemDatabase.checkIfCanceled(wfid).catch(endSpanAndRethrow);
         try {
           result = await invokeStepAttempt(attemptNum);
         } catch (error) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -836,7 +836,8 @@ export class DBOSExecutor {
     // If `timeoutMS` is set, race the attempt against a timer, firing the attempt's AbortSignal
     // (exposed as `DBOS.stepStatus.timeoutSignal`) so the step can cancel its underlying operation.
     // A timed-out attempt is abandoned: it has no path to record a result, and its eventual
-    // rejection (if any) is swallowed.
+    // settlement is discarded (Promise.race keeps the abandoned promise's rejection handled,
+    // so it never surfaces as an unhandled rejection).
     const invokeStepAttempt = async (attemptNum: number | undefined): Promise<R> => {
       const timeoutAbort = timeoutMS === undefined ? undefined : new AbortController();
       let cresult: R | undefined;
@@ -862,11 +863,6 @@ export class DBOSExecutor {
       try {
         await Promise.race([attemptPromise, timeoutPromise]);
         return cresult!;
-      } catch (e) {
-        if (e === timeoutError) {
-          attemptPromise.catch(() => {});
-        }
-        throw e;
       } finally {
         clearTimeout(timeoutID);
       }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -882,8 +882,9 @@ export class DBOSExecutor {
         );
       }
       while (result === dbosNull && attemptNum++ < (maxAttempts ?? 3)) {
+        // Outside the try so workflow cancellation propagates immediately instead of consuming the remaining attempts
+        await this.systemDatabase.checkIfCanceled(wfid);
         try {
-          await this.systemDatabase.checkIfCanceled(wfid);
           result = await invokeStepAttempt(attemptNum);
         } catch (error) {
           const e = error as Error;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -8,6 +8,7 @@ import {
   DBOSUnexpectedStepError,
   DBOSAwaitedWorkflowCancelledError,
   DBOSQueueDuplicatedError,
+  DBOSStepTimeoutError,
 } from './error';
 import {
   InvokedHandle,
@@ -811,6 +812,7 @@ export class DBOSExecutor {
       intervalSeconds: stepConfig.intervalSeconds,
       maxAttempts: stepConfig.maxAttempts,
       backoffRate: stepConfig.backoffRate,
+      timeoutMS: stepConfig.timeoutMS,
     });
 
     // Check if this execution previously happened, returning its original result if it did.
@@ -827,6 +829,47 @@ export class DBOSExecutor {
     }
 
     const maxAttempts = stepConfig.maxAttempts ?? 3;
+    const timeoutMS = stepConfig.timeoutMS;
+
+    // Run a single attempt of the step function.
+    // If `timeoutMS` is set, race the attempt against a timer, firing the attempt's AbortSignal
+    // (exposed as `DBOS.stepStatus.timeoutSignal`) so the step can cancel its underlying operation.
+    // A timed-out attempt is abandoned: it has no path to record a result, and its eventual
+    // rejection (if any) is swallowed.
+    const invokeStepAttempt = async (attemptNum: number | undefined): Promise<R> => {
+      const timeoutAbort = timeoutMS === undefined ? undefined : new AbortController();
+      let cresult: R | undefined;
+      const attemptPromise = runWithTrace(span, async () => {
+        await runInStepContext(lctx, funcID, maxAttempts, attemptNum, timeoutAbort?.signal, async () => {
+          const sf = stepFn as unknown as (...args: T) => Promise<R>;
+          cresult = await sf.call(clsInst, ...args);
+        });
+      });
+      if (timeoutMS === undefined) {
+        await attemptPromise;
+        return cresult!;
+      }
+
+      const timeoutError = new DBOSStepTimeoutError(stepFnName, timeoutMS);
+      let timeoutID: ReturnType<typeof setTimeout> | undefined = undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutID = setTimeout(() => {
+          timeoutAbort!.abort(timeoutError);
+          reject(timeoutError);
+        }, timeoutMS);
+      });
+      try {
+        await Promise.race([attemptPromise, timeoutPromise]);
+        return cresult!;
+      } catch (e) {
+        if (e === timeoutError) {
+          attemptPromise.catch(() => {});
+        }
+        throw e;
+      } finally {
+        clearTimeout(timeoutID);
+      }
+    };
 
     // Execute the step function.  If it throws an exception, retry with exponential backoff.
     // After reaching the maximum number of retries, throw an DBOSError.
@@ -844,15 +887,7 @@ export class DBOSExecutor {
       while (result === dbosNull && attemptNum++ < (maxAttempts ?? 3)) {
         try {
           await this.systemDatabase.checkIfCanceled(wfid);
-
-          let cresult: R | undefined;
-          await runWithTrace(span, async () => {
-            await runInStepContext(lctx, funcID, maxAttempts, attemptNum, async () => {
-              const sf = stepFn as unknown as (...args: T) => Promise<R>;
-              cresult = await sf.call(clsInst, ...args);
-            });
-          });
-          result = cresult!;
+          result = await invokeStepAttempt(attemptNum);
         } catch (error) {
           const e = error as Error;
           if (stepConfig.shouldRetry) {
@@ -901,14 +936,7 @@ export class DBOSExecutor {
       }
     } else {
       try {
-        let cresult: R | undefined;
-        await runWithTrace(span, async () => {
-          await runInStepContext(lctx, funcID, maxAttempts, undefined, async () => {
-            const sf = stepFn as unknown as (...args: T) => Promise<R>;
-            cresult = await sf.call(clsInst, ...args);
-          });
-        });
-        result = cresult!;
+        result = await invokeStepAttempt(undefined);
       } catch (error) {
         err = error as Error;
       }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -104,7 +104,7 @@ import { Server } from 'http';
 
 import { randomUUID } from 'node:crypto';
 
-import { StepConfig } from './step';
+import { StepConfig, validateStepConfig } from './step';
 import { Conductor } from './conductor/conductor';
 import {
   DuplicationPolicy,
@@ -2065,6 +2065,7 @@ export class DBOS {
     config: StepConfig & FunctionName = {},
   ): (this: This, ...args: Args) => Promise<Return> {
     const name = config.name ?? func.name;
+    validateStepConfig(config, name);
 
     const reg = wrapDBOSFunctionAndRegister(config?.ctorOrProto, config?.className, name, name, func);
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 import { WorkflowConfig } from './workflow';
-import { StepConfig } from './step';
+import { StepConfig, validateStepConfig } from './step';
 import { DBOSConflictingRegistrationError, DBOSNotRegisteredError } from './error';
 import { DataSourceTransactionHandler } from './datasource';
 
@@ -407,6 +407,7 @@ export class MethodRegistration<This, Args extends unknown[], Return> implements
 
   setStepConfig(stepCfg: StepConfig): void {
     this.checkFuncTypeUnassigned('Step');
+    validateStepConfig(stepCfg, `${this.getClassName()}.${this.name}`);
     this.stepConfig = stepCfg;
   }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -200,6 +200,17 @@ export class DBOSAwaitedWorkflowExceededMaxRecoveryAttempts extends DBOSError {
   }
 }
 
+const StepTimeout = 31;
+/** Exception raised when a single attempt of a step exceeds its configured `timeoutMS` */
+export class DBOSStepTimeoutError extends DBOSError {
+  constructor(
+    readonly stepName: string,
+    readonly timeoutMS: number,
+  ) {
+    super(`Step ${stepName} timed out after ${timeoutMS}ms`, StepTimeout);
+  }
+}
+
 export function getDBOSErrorCode(e: Error): number | undefined {
   if (e && typeof e === 'object' && 'dbosErrorCode' in e) {
     const code = (e as Record<string, unknown>).dbosErrorCode;

--- a/src/step.ts
+++ b/src/step.ts
@@ -1,3 +1,5 @@
+import { DBOSError } from './error';
+
 /**
  * Configuration options for a `DBOS.step` function
  */
@@ -21,4 +23,14 @@ export interface StepConfig {
   timeoutMS?: number;
   /** If specified, override step function name */
   name?: string;
+}
+
+/** Validate a step configuration, throwing `DBOSError` if it is invalid. */
+export function validateStepConfig(config: StepConfig, stepName: string): void {
+  const timeoutMS = config.timeoutMS;
+  if (timeoutMS !== undefined && (typeof timeoutMS !== 'number' || !Number.isFinite(timeoutMS) || timeoutMS <= 0)) {
+    throw new DBOSError(
+      `Invalid timeoutMS (${timeoutMS}) in configuration of step ${stepName}: must be a positive number`,
+    );
+  }
 }

--- a/src/step.ts
+++ b/src/step.ts
@@ -12,6 +12,13 @@ export interface StepConfig {
   backoffRate?: number;
   /** If `retriesAllowed` is true: called after a step throws to decide whether to retry that error. Defaults to retrying every error. */
   shouldRetry?: (error: unknown) => boolean | Promise<boolean>;
+  /**
+   * Maximum duration in milliseconds of a single attempt of this step.
+   * An attempt exceeding this fails with `DBOSStepTimeoutError`; if `retriesAllowed` is true, it is retried like any other failure.
+   * While an attempt runs, `DBOS.stepStatus.timeoutSignal` fires when the timeout expires so the step can cancel its underlying operation.
+   * Note the attempt's code is not forcibly terminated: code that does not observe the signal keeps running in the background and its result is discarded.
+   */
+  timeoutMS?: number;
   /** If specified, override step function name */
   name?: string;
 }

--- a/tests/scheduler_decorator.test.ts
+++ b/tests/scheduler_decorator.test.ts
@@ -185,12 +185,14 @@ describe('cf-scheduled-wf-tests-when-active', () => {
 
   test('wf-scheduled-recover', async () => {
     DBOSSchedTestClass.reset(false);
+    const firstLaunchTime = process.hrtime();
     await DBOS.launch();
     await DBOS.registerQueue(q.name, { onConflict: 'always_update', concurrency: 1 });
     try {
       await sleepms(3000);
       expect(DBOSSchedTestClass.nCalls).toBeGreaterThanOrEqual(1);
-      expect(DBOSSchedTestClass.nCalls).toBeLessThanOrEqual(4);
+      // Only the intervals elapsed since launch, +1 for boundary alignment and +1 for a recovered in-flight workflow
+      expect(DBOSSchedTestClass.nCalls).toBeLessThanOrEqual(process.hrtime(firstLaunchTime)[0] + 2);
       expect(DBOSSchedTestClass.nQCalls).toBeGreaterThanOrEqual(1); // This has some delay, potentially...
 
       const wfs = await DBOS.listWorkflows({
@@ -208,12 +210,15 @@ describe('cf-scheduled-wf-tests-when-active', () => {
     }
     await sleepms(5000);
     DBOSSchedTestClass.reset(false);
+    const secondLaunchTime = process.hrtime();
     await DBOS.launch();
     await DBOS.registerQueue(q.name, { onConflict: 'always_update', concurrency: 1 });
     try {
       await sleepms(3000);
       expect(DBOSSchedTestClass.nCalls).toBeGreaterThanOrEqual(1); // 3 new ones, +/- 1
-      expect(DBOSSchedTestClass.nCalls).toBeLessThanOrEqual(4); // No old ones from recovery or sleep interval
+      // None of the ~5 missed during the downtime: only the intervals elapsed since relaunch,
+      // +1 for boundary alignment and +1 for a recovered in-flight workflow
+      expect(DBOSSchedTestClass.nCalls).toBeLessThanOrEqual(process.hrtime(secondLaunchTime)[0] + 2);
     } finally {
       await DBOS.shutdown();
     }

--- a/tests/step_timeout.test.ts
+++ b/tests/step_timeout.test.ts
@@ -93,6 +93,11 @@ class StepTimeoutTestClass {
   }
 
   @DBOS.workflow()
+  static async badRunStepWorkflow() {
+    return await DBOS.runStep(async () => Promise.resolve(1), { name: 'bad-run-step', timeoutMS: -5 });
+  }
+
+  @DBOS.workflow()
   static async runStepTimeoutWorkflow() {
     return await DBOS.runStep(
       async () => {
@@ -195,6 +200,33 @@ describe('step-timeout-tests', () => {
 
   test('no-timeout-no-signal', async () => {
     await expect(StepTimeoutTestClass.plainStep()).resolves.toBe('plain');
+  });
+
+  test('invalid-timeoutMS-is-rejected', async () => {
+    // At registration, via DBOS.registerStep
+    for (const timeoutMS of [0, -100, NaN, Infinity]) {
+      expect(() =>
+        DBOS.registerStep(async () => Promise.resolve(), { name: `bad-step-${timeoutMS}`, timeoutMS }),
+      ).toThrow(`Invalid timeoutMS (${timeoutMS}) in configuration of step bad-step-${timeoutMS}`);
+    }
+
+    // At class definition, via the @DBOS.step decorator (registration requires DBOS to not be launched)
+    await DBOS.shutdown();
+    expect(() => {
+      class BadStepClass {
+        @DBOS.step({ name: 'bad-decorated-step', timeoutMS: -1 })
+        static async badStep() {
+          return Promise.resolve();
+        }
+      }
+      void BadStepClass;
+    }).toThrow('Invalid timeoutMS (-1)');
+    await DBOS.launch();
+
+    // At call time, via DBOS.runStep
+    await expect(StepTimeoutTestClass.badRunStepWorkflow()).rejects.toThrow(
+      'Invalid timeoutMS (-5) in configuration of step bad-run-step',
+    );
   });
 
   test('workflow-deadline-wins-over-step-timeout', async () => {

--- a/tests/step_timeout.test.ts
+++ b/tests/step_timeout.test.ts
@@ -5,6 +5,10 @@ import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
 import { DBOSMaxStepRetriesError, DBOSStepTimeoutError, DBOSWorkflowCancelledError } from '../src/error';
 import { StatusString } from '../src/workflow';
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // Sleep that resolves after `ms`, or rejects with the signal's reason when it aborts.
 // Models a step operation that cooperatively cancels on timeout.
 function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
@@ -29,11 +33,13 @@ class StepTimeoutTestClass {
   static attempts = 0;
   static abortsObserved = 0;
   static hangAttempts = 0; // The first `hangAttempts` attempts hang until aborted
+  static zombieDone = false;
 
   static reset() {
     StepTimeoutTestClass.attempts = 0;
     StepTimeoutTestClass.abortsObserved = 0;
     StepTimeoutTestClass.hangAttempts = 0;
+    StepTimeoutTestClass.zombieDone = false;
   }
 
   static async slowStepGuts() {
@@ -90,6 +96,40 @@ class StepTimeoutTestClass {
     } catch (e) {
       return `caught: ${(e as Error).message}`;
     }
+  }
+
+  // Ignores the timeout signal: the first attempt keeps running long past the timeout, then resolves
+  @DBOS.step({ retriesAllowed: true, maxAttempts: 2, intervalSeconds: 0, timeoutMS: 100 })
+  static async uncooperativeStep() {
+    StepTimeoutTestClass.attempts++;
+    if (StepTimeoutTestClass.attempts === 1) {
+      await sleep(1000);
+      StepTimeoutTestClass.zombieDone = true;
+      return 'zombie';
+    }
+    return 'fresh';
+  }
+
+  // Ignores the timeout signal: the first attempt keeps running long past the timeout, then rejects
+  @DBOS.step({ retriesAllowed: true, maxAttempts: 2, intervalSeconds: 0, timeoutMS: 100 })
+  static async uncooperativeThrowingStep() {
+    StepTimeoutTestClass.attempts++;
+    if (StepTimeoutTestClass.attempts === 1) {
+      await sleep(1000);
+      StepTimeoutTestClass.zombieDone = true;
+      throw new Error('zombie rejection');
+    }
+    return 'fresh';
+  }
+
+  @DBOS.workflow()
+  static async uncooperativeStepWorkflow() {
+    return await StepTimeoutTestClass.uncooperativeStep();
+  }
+
+  @DBOS.workflow()
+  static async uncooperativeThrowingStepWorkflow() {
+    return await StepTimeoutTestClass.uncooperativeThrowingStep();
   }
 
   @DBOS.workflow()
@@ -200,6 +240,51 @@ describe('step-timeout-tests', () => {
 
   test('no-timeout-no-signal', async () => {
     await expect(StepTimeoutTestClass.plainStep()).resolves.toBe('plain');
+  });
+
+  test('uncooperative-zombie-resolution-is-discarded', async () => {
+    const wfid = randomUUID();
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await expect(StepTimeoutTestClass.uncooperativeStepWorkflow()).resolves.toBe('fresh');
+    });
+    expect(StepTimeoutTestClass.attempts).toBe(2);
+    // The retry won while the abandoned first attempt was still running
+    expect(StepTimeoutTestClass.zombieDone).toBe(false);
+
+    // Let the abandoned attempt run to completion, then confirm its result went nowhere
+    while (!StepTimeoutTestClass.zombieDone) {
+      await sleep(50);
+    }
+    const steps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].output).toBe('fresh');
+
+    const status = await DBOS.getWorkflowStatus(wfid);
+    expect(status?.status).toBe(StatusString.SUCCESS);
+  });
+
+  test('uncooperative-zombie-rejection-is-swallowed', async () => {
+    const zombieRejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      if (reason instanceof Error && reason.message === 'zombie rejection') {
+        zombieRejections.push(reason);
+      }
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(StepTimeoutTestClass.uncooperativeThrowingStepWorkflow()).resolves.toBe('fresh');
+      expect(StepTimeoutTestClass.attempts).toBe(2);
+
+      // Let the abandoned attempt reject, then give the event loop a beat to surface any unhandled rejection
+      while (!StepTimeoutTestClass.zombieDone) {
+        await sleep(50);
+      }
+      await sleep(100);
+      expect(zombieRejections.length).toBe(0);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
   });
 
   test('invalid-timeoutMS-is-rejected', async () => {

--- a/tests/step_timeout.test.ts
+++ b/tests/step_timeout.test.ts
@@ -322,5 +322,11 @@ describe('step-timeout-tests', () => {
     await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
     const status = await DBOS.getWorkflowStatus(workflowID);
     expect(status?.status).toBe(StatusString.CANCELLED);
+
+    // The cancellation stopped the retry loop after the first attempt instead of consuming all three,
+    // and was not recorded as the step's durable result
+    expect(StepTimeoutTestClass.attempts).toBe(1);
+    const steps = (await DBOS.listWorkflowSteps(workflowID))!;
+    expect(steps.length).toBe(0);
   });
 });

--- a/tests/step_timeout.test.ts
+++ b/tests/step_timeout.test.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from 'node:crypto';
+import { DBOS } from '../src';
+import { DBOSConfig } from '../src/dbos-executor';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
+import { DBOSMaxStepRetriesError, DBOSStepTimeoutError, DBOSWorkflowCancelledError } from '../src/error';
+import { StatusString } from '../src/workflow';
+
+// Sleep that resolves after `ms`, or rejects with the signal's reason when it aborts.
+// Models a step operation that cooperatively cancels on timeout.
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason as Error);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal!.reason as Error);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+class StepTimeoutTestClass {
+  static attempts = 0;
+  static abortsObserved = 0;
+  static hangAttempts = 0; // The first `hangAttempts` attempts hang until aborted
+
+  static reset() {
+    StepTimeoutTestClass.attempts = 0;
+    StepTimeoutTestClass.abortsObserved = 0;
+    StepTimeoutTestClass.hangAttempts = 0;
+  }
+
+  static async slowStepGuts() {
+    StepTimeoutTestClass.attempts++;
+    const signal = DBOS.stepStatus?.timeoutSignal;
+    expect(signal).toBeDefined();
+    if (StepTimeoutTestClass.attempts <= StepTimeoutTestClass.hangAttempts) {
+      try {
+        await sleepUnlessAborted(5000, signal);
+      } catch (e) {
+        StepTimeoutTestClass.abortsObserved++;
+        throw e;
+      }
+    }
+    return StepTimeoutTestClass.attempts;
+  }
+
+  @DBOS.step({ retriesAllowed: true, maxAttempts: 3, intervalSeconds: 0, timeoutMS: 200 })
+  static async slowStep() {
+    return await StepTimeoutTestClass.slowStepGuts();
+  }
+
+  @DBOS.step({
+    retriesAllowed: true,
+    maxAttempts: 3,
+    intervalSeconds: 0,
+    timeoutMS: 200,
+    shouldRetry: (e) => !(e instanceof DBOSStepTimeoutError),
+  })
+  static async noRetryOnTimeoutStep() {
+    return await StepTimeoutTestClass.slowStepGuts();
+  }
+
+  @DBOS.step({ retriesAllowed: false, timeoutMS: 200 })
+  static async noRetriesStep() {
+    return await StepTimeoutTestClass.slowStepGuts();
+  }
+
+  @DBOS.step()
+  static async plainStep() {
+    expect(DBOS.stepStatus?.timeoutSignal).toBeUndefined();
+    return Promise.resolve('plain');
+  }
+
+  @DBOS.workflow()
+  static async slowStepWorkflow() {
+    return await StepTimeoutTestClass.slowStep();
+  }
+
+  @DBOS.workflow()
+  static async catchTimeoutWorkflow() {
+    try {
+      return await StepTimeoutTestClass.noRetryOnTimeoutStep();
+    } catch (e) {
+      return `caught: ${(e as Error).message}`;
+    }
+  }
+
+  @DBOS.workflow()
+  static async runStepTimeoutWorkflow() {
+    return await DBOS.runStep(
+      async () => {
+        return await StepTimeoutTestClass.slowStepGuts();
+      },
+      { name: 'run-step-with-timeout', retriesAllowed: true, maxAttempts: 2, intervalSeconds: 0, timeoutMS: 200 },
+    );
+  }
+}
+
+describe('step-timeout-tests', () => {
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestSysDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    StepTimeoutTestClass.reset();
+    await DBOS.launch();
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  });
+
+  test('timeout-attempt-is-retried-then-succeeds', async () => {
+    const wfid = randomUUID();
+    StepTimeoutTestClass.hangAttempts = 1;
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await expect(StepTimeoutTestClass.slowStepWorkflow()).resolves.toBe(2);
+    });
+    expect(StepTimeoutTestClass.attempts).toBe(2);
+    expect(StepTimeoutTestClass.abortsObserved).toBe(1);
+
+    // The step timeout did not cancel the workflow
+    const status = await DBOS.getWorkflowStatus(wfid);
+    expect(status?.status).toBe(StatusString.SUCCESS);
+  });
+
+  test('timeouts-exhaust-retries', async () => {
+    StepTimeoutTestClass.hangAttempts = 3;
+
+    try {
+      await StepTimeoutTestClass.slowStepWorkflow();
+      expect(true).toBe(false); // An exception should be thrown first
+    } catch (error) {
+      const e = error as DBOSMaxStepRetriesError;
+      expect(e).toBeInstanceOf(DBOSMaxStepRetriesError);
+      expect(e.errors.length).toBe(3);
+      expect(e.errors.every((err) => err instanceof DBOSStepTimeoutError)).toBe(true);
+      expect(e.errors[0].message).toContain('timed out after 200ms');
+    }
+    expect(StepTimeoutTestClass.attempts).toBe(3);
+    expect(StepTimeoutTestClass.abortsObserved).toBe(3);
+  });
+
+  test('shouldRetry-can-opt-out-of-timeouts', async () => {
+    const wfid = randomUUID();
+    StepTimeoutTestClass.hangAttempts = 3;
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await expect(StepTimeoutTestClass.catchTimeoutWorkflow()).resolves.toBe(
+        'caught: Step noRetryOnTimeoutStep timed out after 200ms',
+      );
+    });
+    expect(StepTimeoutTestClass.attempts).toBe(1);
+
+    // The timeout error was durably recorded for the step
+    const steps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].error).not.toBeNull();
+    expect(steps[0].error!.message).toContain('timed out after 200ms');
+  });
+
+  test('timeout-applies-without-retries', async () => {
+    StepTimeoutTestClass.hangAttempts = 1;
+
+    await expect(StepTimeoutTestClass.noRetriesStep()).rejects.toThrow(new DBOSStepTimeoutError('noRetriesStep', 200));
+    expect(StepTimeoutTestClass.attempts).toBe(1);
+    expect(StepTimeoutTestClass.abortsObserved).toBe(1);
+  });
+
+  test('timeout-applies-to-runStep', async () => {
+    StepTimeoutTestClass.hangAttempts = 1;
+
+    await expect(StepTimeoutTestClass.runStepTimeoutWorkflow()).resolves.toBe(2);
+    expect(StepTimeoutTestClass.attempts).toBe(2);
+    expect(StepTimeoutTestClass.abortsObserved).toBe(1);
+  });
+
+  test('fast-step-is-unaffected', async () => {
+    await expect(StepTimeoutTestClass.slowStepWorkflow()).resolves.toBe(1);
+    expect(StepTimeoutTestClass.attempts).toBe(1);
+    expect(StepTimeoutTestClass.abortsObserved).toBe(0);
+  });
+
+  test('no-timeout-no-signal', async () => {
+    await expect(StepTimeoutTestClass.plainStep()).resolves.toBe('plain');
+  });
+
+  test('workflow-deadline-wins-over-step-timeout', async () => {
+    const workflowID = randomUUID();
+    StepTimeoutTestClass.hangAttempts = 3;
+
+    const handle = await DBOS.startWorkflow(StepTimeoutTestClass, { workflowID, timeoutMS: 100 }).slowStepWorkflow();
+    await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
+    const status = await DBOS.getWorkflowStatus(workflowID);
+    expect(status?.status).toBe(StatusString.CANCELLED);
+  });
+});


### PR DESCRIPTION
Implements cooperative step timeouts. You can set them up in step configuration:

```ts
    return await DBOS.runStep(
      async () => {
        return await example_step();
      },
      { name: 'run-step-with-timeout', retriesAllowed: true, timeoutMS: 5000 },
    );
```

A timed out step will throw `DBOSStepTimeoutError`.

An `AbortSignal` is exposed through `DBOS.stepStatus.timeoutSignal` that steps can use to detect when they have timed out and cooperatively abort.

Closes https://github.com/dbos-inc/dbos-transact-ts/issues/1273