### PR TITLE
Add 3-day install cooldown (supply-chain protection)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain protection: refuse to install package versions published
+# less than 3 days ago, giving time for malicious releases to be caught.
+# Requires npm >= 11.10.0; ignored by older npm. Override with --min-release-age=0.
+min-release-age=3


### PR DESCRIPTION
Closes #1293

## What

Adds `.npmrc` with `min-release-age=3` — npm will not install a package version until it is at least 3 days old.

## Why

Supply-chain protection. Most malicious npm releases are caught and yanked within hours to a day of publish. A short install cooldown means the repo never pulls a version fresh enough to be in that window.

## Notes

- Native npm feature (`min-release-age`), requires **npm >= 11.10.0**. Older npm silently ignores unknown `.npmrc` keys, so this can't break CI on older runners.
- Bypass for an urgent fix: `npm install --min-release-age=0`.
- 3 days chosen per request; bump the number to widen the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)