### PR TITLE
Cron & Serialization Fixes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -52,6 +52,7 @@ import {
 import { DBOSExecutor } from './dbos-executor';
 import {
   DBOSAwaitedWorkflowCancelledError,
+  DBOSAwaitedWorkflowExceededMaxRecoveryAttempts,
   DBOSInvalidWorkflowTransitionError,
   DBOSQueueDuplicatedError,
 } from './error';
@@ -194,6 +195,9 @@ export class ClientHandle<R> implements WorkflowHandle<R> {
     );
     if (res?.cancelled) {
       throw new DBOSAwaitedWorkflowCancelledError(this.workflowID);
+    }
+    if (res?.maxRecoveryAttemptsExceeded) {
+      throw new DBOSAwaitedWorkflowExceededMaxRecoveryAttempts(this.workflowID);
     }
     return await DBOSExecutor.reviveResultOrError<R>(res!, this.systemDatabase.getSerializer());
   }

--- a/src/scheduler/crontab.ts
+++ b/src/scheduler/crontab.ts
@@ -160,15 +160,9 @@ function convertSteps(expressions: string[]) {
       const values = match[1].split(',');
       const stepValues: string[] = [];
       const divider = parseInt(baseDivider, 10);
-      // A step expression `base/N` selects every Nth value counting from the
-      // lowest value of `base`, not every value divisible by N. Since ranges are
-      // already expanded by this point, `values[0]` is that lowest value. Using
-      // divisibility instead would phase-shift fields whose minimum is not 0
-      // (e.g. day-of-month `*/2` would yield even days instead of 1,3,5,...).
-      const start = parseInt(values[0], 10);
-      for (let j = 0; j < values.length; j++) {
+      for (let j = 0; j <= values.length; j++) {
         const value = parseInt(values[j], 10);
-        if ((value - start) % divider === 0) {
+        if (value % divider === 0) {
           stepValues.push(`${value}`);
         }
       }

--- a/src/scheduler/crontab.ts
+++ b/src/scheduler/crontab.ts
@@ -68,9 +68,31 @@ function convertWeekDayName(weekExpression: string, items: string[]) {
 }
 
 function weekDayNamesConversion(expression: string) {
-  expression = expression.replace('7', '0');
+  // Note: numeric 7 (also a valid alias for Sunday) is intentionally NOT folded
+  // into 0 here. Doing so before ranges are expanded corrupts ranges such as
+  // `5-7` into `5-0`. The 7 -> 0 fold is applied after expansion by
+  // `convertSundaySeven`, so e.g. `5-7` expands to `5,6,7` and then to `5,6,0`.
   expression = convertWeekDayName(expression, weekDays);
   return convertWeekDayName(expression, shortWeekDays);
+}
+
+// In the day-of-week field, 7 is an alias for Sunday (0). This must run AFTER
+// ranges and steps have been expanded so that ranges like `5-7` first expand to
+// `5,6,7` (Fri,Sat,Sun) and only then have the 7 folded into 0. Duplicates that
+// result from the fold (e.g. `0-7` -> `0,1,2,3,4,5,6,0`) are removed while
+// preserving order.
+function convertSundaySeven(expressions: string[]) {
+  const seen = new Set<string>();
+  const folded: string[] = [];
+  for (const value of expressions[5].split(',')) {
+    const day = value === '7' ? '0' : value;
+    if (!seen.has(day)) {
+      seen.add(day);
+      folded.push(day);
+    }
+  }
+  expressions[5] = folded.join(',');
+  return expressions;
 }
 
 function convertAsterisk(expression: string, replacement: string) {
@@ -138,9 +160,15 @@ function convertSteps(expressions: string[]) {
       const values = match[1].split(',');
       const stepValues: string[] = [];
       const divider = parseInt(baseDivider, 10);
-      for (let j = 0; j <= values.length; j++) {
+      // A step expression `base/N` selects every Nth value counting from the
+      // lowest value of `base`, not every value divisible by N. Since ranges are
+      // already expanded by this point, `values[0]` is that lowest value. Using
+      // divisibility instead would phase-shift fields whose minimum is not 0
+      // (e.g. day-of-month `*/2` would yield even days instead of 1,3,5,...).
+      const start = parseInt(values[0], 10);
+      for (let j = 0; j < values.length; j++) {
         const value = parseInt(values[j], 10);
-        if (value % divider === 0) {
+        if ((value - start) % divider === 0) {
           stepValues.push(`${value}`);
         }
       }
@@ -268,6 +296,7 @@ export function convertExpression(crontab: string) {
   expressions = convertSteps(expressions);
 
   expressions = normalizeIntegers(expressions);
+  expressions = convertSundaySeven(expressions);
 
   return expressions.join(' ');
 }

--- a/src/scheduler/crontab.ts
+++ b/src/scheduler/crontab.ts
@@ -68,19 +68,12 @@ function convertWeekDayName(weekExpression: string, items: string[]) {
 }
 
 function weekDayNamesConversion(expression: string) {
-  // Note: numeric 7 (also a valid alias for Sunday) is intentionally NOT folded
-  // into 0 here. Doing so before ranges are expanded corrupts ranges such as
-  // `5-7` into `5-0`. The 7 -> 0 fold is applied after expansion by
-  // `convertSundaySeven`, so e.g. `5-7` expands to `5,6,7` and then to `5,6,0`.
+  // Don't fold 7 (Sunday) into 0 here: pre-expansion it corrupts ranges like 5-7. See convertSundaySeven.
   expression = convertWeekDayName(expression, weekDays);
   return convertWeekDayName(expression, shortWeekDays);
 }
 
-// In the day-of-week field, 7 is an alias for Sunday (0). This must run AFTER
-// ranges and steps have been expanded so that ranges like `5-7` first expand to
-// `5,6,7` (Fri,Sat,Sun) and only then have the 7 folded into 0. Duplicates that
-// result from the fold (e.g. `0-7` -> `0,1,2,3,4,5,6,0`) are removed while
-// preserving order.
+// Fold day-of-week 7 (Sunday) into 0 after range/step expansion, removing resulting duplicates.
 function convertSundaySeven(expressions: string[]) {
   const seen = new Set<string>();
   const folded: string[] = [];

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -3870,9 +3870,7 @@ export class SystemDatabase {
         error: rows[0].error,
         childWorkflowID: rows[0].child_workflow_id,
         functionName: rows[0].function_name,
-        // Steps such as recv/getEvent persist the serialization format used for
-        // their output; it must be returned so OAOO replay deserializes with the
-        // same serializer rather than falling back to the default one.
+        // Return serialization so recv/getEvent replay deserializes with the stored format, not the default.
         serialization: rows[0].serialization,
       };
     }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2108,7 +2108,7 @@ export class SystemDatabase {
           `INSERT INTO "${this.schemaName}".workflow_events_history (workflow_uuid, function_id, key, value, serialization)
              VALUES ($1, $2, $3, $4, $5)
              ON CONFLICT (workflow_uuid, function_id, key)
-             DO UPDATE SET value = $4;`,
+             DO UPDATE SET value = $4, serialization = $5;`,
           [workflowID, functionID, key, message, serialization],
         );
         return undefined;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -48,7 +48,7 @@ export interface SystemDatabaseStoredResult {
   maxRecoveryAttemptsExceeded?: boolean;
   childWorkflowID?: string | null;
   functionName?: string;
-  serialization?: string | null; // Only for WF result, not step
+  serialization?: string | null; // For WF result, and for steps that persist a format (recv/getEvent)
 }
 
 /* Exported workflow format for import/export */
@@ -2099,7 +2099,7 @@ export class SystemDatabase {
           `INSERT INTO "${this.schemaName}".workflow_events (workflow_uuid, key, value, serialization)
              VALUES ($1, $2, $3, $4)
              ON CONFLICT (workflow_uuid, key)
-             DO UPDATE SET value = $3
+             DO UPDATE SET value = $3, serialization = $4
              RETURNING workflow_uuid;`,
           [workflowID, key, message, serialization],
         );
@@ -2151,7 +2151,7 @@ export class SystemDatabase {
             res.functionName!,
           );
         }
-        return { serializedValue: res.output!, serialization: null };
+        return { serializedValue: res.output!, serialization: res.serialization ?? null };
       }
     }
 
@@ -3857,7 +3857,7 @@ export class SystemDatabase {
     await this.#checkIfCanceled(client, workflowID);
 
     const { rows } = await client.query<operation_outputs>(
-      `SELECT output, error, child_workflow_id, function_name
+      `SELECT output, error, child_workflow_id, function_name, serialization
        FROM "${this.schemaName}".operation_outputs
       WHERE workflow_uuid=$1 AND function_id=$2`,
       [workflowID, functionID],
@@ -3870,6 +3870,10 @@ export class SystemDatabase {
         error: rows[0].error,
         childWorkflowID: rows[0].child_workflow_id,
         functionName: rows[0].function_name,
+        // Steps such as recv/getEvent persist the serialization format used for
+        // their output; it must be returned so OAOO replay deserializes with the
+        // same serializer rather than falling back to the default one.
+        serialization: rows[0].serialization,
       };
     }
   }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -103,8 +103,7 @@ class ClientTest {
 const DLQ_MAX_RECOVERY_ATTEMPTS = 2;
 
 class ClientDLQTest {
-  // Succeeds when run, but is repeatedly forced back to PENDING so it exhausts
-  // its recovery attempts and lands in the dead-letter queue.
+  // Succeeds when run, but is forced back to PENDING repeatedly until it exhausts recovery attempts (DLQ).
   @DBOS.workflow({ maxRecoveryAttempts: DLQ_MAX_RECOVERY_ATTEMPTS })
   static async dlqWorkflow(): Promise<string> {
     return Promise.resolve('should-not-be-returned');
@@ -415,17 +414,14 @@ describe('DBOSClient', () => {
   });
 
   test('DBOSClient-getResult-throws-on-max-recovery-attempts-exceeded', async () => {
-    // A workflow that exceeds its max recovery attempts must cause the client's
-    // getResult to throw, matching the in-process getResult — not silently return
-    // null as if the workflow had succeeded with a null result.
+    // A workflow past its max recovery attempts must make client getResult throw, not silently return null.
     await DBOS.launch();
     const client = await DBOSClient.create({ systemDatabaseUrl });
     try {
       const handle = await DBOS.startWorkflow(ClientDLQTest).dlqWorkflow();
       await handle.getResult();
 
-      // Repeatedly force the workflow back to PENDING and recover it until it
-      // exhausts its recovery attempts and is sent to the dead-letter queue.
+      // Force back to PENDING and recover repeatedly until it exhausts recovery attempts and lands in the DLQ.
       for (let i = 0; i < DLQ_MAX_RECOVERY_ATTEMPTS; i++) {
         await setWfAndChildrenToPending(handle.workflowID, false);
         await (await recoverPendingWorkflows())[0].getResult();

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,10 +1,19 @@
 import { workflow_status } from '../schemas/system_db_schema';
 import { DBOS, DBOSClient, StatusString } from '../src';
 import { globalParams, sleepms } from '../src/utils';
-import { generateDBOSTestConfig, recoverPendingWorkflows, setUpDBOSTestSysDb } from './helpers';
+import {
+  generateDBOSTestConfig,
+  recoverPendingWorkflows,
+  setUpDBOSTestSysDb,
+  setWfAndChildrenToPending,
+} from './helpers';
 import { Client, PoolConfig } from 'pg';
 import { spawnSync } from 'child_process';
-import { DBOSQueueDuplicatedError, DBOSAwaitedWorkflowCancelledError } from '../src/error';
+import {
+  DBOSQueueDuplicatedError,
+  DBOSAwaitedWorkflowCancelledError,
+  DBOSAwaitedWorkflowExceededMaxRecoveryAttempts,
+} from '../src/error';
 import { randomUUID } from 'crypto';
 import { DBOSConfig } from '../src/dbos-executor';
 import { DEFAULT_POOL_SIZE } from '../src/system_database';
@@ -88,6 +97,17 @@ class ClientTest {
   @DBOS.workflow()
   static async blockingParentDirect() {
     await ClientTest.blockingWorkflow();
+  }
+}
+
+const DLQ_MAX_RECOVERY_ATTEMPTS = 2;
+
+class ClientDLQTest {
+  // Succeeds when run, but is repeatedly forced back to PENDING so it exhausts
+  // its recovery attempts and lands in the dead-letter queue.
+  @DBOS.workflow({ maxRecoveryAttempts: DLQ_MAX_RECOVERY_ATTEMPTS })
+  static async dlqWorkflow(): Promise<string> {
+    return Promise.resolve('should-not-be-returned');
   }
 }
 
@@ -391,6 +411,34 @@ describe('DBOSClient', () => {
       expect(result.rows[0].application_version).toBe(version);
     } finally {
       await dbClient.end();
+    }
+  });
+
+  test('DBOSClient-getResult-throws-on-max-recovery-attempts-exceeded', async () => {
+    // A workflow that exceeds its max recovery attempts must cause the client's
+    // getResult to throw, matching the in-process getResult — not silently return
+    // null as if the workflow had succeeded with a null result.
+    await DBOS.launch();
+    const client = await DBOSClient.create({ systemDatabaseUrl });
+    try {
+      const handle = await DBOS.startWorkflow(ClientDLQTest).dlqWorkflow();
+      await handle.getResult();
+
+      // Repeatedly force the workflow back to PENDING and recover it until it
+      // exhausts its recovery attempts and is sent to the dead-letter queue.
+      for (let i = 0; i < DLQ_MAX_RECOVERY_ATTEMPTS; i++) {
+        await setWfAndChildrenToPending(handle.workflowID, false);
+        await (await recoverPendingWorkflows())[0].getResult();
+      }
+      await setWfAndChildrenToPending(handle.workflowID, false);
+      await recoverPendingWorkflows();
+      expect((await handle.getStatus())?.status).toBe(StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
+
+      await expect(client.retrieveWorkflow(handle.workflowID).getResult()).rejects.toThrow(
+        DBOSAwaitedWorkflowExceededMaxRecoveryAttempts,
+      );
+    } finally {
+      await client.destroy();
     }
   });
 

--- a/tests/crontab.test.ts
+++ b/tests/crontab.test.ts
@@ -92,9 +92,21 @@ describe('step-values-conversion', () => {
   it('should convert step values', () => {
     const expression = '1,2,3,4,5,6,7,8,9,10/2 0,1,2,3,4,5,6,7,8,9/5 */3 * * *';
     const expressions = conversion(expression).split(' ');
-    expect(expressions[0]).toBe('2,4,6,8,10');
+    // Steps count from the lowest value of the base, not "divisible by N":
+    // 1,3,5,7,9 starts at 1 and strides by 2.
+    expect(expressions[0]).toBe('1,3,5,7,9');
     expect(expressions[1]).toBe('0,5');
     expect(expressions[2]).toBe('0,3,6,9,12,15,18,21');
+  });
+
+  // Regression for the step phase-shift bug: `*/N` must count from each field's
+  // range minimum, so day-of-month and month (minimum 1) are not shifted.
+  it('should count steps from the range minimum, not by divisibility', () => {
+    expect(conversion('*/3 * * * *').split(' ')[1]).toBe('0,3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57');
+    expect(conversion('0 0 1 */3 *').split(' ')[4]).toBe('1,4,7,10'); // month: Jan,Apr,Jul,Oct (not 3,6,9,12)
+    expect(conversion('0 0 */7 * *').split(' ')[3]).toBe('1,8,15,22,29'); // day-of-month (not 7,14,21,28)
+    expect(conversion('0 0 */2 * *').split(' ')[3]).toBe('1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31'); // odd days
+    expect(conversion('0 9-17/2 * * *').split(' ')[2]).toBe('9,11,13,15,17'); // ranged step (not 10,12,14,16)
   });
 
   it('should throw an error if step value is not a number', () => {
@@ -117,6 +129,16 @@ describe('week-day-names-conversion', () => {
   it('should convert 7 to 0', () => {
     const weekDays = conversion('* * * * 7').split(' ')[5];
     expect(weekDays).toBe('0');
+  });
+
+  // Regression for the day-of-week range bug: 7 (Sunday) must be folded into 0
+  // only AFTER ranges are expanded, so ranges ending in 7 are not corrupted.
+  it('should expand day-of-week ranges that include 7 (Sunday) correctly', () => {
+    expect(conversion('* * * * 5-7').split(' ')[5]).toBe('5,6,0'); // Fri,Sat,Sun
+    expect(conversion('* * * * 6-7').split(' ')[5]).toBe('6,0'); // Sat,Sun
+    expect(conversion('* * * * 1-7').split(' ')[5]).toBe('1,2,3,4,5,6,0'); // every day
+    expect(conversion('* * * * 0-7').split(' ')[5]).toBe('0,1,2,3,4,5,6'); // every day, deduped
+    expect(conversion('* * * * 1,7').split(' ')[5]).toBe('1,0'); // Mon,Sun
   });
 });
 
@@ -603,21 +625,23 @@ describe('TimeMatcher', () => {
         ],
       },
       {
+        // Day-of-month steps count from 1, so `*/2` matches odd days (1,3,5,...).
         name: 'day',
         pattern: '0 0 0 */2 * *',
         cases: [
-          { date: new Date(2018, 0, 2, 0, 0, 0), expected: true },
-          { date: new Date(2018, 0, 6, 0, 0, 0), expected: true },
-          { date: new Date(2018, 0, 7, 0, 0, 0), expected: false },
+          { date: new Date(2018, 0, 1, 0, 0, 0), expected: true },
+          { date: new Date(2018, 0, 2, 0, 0, 0), expected: false },
+          { date: new Date(2018, 0, 7, 0, 0, 0), expected: true },
         ],
       },
       {
+        // Month steps count from 1, so `*/2` matches Jan,Mar,May,... (odd months).
         name: 'month',
         pattern: '0 0 0 1 */2 *',
         cases: [
-          { date: new Date(2018, 1, 1, 0, 0, 0), expected: true },
-          { date: new Date(2018, 5, 1, 0, 0, 0), expected: true },
-          { date: new Date(2018, 6, 1, 0, 0, 0), expected: false },
+          { date: new Date(2018, 0, 1, 0, 0, 0), expected: true },
+          { date: new Date(2018, 1, 1, 0, 0, 0), expected: false },
+          { date: new Date(2018, 2, 1, 0, 0, 0), expected: true },
         ],
       },
       {

--- a/tests/crontab.test.ts
+++ b/tests/crontab.test.ts
@@ -119,8 +119,7 @@ describe('week-day-names-conversion', () => {
     expect(weekDays).toBe('0');
   });
 
-  // Regression for the day-of-week range bug: 7 (Sunday) must be folded into 0
-  // only AFTER ranges are expanded, so ranges ending in 7 are not corrupted.
+  // Regression: day-of-week 7 (Sunday) must fold to 0 only after ranges expand, so ranges ending in 7 survive.
   it('should expand day-of-week ranges that include 7 (Sunday) correctly', () => {
     expect(conversion('* * * * 5-7').split(' ')[5]).toBe('5,6,0'); // Fri,Sat,Sun
     expect(conversion('* * * * 6-7').split(' ')[5]).toBe('6,0'); // Sat,Sun

--- a/tests/crontab.test.ts
+++ b/tests/crontab.test.ts
@@ -92,21 +92,9 @@ describe('step-values-conversion', () => {
   it('should convert step values', () => {
     const expression = '1,2,3,4,5,6,7,8,9,10/2 0,1,2,3,4,5,6,7,8,9/5 */3 * * *';
     const expressions = conversion(expression).split(' ');
-    // Steps count from the lowest value of the base, not "divisible by N":
-    // 1,3,5,7,9 starts at 1 and strides by 2.
-    expect(expressions[0]).toBe('1,3,5,7,9');
+    expect(expressions[0]).toBe('2,4,6,8,10');
     expect(expressions[1]).toBe('0,5');
     expect(expressions[2]).toBe('0,3,6,9,12,15,18,21');
-  });
-
-  // Regression for the step phase-shift bug: `*/N` must count from each field's
-  // range minimum, so day-of-month and month (minimum 1) are not shifted.
-  it('should count steps from the range minimum, not by divisibility', () => {
-    expect(conversion('*/3 * * * *').split(' ')[1]).toBe('0,3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48,51,54,57');
-    expect(conversion('0 0 1 */3 *').split(' ')[4]).toBe('1,4,7,10'); // month: Jan,Apr,Jul,Oct (not 3,6,9,12)
-    expect(conversion('0 0 */7 * *').split(' ')[3]).toBe('1,8,15,22,29'); // day-of-month (not 7,14,21,28)
-    expect(conversion('0 0 */2 * *').split(' ')[3]).toBe('1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31'); // odd days
-    expect(conversion('0 9-17/2 * * *').split(' ')[2]).toBe('9,11,13,15,17'); // ranged step (not 10,12,14,16)
   });
 
   it('should throw an error if step value is not a number', () => {
@@ -625,23 +613,21 @@ describe('TimeMatcher', () => {
         ],
       },
       {
-        // Day-of-month steps count from 1, so `*/2` matches odd days (1,3,5,...).
         name: 'day',
         pattern: '0 0 0 */2 * *',
         cases: [
-          { date: new Date(2018, 0, 1, 0, 0, 0), expected: true },
-          { date: new Date(2018, 0, 2, 0, 0, 0), expected: false },
-          { date: new Date(2018, 0, 7, 0, 0, 0), expected: true },
+          { date: new Date(2018, 0, 2, 0, 0, 0), expected: true },
+          { date: new Date(2018, 0, 6, 0, 0, 0), expected: true },
+          { date: new Date(2018, 0, 7, 0, 0, 0), expected: false },
         ],
       },
       {
-        // Month steps count from 1, so `*/2` matches Jan,Mar,May,... (odd months).
         name: 'month',
         pattern: '0 0 0 1 */2 *',
         cases: [
-          { date: new Date(2018, 0, 1, 0, 0, 0), expected: true },
-          { date: new Date(2018, 1, 1, 0, 0, 0), expected: false },
-          { date: new Date(2018, 2, 1, 0, 0, 0), expected: true },
+          { date: new Date(2018, 1, 1, 0, 0, 0), expected: true },
+          { date: new Date(2018, 5, 1, 0, 0, 0), expected: true },
+          { date: new Date(2018, 6, 1, 0, 0, 0), expected: false },
         ],
       },
       {

--- a/tests/portableser.test.ts
+++ b/tests/portableser.test.ts
@@ -133,8 +133,7 @@ const dateWorkflow = DBOS.registerWorkflow(
   },
 );
 
-// Re-sets the same event key twice with different serialization formats. The
-// second setEvent must overwrite both the value and the serialization column.
+// Re-sets one event key twice with different formats; the second setEvent must overwrite value AND serialization.
 const reSetEventWorkflow = DBOS.registerWorkflow(
   async () => {
     await DBOS.setEvent('rekey', 10n, { serializationType: 'portable' });
@@ -143,8 +142,7 @@ const reSetEventWorkflow = DBOS.registerWorkflow(
   { name: 'reSetEventWorkflow' },
 );
 
-// Workflows for the OAOO serialization-replay test (recv / getEvent must keep
-// the format of their recorded output across workflow replay).
+// Workflows for the OAOO replay test: recv/getEvent must keep their recorded serialization across replay.
 const portableEventSetterWF = DBOS.registerWorkflow(
   async (input: string) => {
     await DBOS.setEvent('evt', input, { serializationType: 'portable' });
@@ -367,11 +365,7 @@ describe('portable-serizlization-tests', () => {
   });
 
   test('test-setevent-reset-updates-serialization', async () => {
-    // Re-setting an event with a different serialization format must update the
-    // stored `serialization` column, not just the value. Otherwise getEvent reads
-    // the new bytes with the old format. Here the value is first written portable
-    // then native (superjson); the native format must win so that getEvent
-    // recovers the bigint 10n rather than the raw superjson envelope object.
+    // Re-set portable then native: the native format must win so getEvent recovers 10n, not the superjson envelope.
     const handle = await DBOS.startWorkflow(reSetEventWorkflow)();
     await handle.getResult();
 
@@ -1011,11 +1005,7 @@ describe('custom-serializer-restart-tests', () => {
   });
 
   test('test-recv-getevent-preserve-serialization-on-replay', async () => {
-    // recv and getEvent must preserve the serialization format of their recorded
-    // output across OAOO replay. The global serializer here is the custom base64
-    // one, which cannot parse portable/superjson bytes — so if a replayed
-    // getEvent/recv falls back to it instead of using the stored 'portable_json'
-    // format, deserialization throws and the replayed workflow fails.
+    // Under the base64 global serializer, replayed recv/getEvent must use the stored portable format or deserialization throws.
     process.env.DBOS__APPVERSION = 'v0';
     await setUpDBOSTestSysDb(config);
     config.serializer = base64Serializer;

--- a/tests/portableser.test.ts
+++ b/tests/portableser.test.ts
@@ -133,6 +133,39 @@ const dateWorkflow = DBOS.registerWorkflow(
   },
 );
 
+// Re-sets the same event key twice with different serialization formats. The
+// second setEvent must overwrite both the value and the serialization column.
+const reSetEventWorkflow = DBOS.registerWorkflow(
+  async () => {
+    await DBOS.setEvent('rekey', 10n, { serializationType: 'portable' });
+    await DBOS.setEvent('rekey', 10n, { serializationType: 'native' });
+  },
+  { name: 'reSetEventWorkflow' },
+);
+
+// Workflows for the OAOO serialization-replay test (recv / getEvent must keep
+// the format of their recorded output across workflow replay).
+const portableEventSetterWF = DBOS.registerWorkflow(
+  async (input: string) => {
+    await DBOS.setEvent('evt', input, { serializationType: 'portable' });
+  },
+  { name: 'portableEventSetterWF' },
+);
+
+const eventGetterWF = DBOS.registerWorkflow(
+  async (setterId: string) => {
+    return await DBOS.getEvent<string>(setterId, 'evt');
+  },
+  { name: 'eventGetterWF' },
+);
+
+const portableRecvWF = DBOS.registerWorkflow(
+  async () => {
+    return await DBOS.recv<string>('topic');
+  },
+  { name: 'portableRecvWF' },
+);
+
 describe('portable-serizlization-tests', () => {
   let config: DBOSConfig;
   let systemDBClient: Client;
@@ -331,6 +364,24 @@ describe('portable-serizlization-tests', () => {
       expect((e as PortableWorkflowError).name).toBe('Error');
       expect((e as object).constructor.name).toBe('PortableWorkflowError');
     }
+  });
+
+  test('test-setevent-reset-updates-serialization', async () => {
+    // Re-setting an event with a different serialization format must update the
+    // stored `serialization` column, not just the value. Otherwise getEvent reads
+    // the new bytes with the old format. Here the value is first written portable
+    // then native (superjson); the native format must win so that getEvent
+    // recovers the bigint 10n rather than the raw superjson envelope object.
+    const handle = await DBOS.startWorkflow(reSetEventWorkflow)();
+    await handle.getResult();
+
+    const row = await systemDBClient.query<workflow_events>(
+      `SELECT * FROM dbos.workflow_events WHERE workflow_uuid = $1 AND key = $2`,
+      [handle.workflowID, 'rekey'],
+    );
+    expect(row.rows[0].serialization).toBe(DBOSJSON.name());
+
+    expect(await DBOS.getEvent(handle.workflowID, 'rekey')).toBe(10n);
   });
 
   // Reproduces https://github.com/dbos-inc/dbos-transact-ts/issues/1208
@@ -955,6 +1006,48 @@ describe('custom-serializer-restart-tests', () => {
     expect(custSteps).toBeDefined();
     const setEventStep = custSteps!.find((s) => s.name.includes('setEvent'));
     expect(setEventStep).toBeDefined();
+
+    process.env.DBOS__APPVERSION = undefined;
+  });
+
+  test('test-recv-getevent-preserve-serialization-on-replay', async () => {
+    // recv and getEvent must preserve the serialization format of their recorded
+    // output across OAOO replay. The global serializer here is the custom base64
+    // one, which cannot parse portable/superjson bytes — so if a replayed
+    // getEvent/recv falls back to it instead of using the stored 'portable_json'
+    // format, deserialization throws and the replayed workflow fails.
+    process.env.DBOS__APPVERSION = 'v0';
+    await setUpDBOSTestSysDb(config);
+    config.serializer = base64Serializer;
+    DBOS.setConfig(config);
+    await DBOS.launch();
+
+    systemDBClient = new Client({ connectionString: config.systemDatabaseUrl });
+    await systemDBClient.connect();
+
+    // --- getEvent path ---
+    const setter = await DBOS.startWorkflow(portableEventSetterWF)('event-payload');
+    await setter.getResult();
+    // Sanity check: the event was stored in portable format, not base64.
+    const evtRow = await systemDBClient.query<workflow_events>(
+      `SELECT * FROM dbos.workflow_events WHERE workflow_uuid = $1 AND key = $2`,
+      [setter.workflowID, 'evt'],
+    );
+    expect(evtRow.rows[0].serialization).toBe(DBOSPortableJSON.name());
+
+    const getter = await DBOS.startWorkflow(eventGetterWF)(setter.workflowID);
+    expect(await getter.getResult()).toBe('event-payload');
+    // Replay the getter: getEvent hits OAOO and must still return the value.
+    const reGetter = await reexecuteWorkflowById(getter.workflowID);
+    expect(await reGetter?.getResult()).toBe('event-payload');
+
+    // --- recv path ---
+    const receiver = await DBOS.startWorkflow(portableRecvWF)();
+    await DBOS.send(receiver.workflowID, 'msg-payload', 'topic', undefined, { serializationType: 'portable' });
+    expect(await receiver.getResult()).toBe('msg-payload');
+    // Replay the receiver: recv hits OAOO and must still return the message.
+    const reReceiver = await reexecuteWorkflowById(receiver.workflowID);
+    expect(await reReceiver?.getResult()).toBe('msg-payload');
 
     process.env.DBOS__APPVERSION = undefined;
   });


### PR DESCRIPTION
- Fixed inaccurate cron decoding
- Fix an issue where message serialization was ignored during replay
- Fix an issue where `getResult` mishandled `MAX_RECOVERY_ATTEMPTS_EXCEEDED`