### PR TITLE
Debounce With Delay

### DIFF
--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -36,6 +36,8 @@ export interface workflow_status {
   completed_at?: number | null;
   attributes?: Record<string, unknown> | null; // Custom key-value attributes attached at creation, stored as JSONB.
   schedule_name?: string | null; // If enqueued by a named schedule, that schedule's name.
+  debounce_deadline_epoch_ms?: number | null; // Absolute cap (epoch ms) beyond which bounces may not extend the delay.
+  is_debounced?: boolean; // True if the deduplication ID is a debounce key cleared on the DELAYED->ENQUEUED transition.
 }
 
 export interface notifications {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,8 @@ import {
   type WorkflowStatusInternal,
   type WorkflowScheduleInternal,
   type VersionInfo,
+  type DebounceParams,
+  type DebounceResult,
   DBOS_STREAM_CLOSED_SENTINEL,
   DEFAULT_POOL_SIZE,
 } from './system_database';
@@ -302,6 +304,20 @@ export class DBOSClient {
     options: ClientEnqueueOptions,
     ...args: Parameters<T>
   ): Promise<WorkflowHandle<Awaited<ReturnType<T>>>> {
+    const internalStatus = await this.#buildEnqueueStatus(options, args);
+
+    let finalID: string;
+    if (options.duplicationPolicy === 'return-existing') {
+      finalID = await this.#initSingletonWorkflow(internalStatus, options);
+    } else {
+      await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+      finalID = internalStatus.workflowUUID;
+    }
+
+    return new ClientHandle<Awaited<ReturnType<T>>>(this.systemDatabase, finalID);
+  }
+
+  async #buildEnqueueStatus(options: ClientEnqueueOptions, args: unknown[]): Promise<WorkflowStatusInternal> {
     validateWorkflowAttributes(options.attributes);
     const { workflowName, workflowClassName, workflowConfigName, queueName, appVersion } = options;
     const workflowUUID = options.workflowID ?? randomUUID();
@@ -311,7 +327,7 @@ export class DBOSClient {
       options.delaySeconds !== undefined && options.delaySeconds > 0
         ? Date.now() + options.delaySeconds * 1000
         : undefined;
-    const internalStatus: WorkflowStatusInternal = {
+    return {
       workflowUUID: workflowUUID,
       status: delayUntilEpochMS !== undefined ? StatusString.DELAYED : StatusString.ENQUEUED,
       workflowName: workflowName,
@@ -338,16 +354,39 @@ export class DBOSClient {
       delayUntilEpochMS,
       attributes: options.attributes,
     };
+  }
 
-    let finalID: string;
-    if (options.duplicationPolicy === 'return-existing') {
-      finalID = await this.#initSingletonWorkflow(internalStatus, options);
-    } else {
-      await this.systemDatabase.initWorkflowStatus(internalStatus, null);
-      finalID = internalStatus.workflowUUID;
+  /**
+   * Enqueue a debounced workflow for `DebouncerClient`.
+   * The debounce fields are stamped onto the built status here because they are
+   * not part of the public enqueue API.
+   * @internal
+   */
+  async enqueueDebounced(
+    options: ClientEnqueueOptions,
+    debounceDeadlineEpochMS: number | undefined,
+    args: unknown[],
+  ): Promise<string> {
+    const internalStatus = await this.#buildEnqueueStatus(options, args);
+    internalStatus.debounceDeadlineEpochMS = debounceDeadlineEpochMS;
+    internalStatus.isDebounced = true;
+    if (
+      internalStatus.delayUntilEpochMS !== undefined &&
+      debounceDeadlineEpochMS !== undefined &&
+      debounceDeadlineEpochMS < internalStatus.delayUntilEpochMS
+    ) {
+      internalStatus.delayUntilEpochMS = debounceDeadlineEpochMS;
     }
+    await this.systemDatabase.initWorkflowStatus(internalStatus, null);
+    return internalStatus.workflowUUID;
+  }
 
-    return new ClientHandle<Awaited<ReturnType<T>>>(this.systemDatabase, finalID);
+  /**
+   * Extend an existing debounced DELAYED workflow, for `DebouncerClient`.
+   * @internal
+   */
+  async debounceDelayedWorkflow(params: DebounceParams): Promise<DebounceResult> {
+    return await this.systemDatabase.debounceDelayedWorkflow(params);
   }
 
   /**

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -56,7 +56,7 @@ import {
   runWithTopContext,
 } from './context';
 import { deserializeError, serializeError } from 'serialize-error';
-import { globalParams, sleepms, INTERNAL_QUEUE_NAME, DEBOUNCER_WORKLOW_NAME as DEBOUNCER_WORKLOW_NAME } from './utils';
+import { globalParams, sleepms, INTERNAL_QUEUE_NAME } from './utils';
 import {
   DBOSPortableJSON,
   DBOSSerializer,
@@ -69,7 +69,7 @@ import {
   serializeResErrorWithSerializer,
   serializeValue,
 } from './serialization';
-import { DBOS, GetWorkflowsInput } from '.';
+import { GetWorkflowsInput } from '.';
 
 import { wfQueueRunner, WorkflowQueue } from './wfqueue';
 import { debugTriggerPoint, DEBUG_TRIGGER_WORKFLOW_ENQUEUE } from './debugpoint';
@@ -84,7 +84,6 @@ import {
   toWorkflowStatus,
 } from './workflow_management';
 import { maskDatabaseUrl } from './database_utils';
-import { debouncerWorkflowFunction } from './debouncer';
 import { Pool } from 'pg';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -485,10 +484,18 @@ export class DBOSExecutor {
         : (funcArgs.deserialized as T);
 
     const delaySeconds = params.enqueueOptions?.delaySeconds;
-    const delayUntilEpochMS =
+    let delayUntilEpochMS =
       params.queueName !== undefined && delaySeconds !== undefined && delaySeconds > 0
         ? Date.now() + delaySeconds * 1000
         : undefined;
+    const debounceDeadlineEpochMS = params.enqueueOptions?.debounceDeadlineEpochMS;
+    if (
+      delayUntilEpochMS !== undefined &&
+      debounceDeadlineEpochMS !== undefined &&
+      debounceDeadlineEpochMS < delayUntilEpochMS
+    ) {
+      delayUntilEpochMS = debounceDeadlineEpochMS;
+    }
     const internalStatus: WorkflowStatusInternal = {
       workflowUUID: workflowID,
       status:
@@ -521,6 +528,8 @@ export class DBOSExecutor {
       serialization: funcArgs.sername,
       delayUntilEpochMS,
       attributes: params.workflowAttributes,
+      debounceDeadlineEpochMS,
+      isDebounced: params.enqueueOptions?.isDebounced ?? false,
     };
 
     if (isTempWorkflow) {
@@ -1354,16 +1363,5 @@ export class DBOSExecutor {
       return;
     }
     DBOSExecutor.internalQueue = new WorkflowQueue(INTERNAL_QUEUE_NAME, {});
-  }
-
-  static debouncerWorkflow: UntypedAsyncFunction | undefined = undefined;
-
-  static createDebouncerWorkflow() {
-    if (DBOSExecutor.debouncerWorkflow !== undefined) {
-      return;
-    }
-    DBOSExecutor.debouncerWorkflow = DBOS.registerWorkflow(debouncerWorkflowFunction, {
-      name: DEBOUNCER_WORKLOW_NAME,
-    }) as UntypedAsyncFunction;
   }
 }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -352,7 +352,7 @@ export function runInternalStep<T>(
  * methods so they participate in the same transaction.
  * Outside a workflow, the callback is called directly with `undefined` as the client.
  */
-async function runTransactionalInternalStep<T>(
+export async function runTransactionalInternalStep<T>(
   callback: (client: PoolClient | undefined) => Promise<T>,
   funcName: string,
 ): Promise<T> {
@@ -457,7 +457,6 @@ export class DBOS {
       globalParams.executorID = randomUUID();
     }
 
-    DBOSExecutor.createDebouncerWorkflow();
     DBOSExecutor.createInternalQueue();
     DBOSExecutor.globalInstance = new DBOSExecutor(internalConfig);
 
@@ -619,7 +618,6 @@ export class DBOS {
     assert(!DBOS.isInitialized(), 'Cannot call DBOS.clearRegistry after DBOS.launch');
     clearAllRegistrations();
     wfQueueRunner.clearRegistrations();
-    DBOSExecutor.debouncerWorkflow = undefined;
     DBOSExecutor.internalQueue = undefined;
   }
 

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -1,29 +1,27 @@
-import { randomUUID } from 'node:crypto';
 import { DBOS, DBOSClient } from '.';
-import { StartWorkflowParams } from './dbos';
+import { runTransactionalInternalStep, StartWorkflowParams } from './dbos';
 import { DBOSExecutor } from './dbos-executor';
+import { getNextWFID } from './context';
 import {
+  ensureDBOSIsLaunched,
   getFunctionRegistration,
   getFunctionRegistrationByName,
   getRegisteredFunctionClassName,
   UntypedAsyncFunction,
 } from './decorators';
-import { getDBOSErrorCode, QueueDedupIDDuplicated } from './error';
-import { DEBOUNCER_WORKLOW_NAME, INTERNAL_QUEUE_NAME } from './utils';
+import { DBOSError, DBOSQueueDuplicatedError, getDBOSErrorCode, QueueDedupIDDuplicated } from './error';
+import { serializeArgs, serializeFunctionInputOutput } from './serialization';
+import { DebounceResult } from './system_database';
+import { INTERNAL_QUEUE_NAME } from './utils';
+import { WorkflowHandle } from './workflow';
+import { PortableWorkflowError } from '../schemas/system_db_schema';
 
-// Parameters for the debouncer workflow
-interface DebouncerWorkflowParams {
+// Parameters for the debouncer
+interface DebouncerParams {
   workflowName: string;
   workflowClassName: string;
   startWorkflowParams?: StartWorkflowParams;
   debounceTimeoutMs?: number;
-}
-
-// The message sent from a debounce to the debouncer workflow
-interface DebouncerMessage {
-  args: unknown[];
-  messageID: string;
-  debouncePeriodMs: number;
 }
 
 interface DebouncerConfig<Args extends unknown[], Return> {
@@ -39,38 +37,78 @@ interface DebouncerClientConfig {
   debounceTimeoutMs?: number;
 }
 
-const _DEBOUNCER_TOPIC = 'DEBOUNCER_TOPIC';
+/**
+ * True if `e` is a queue-deduplication error, including the portable-serialization
+ * replay form, which carries only the original type name.
+ */
+function isQueueDeduplicatedError(e: unknown): boolean {
+  if (e instanceof Error && getDBOSErrorCode(e) === QueueDedupIDDuplicated) {
+    return true;
+  }
+  return e instanceof PortableWorkflowError && e.name === DBOSQueueDuplicatedError.name;
+}
 
-export const debouncerWorkflowFunction = async (
-  initialDebouncePeriodMs: number,
-  cfg: DebouncerWorkflowParams,
-  ...args: unknown[]
-) => {
-  let workflowInputs = args;
-  const debounceDeadlineEpochMs = cfg.debounceTimeoutMs ? Date.now() + cfg.debounceTimeoutMs : Number.MAX_VALUE;
-  let debouncePeriodMs = initialDebouncePeriodMs;
-  while (Date.now() < debounceDeadlineEpochMs) {
-    const timeUntilDeadline = Math.max(debounceDeadlineEpochMs - Date.now(), 0);
-    const timeoutMs = Math.min(debouncePeriodMs, timeUntilDeadline);
-    const message = await DBOS.recv<DebouncerMessage>(_DEBOUNCER_TOPIC, timeoutMs / 1000);
-    if (message === null) {
-      break;
-    } else {
-      workflowInputs = message['args'];
-      debouncePeriodMs = message['debouncePeriodMs'];
-      await DBOS.setEvent(message.messageID, message.messageID);
-    }
+/**
+ * A debounce owns the workflow's deduplication ID (the debounce key) and its delay
+ * (the debounce period), so a caller must not also set them. Priority and partition
+ * keys are rejected because they cannot apply to a debounced enqueue.
+ */
+function rejectConflictingOptions(params: StartWorkflowParams | undefined): void {
+  const enqueueOptions = params?.enqueueOptions;
+  if (enqueueOptions?.deduplicationID !== undefined) {
+    throw new DBOSError(
+      'Cannot debounce a workflow with a deduplicationID set: the debounce key is used as the workflow deduplication ID.',
+    );
   }
-  const methReg = getFunctionRegistrationByName(cfg.workflowClassName, cfg.workflowName);
-  if (!methReg || !methReg.registeredFunction) {
-    throw Error(`Invalid workflow name provided to debouncer: ${cfg.workflowName}`);
+  if (enqueueOptions?.delaySeconds !== undefined) {
+    throw new DBOSError('Cannot debounce a workflow with a delay set: the debounce period controls the delay.');
   }
-  const func = methReg?.registeredFunction as UntypedAsyncFunction;
-  await DBOS.startWorkflow(func, cfg.startWorkflowParams)(...workflowInputs);
-};
+  if (enqueueOptions?.priority !== undefined) {
+    throw new DBOSError(
+      'Cannot debounce a workflow with a priority set: priority is not supported for debounced workflows.',
+    );
+  }
+  if (enqueueOptions?.queuePartitionKey !== undefined) {
+    throw new DBOSError(
+      'Cannot debounce a workflow with a queue partition key set: partitioned queues do not support deduplication, which debouncing requires.',
+    );
+  }
+  if (params?.duplicationPolicy === 'return-existing') {
+    throw new DBOSError(
+      "Cannot debounce a workflow with duplicationPolicy 'return-existing': a debounce owns the deduplication behavior.",
+    );
+  }
+}
+
+// The action a debounce caller should take after a bounce attempt.
+type BounceAction = 'return' | 'enqueue' | 'raise' | 'retry';
+
+/**
+ * Decide what a debounce caller should do after a bounce attempt.
+ * - 'return': an existing debounced workflow was extended; return a handle to it.
+ * - 'enqueue': the key is unheld; enqueue a fresh debounced workflow.
+ * - 'raise': the key is held by a non-debounced workflow or by a different workflow
+ *   whose debounce key collides; surface the deduplication conflict.
+ * - 'retry': a same-name debounced holder flipped out of DELAYED mid-bounce (a rare race); retry.
+ */
+function classifyBounce(result: DebounceResult, workflowName: string, workflowClassName: string): BounceAction {
+  if (result.bouncedWorkflowID !== null) {
+    return 'return';
+  }
+  if (result.holderWorkflowID === null) {
+    return 'enqueue';
+  }
+  if (!result.holderIsDebounced) {
+    return 'raise';
+  }
+  if (result.holderWorkflowName !== workflowName || (result.holderWorkflowClassName ?? '') !== workflowClassName) {
+    return 'raise';
+  }
+  return 'retry';
+}
 
 export class Debouncer<Args extends unknown[], Return> {
-  private readonly cfg: DebouncerWorkflowParams;
+  private readonly cfg: DebouncerParams;
   constructor(params: DebouncerConfig<Args, Return>) {
     const wInfo = getFunctionRegistration(params.workflow);
     this.cfg = {
@@ -81,65 +119,96 @@ export class Debouncer<Args extends unknown[], Return> {
     };
   }
 
-  async debounce(debounceKey: string, debouncePeriodMs: number, ...args: Args) {
+  async debounce(debounceKey: string, debouncePeriodMs: number, ...args: Args): Promise<WorkflowHandle<Return>> {
     if (debouncePeriodMs <= 0) {
       throw Error(`debouncePeriodMs must be positive, not ${debouncePeriodMs}`);
     }
-    const cfg = { ...this.cfg };
-    cfg.startWorkflowParams = this.cfg.startWorkflowParams ? { ...this.cfg.startWorkflowParams } : {};
-    cfg.startWorkflowParams.workflowID = cfg.startWorkflowParams.workflowID ?? (await DBOS.randomUUID());
+    ensureDBOSIsLaunched('debounce');
+    rejectConflictingOptions(this.cfg.startWorkflowParams);
+
+    const exec = DBOSExecutor.globalInstance!;
+    const queueName = this.cfg.startWorkflowParams?.queueName ?? INTERNAL_QUEUE_NAME;
+    const deduplicationID = `${this.cfg.workflowClassName}.${this.cfg.workflowName}-${debounceKey}`;
+
+    // Capture a pinned workflow ID once: it is re-applied on every enqueue attempt (a lost
+    // dedup race consumes it before throwing) and goes unused when a bounce coalesces.
+    const pinnedWorkflowID = getNextWFID(this.cfg.startWorkflowParams?.workflowID);
+
+    // Resolve the workflow function so bounced inputs serialize identically to enqueued ones.
+    const methReg = getFunctionRegistrationByName(this.cfg.workflowClassName, this.cfg.workflowName);
+    if (!methReg || !methReg.registeredFunction) {
+      throw new DBOSError(`Invalid workflow name provided to debouncer: ${this.cfg.workflowName}`);
+    }
+    const func = methReg.registeredFunction as UntypedAsyncFunction;
+    const serializationType = methReg.workflowConfig?.serialization;
+
     while (true) {
-      const deduplicationID = `${cfg.workflowClassName}.${cfg.workflowName}-${debounceKey}`;
+      // Try to extend an existing debounced workflow for this key first (the sole coalescing mechanism).
+      // In a workflow, the bounce commits atomically with its step checkpoint so a crash can never
+      // commit one without the other, which on recovery would re-bounce work that already ran.
+      const funcArgs = await serializeFunctionInputOutput(
+        serializationType === 'portable' ? { positionalArgs: args } : args,
+        [this.cfg.workflowName, '<arguments>'],
+        exec.serializer,
+        serializationType,
+      );
+      const bounceParams = {
+        workflowName: this.cfg.workflowName,
+        workflowClassName: this.cfg.workflowClassName,
+        queueName,
+        deduplicationID,
+        delayUntilEpochMS: Date.now() + debouncePeriodMs,
+        input: funcArgs.stringified,
+        serialization: funcArgs.sername,
+      };
+      const result = await runTransactionalInternalStep<DebounceResult>(
+        (client) => exec.systemDatabase.debounceDelayedWorkflow(bounceParams, client),
+        'DBOS.debounceDelayedWorkflow',
+      );
+
+      const action = classifyBounce(result, this.cfg.workflowName, this.cfg.workflowClassName);
+      if (action === 'return') {
+        return DBOS.retrieveWorkflow<Return>(result.bouncedWorkflowID!);
+      }
+      if (action === 'raise') {
+        throw new DBOSQueueDuplicatedError(result.holderWorkflowID!, queueName, deduplicationID);
+      }
+      if (action === 'retry') {
+        continue;
+      }
+
+      // action === 'enqueue': the key is free, create a fresh debounced workflow.
+      const debounceDeadlineEpochMS = this.cfg.debounceTimeoutMs ? Date.now() + this.cfg.debounceTimeoutMs : undefined;
       try {
-        // Attempt to enqueue a debouncer for this workflow
-        await DBOS.startWorkflow(DBOSExecutor.debouncerWorkflow!, {
-          queueName: INTERNAL_QUEUE_NAME,
-          enqueueOptions: { deduplicationID },
-        })(debouncePeriodMs, cfg, ...args);
-        return DBOS.retrieveWorkflow<Return>(cfg.startWorkflowParams.workflowID);
+        // A null timeout detaches any propagated workflow deadline: a debounce delay can be long,
+        // so an inherited absolute deadline could expire before the debounced workflow ever runs.
+        const handle = await DBOS.startWorkflow(func, {
+          workflowID: pinnedWorkflowID,
+          queueName,
+          timeoutMS: this.cfg.startWorkflowParams?.timeoutMS ?? null,
+          workflowAttributes: this.cfg.startWorkflowParams?.workflowAttributes,
+          enqueueOptions: {
+            applicationVersion: this.cfg.startWorkflowParams?.enqueueOptions?.applicationVersion,
+            deduplicationID,
+            delaySeconds: debouncePeriodMs / 1000,
+            debounceDeadlineEpochMS,
+            isDebounced: true,
+          },
+        })(...args);
+        return handle as WorkflowHandle<Return>;
       } catch (e) {
-        // If there is already a debouncer, send a message to it.
-        if (e instanceof Error && getDBOSErrorCode(e) === QueueDedupIDDuplicated) {
-          const dedupWorkflowID = await DBOS.runStep(async () => {
-            return await DBOSExecutor.globalInstance?.systemDatabase.getDeduplicatedWorkflow(
-              INTERNAL_QUEUE_NAME,
-              deduplicationID,
-            );
-          });
-          if (!dedupWorkflowID) {
-            continue;
-          } else {
-            const messageID = await DBOS.randomUUID();
-            const message: DebouncerMessage = {
-              messageID,
-              args,
-              debouncePeriodMs,
-            };
-            await DBOS.send(dedupWorkflowID, message, _DEBOUNCER_TOPIC);
-            // Wait for the debouncer to acknowledge receipt of the message.
-            // If the message is not acknowledged, this likely means the debouncer started its workflow
-            // and exited without processing this message, so try again.
-            const event = await DBOS.getEvent(dedupWorkflowID, messageID, 1000);
-            if (!event) {
-              continue;
-            }
-            // Retrieve the user workflow ID from the input to the debouncer
-            // and return a handle to it.
-            const dedupWorkflowInput = await DBOS.retrieveWorkflow(dedupWorkflowID).getWorkflowInputs();
-            const typedInput = dedupWorkflowInput as Parameters<typeof debouncerWorkflowFunction>;
-            const userWorkflowID = typedInput[1].startWorkflowParams!.workflowID!;
-            return DBOS.retrieveWorkflow<Return>(userWorkflowID);
-          }
-        } else {
+        // A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
+        if (!isQueueDeduplicatedError(e)) {
           throw e;
         }
+        continue;
       }
     }
   }
 }
 
 export class DebouncerClient {
-  private readonly cfg: DebouncerWorkflowParams;
+  private readonly cfg: DebouncerParams;
   constructor(
     readonly client: DBOSClient,
     params: DebouncerClientConfig,
@@ -152,60 +221,64 @@ export class DebouncerClient {
     };
   }
 
-  async debounce(debounceKey: string, debouncePeriodMs: number, ...args: unknown[]) {
+  async debounce(debounceKey: string, debouncePeriodMs: number, ...args: unknown[]): Promise<WorkflowHandle<unknown>> {
     if (debouncePeriodMs <= 0) {
       throw Error(`debouncePeriodMs must be positive, not ${debouncePeriodMs}`);
     }
-    const cfg = { ...this.cfg };
-    cfg.startWorkflowParams = this.cfg.startWorkflowParams ? { ...this.cfg.startWorkflowParams } : {};
-    cfg.startWorkflowParams.workflowID = cfg.startWorkflowParams.workflowID ?? String(randomUUID());
+    rejectConflictingOptions(this.cfg.startWorkflowParams);
+
+    const queueName = this.cfg.startWorkflowParams?.queueName ?? INTERNAL_QUEUE_NAME;
+    const deduplicationID = `${this.cfg.workflowClassName}.${this.cfg.workflowName}-${debounceKey}`;
+
     while (true) {
-      const deduplicationID = `${cfg.workflowClassName}.${cfg.workflowName}-${debounceKey}`;
+      // Try to extend an existing debounced workflow for this key first (the sole coalescing mechanism).
+      const serparam = await serializeArgs(args, undefined, this.client.serializer, undefined);
+      const result = await this.client.debounceDelayedWorkflow({
+        workflowName: this.cfg.workflowName,
+        workflowClassName: this.cfg.workflowClassName,
+        queueName,
+        deduplicationID,
+        delayUntilEpochMS: Date.now() + debouncePeriodMs,
+        input: serparam.serializedValue,
+        serialization: serparam.serialization,
+      });
+
+      const action = classifyBounce(result, this.cfg.workflowName, this.cfg.workflowClassName);
+      if (action === 'return') {
+        return this.client.retrieveWorkflow(result.bouncedWorkflowID!);
+      }
+      if (action === 'raise') {
+        throw new DBOSQueueDuplicatedError(result.holderWorkflowID!, queueName, deduplicationID);
+      }
+      if (action === 'retry') {
+        continue;
+      }
+
+      // action === 'enqueue': the key is free, create a fresh debounced workflow.
+      const debounceDeadlineEpochMS = this.cfg.debounceTimeoutMs ? Date.now() + this.cfg.debounceTimeoutMs : undefined;
       try {
-        // Attempt to enqueue a debouncer for this workflow
-        await this.client.enqueue(
-          { workflowName: DEBOUNCER_WORKLOW_NAME, queueName: INTERNAL_QUEUE_NAME, deduplicationID },
-          debouncePeriodMs,
-          cfg,
-          ...args,
-        );
-        return this.client.retrieveWorkflow(cfg.startWorkflowParams.workflowID);
-      } catch (e) {
-        // If there is already a debouncer, send a message to it.
-        if (e instanceof Error && getDBOSErrorCode(e) === QueueDedupIDDuplicated) {
-          // Access the private client system database
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-          const dedupWorkflowID = (await (this.client as any).systemDatabase.getDeduplicatedWorkflow(
-            INTERNAL_QUEUE_NAME,
+        const workflowID = await this.client.enqueueDebounced(
+          {
+            workflowName: this.cfg.workflowName,
+            workflowClassName: this.cfg.workflowClassName || undefined,
+            queueName,
+            workflowID: this.cfg.startWorkflowParams?.workflowID,
+            workflowTimeoutMS: this.cfg.startWorkflowParams?.timeoutMS ?? undefined,
+            appVersion: this.cfg.startWorkflowParams?.enqueueOptions?.applicationVersion,
+            attributes: this.cfg.startWorkflowParams?.workflowAttributes,
             deduplicationID,
-          )) as string;
-          if (!dedupWorkflowID) {
-            continue;
-          } else {
-            const messageID = String(randomUUID());
-            const message: DebouncerMessage = {
-              messageID,
-              args,
-              debouncePeriodMs,
-            };
-            await this.client.send(dedupWorkflowID, message, _DEBOUNCER_TOPIC);
-            // Wait for the debouncer to acknowledge receipt of the message.
-            // If the message is not acknowledged, this likely means the debouncer started its workflow
-            // and exited without processing this message, so try again.
-            const event = await this.client.getEvent(dedupWorkflowID, messageID, 1000);
-            if (!event) {
-              continue;
-            }
-            // Retrieve the user workflow ID from the input to the debouncer
-            // and return a handle to it.
-            const dedupWorkflowInput = await this.client.retrieveWorkflow(dedupWorkflowID).getWorkflowInputs();
-            const typedInput = dedupWorkflowInput as Parameters<typeof debouncerWorkflowFunction>;
-            const userWorkflowID = typedInput[1].startWorkflowParams!.workflowID!;
-            return this.client.retrieveWorkflow(userWorkflowID);
-          }
-        } else {
+            delaySeconds: debouncePeriodMs / 1000,
+          },
+          debounceDeadlineEpochMS,
+          args,
+        );
+        return this.client.retrieveWorkflow(workflowID);
+      } catch (e) {
+        // A concurrent debounce grabbed the key between bounce and enqueue; loop to bounce that workflow instead.
+        if (!isQueueDeduplicatedError(e)) {
           throw e;
         }
+        continue;
       }
     }
   }

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -173,7 +173,7 @@ export class Debouncer<Args extends unknown[], Return> {
         return DBOS.retrieveWorkflow<Return>(result.bouncedWorkflowID!);
       }
       if (action === 'raise') {
-        throw new DBOSQueueDuplicatedError(result.holderWorkflowID!, queueName, deduplicationID);
+        throw new DBOSQueueDuplicatedError(pinnedWorkflowID ?? '', queueName, deduplicationID);
       }
       if (action === 'retry') {
         continue;

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -252,7 +252,7 @@ export class DebouncerClient {
         return this.client.retrieveWorkflow(result.bouncedWorkflowID!);
       }
       if (action === 'raise') {
-        throw new DBOSQueueDuplicatedError(result.holderWorkflowID!, queueName, deduplicationID);
+        throw new DBOSQueueDuplicatedError(this.cfg.startWorkflowParams?.workflowID ?? '', queueName, deduplicationID);
       }
       if (action === 'retry') {
         continue;

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -13,7 +13,7 @@ import { DBOSError, DBOSQueueDuplicatedError, getDBOSErrorCode, QueueDedupIDDupl
 import { serializeArgs, serializeFunctionInputOutput } from './serialization';
 import { DebounceResult } from './system_database';
 import { INTERNAL_QUEUE_NAME } from './utils';
-import { WorkflowHandle } from './workflow';
+import { WorkflowHandle, WorkflowSerializationFormat } from './workflow';
 import { PortableWorkflowError } from '../schemas/system_db_schema';
 
 // Parameters for the debouncer
@@ -35,6 +35,8 @@ interface DebouncerClientConfig {
   workflowClassName?: string;
   startWorkflowParams?: StartWorkflowParams;
   debounceTimeoutMs?: number;
+  // Serialization format for the workflow's inputs, e.g. 'portable' for a workflow registered with portable serialization.
+  serializationType?: WorkflowSerializationFormat;
 }
 
 /**
@@ -209,6 +211,7 @@ export class Debouncer<Args extends unknown[], Return> {
 
 export class DebouncerClient {
   private readonly cfg: DebouncerParams;
+  private readonly serializationType: WorkflowSerializationFormat;
   constructor(
     readonly client: DBOSClient,
     params: DebouncerClientConfig,
@@ -219,6 +222,7 @@ export class DebouncerClient {
       startWorkflowParams: params.startWorkflowParams,
       debounceTimeoutMs: params.debounceTimeoutMs,
     };
+    this.serializationType = params.serializationType;
   }
 
   async debounce(debounceKey: string, debouncePeriodMs: number, ...args: unknown[]): Promise<WorkflowHandle<unknown>> {
@@ -232,7 +236,7 @@ export class DebouncerClient {
 
     while (true) {
       // Try to extend an existing debounced workflow for this key first (the sole coalescing mechanism).
-      const serparam = await serializeArgs(args, undefined, this.client.serializer, undefined);
+      const serparam = await serializeArgs(args, undefined, this.client.serializer, this.serializationType);
       const result = await this.client.debounceDelayedWorkflow({
         workflowName: this.cfg.workflowName,
         workflowClassName: this.cfg.workflowClassName,
@@ -268,6 +272,7 @@ export class DebouncerClient {
             attributes: this.cfg.startWorkflowParams?.workflowAttributes,
             deduplicationID,
             delaySeconds: debouncePeriodMs / 1000,
+            serializationType: this.serializationType,
           },
           debounceDeadlineEpochMS,
           args,

--- a/src/error.ts
+++ b/src/error.ts
@@ -178,6 +178,8 @@ export class DBOSQueueDuplicatedError extends DBOSError {
       `Workflow ${workflowID} was deduplicated due to an existing workflow in queue ${queue} with deduplication ID ${deduplicationID}.`,
       QueueDedupIDDuplicated,
     );
+    // Portable error serialization records err.name, which is otherwise 'Error'; the debouncer matches on it after replay.
+    this.name = 'DBOSQueueDuplicatedError';
   }
 }
 

--- a/src/sysdb_migrations/internal/migrations.ts
+++ b/src/sysdb_migrations/internal/migrations.ts
@@ -677,5 +677,14 @@ export function allMigrations(
         `CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "${schemaName}"."workflow_status" ("schedule_name") WHERE "schedule_name" IS NOT NULL`,
       ],
     },
+    // Debounce support: an absolute cap on how far bounces may extend a delayed
+    // workflow's delay, and a flag marking the deduplication ID as a debounce key
+    // to clear on the DELAYED->ENQUEUED transition.
+    {
+      pg: [
+        `ALTER TABLE "${schemaName}"."workflow_status" ADD COLUMN IF NOT EXISTS "debounce_deadline_epoch_ms" BIGINT DEFAULT NULL`,
+        `ALTER TABLE "${schemaName}"."workflow_status" ADD COLUMN IF NOT EXISTS "is_debounced" BOOLEAN NOT NULL DEFAULT FALSE`,
+      ],
+    },
   ];
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -228,6 +228,10 @@ export interface WorkflowStatusInternal {
   attributes?: Record<string, unknown>;
   // If this workflow was enqueued by a named schedule, that schedule's name. Only set by the persistent scheduler.
   scheduleName?: string;
+  // Absolute cap (epoch ms) beyond which bounces may not extend the delay; unset if not debounced or no timeout.
+  debounceDeadlineEpochMS?: number;
+  // True if this workflow's deduplication ID is a debounce key to clear on the DELAYED->ENQUEUED transition.
+  isDebounced?: boolean;
 }
 
 export interface EnqueueOptions {
@@ -241,6 +245,34 @@ export interface EnqueueOptions {
   applicationVersion?: string;
   // Number of seconds to delay the workflow before it starts executing. The workflow will be in DELAYED status until the delay expires.
   delaySeconds?: number;
+  // Internal, set only by the debouncer: absolute cap (epoch ms) on how far the delay may extend.
+  debounceDeadlineEpochMS?: number;
+  // Internal, set only by the debouncer: marks the deduplication ID as a debounce key.
+  isDebounced?: boolean;
+}
+
+// Arguments to debounceDelayedWorkflow: identify the debounced workflow by
+// (name, class, queue, debounce key) and carry the new delay and inputs.
+export interface DebounceParams {
+  workflowName: string;
+  workflowClassName: string;
+  queueName: string;
+  deduplicationID: string;
+  delayUntilEpochMS: number;
+  input: string | null;
+  serialization: string | null;
+}
+
+export interface DebounceResult {
+  // The extended workflow's ID if an existing debounced DELAYED workflow was bounced; null if no bounce occurred.
+  bouncedWorkflowID: string | null;
+  // The current holder of (queue_name, deduplication_id) when no bounce occurred, or null if the key is unheld.
+  holderWorkflowID: string | null;
+  // Whether the holder is itself a debounced workflow.
+  holderIsDebounced: boolean;
+  // The holder's workflow name and class; a mismatch with the caller's means a debounce-key collision between workflows.
+  holderWorkflowName: string | null;
+  holderWorkflowClassName: string | null;
 }
 
 // How to handle a collision with another workflow that has the same `enqueueOptions.deduplicationID`
@@ -444,6 +476,8 @@ function mapWorkflowStatus(row: workflow_status): WorkflowStatusInternal {
     completedAt: row.completed_at ? Number(row.completed_at) : undefined,
     attributes: row.attributes ?? undefined,
     scheduleName: row.schedule_name ?? undefined,
+    debounceDeadlineEpochMS: row.debounce_deadline_epoch_ms ? Number(row.debounce_deadline_epoch_ms) : undefined,
+    isDebounced: row.is_debounced ?? false,
   };
 }
 
@@ -1030,6 +1064,7 @@ export class SystemDatabase {
         },
       );
       await client.query('COMMIT');
+      await debugTriggerPoint(DEBUG_TRIGGER_STEP_COMMIT);
       return undefined;
     } catch (e) {
       await client.query('ROLLBACK');
@@ -1157,6 +1192,98 @@ export class SystemDatabase {
          AND status = $4`,
       [delayUntilEpochMS, Date.now(), workflowID, StatusString.DELAYED],
     );
+  }
+
+  /**
+   * Extend an existing debounced DELAYED workflow's delay and update its inputs, atomically.
+   * The new delay is capped at the workflow's debounce_deadline_epoch_ms, if one is set.
+   * Matching on workflow name and class ensures a debounce-key collision between different
+   * workflows never overwrites another workflow's inputs. If nothing matched, returns the
+   * current holder (or that the key is unheld) so the caller can start fresh or surface a conflict.
+   * Runs on `client` if given, joining its transaction (e.g. a transactional step's);
+   * otherwise in its own retried transaction.
+   */
+  async debounceDelayedWorkflow(params: DebounceParams, client?: PoolClient): Promise<DebounceResult> {
+    if (client !== undefined) {
+      return await this.#debounceDelayedWorkflowInternal(client, params);
+    }
+    return await this.debounceDelayedWorkflowStandalone(params);
+  }
+
+  @dbRetry()
+  private async debounceDelayedWorkflowStandalone(params: DebounceParams): Promise<DebounceResult> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED');
+      const result = await this.#debounceDelayedWorkflowInternal(client, params);
+      await client.query('COMMIT');
+      return result;
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  async #debounceDelayedWorkflowInternal(client: PoolClient, params: DebounceParams): Promise<DebounceResult> {
+    const classNameOrNull = params.workflowClassName === '' ? null : params.workflowClassName;
+    const updated = await client.query<{ workflow_uuid: string }>(
+      `UPDATE "${this.schemaName}".workflow_status
+       SET delay_until_epoch_ms = CASE
+             WHEN debounce_deadline_epoch_ms IS NOT NULL AND debounce_deadline_epoch_ms < $1
+             THEN debounce_deadline_epoch_ms
+             ELSE $1
+           END,
+           inputs = $2, serialization = $3, updated_at = $4
+       WHERE name = $5 AND class_name IS NOT DISTINCT FROM $6
+         AND queue_name = $7 AND deduplication_id = $8
+         AND status = $9 AND is_debounced = TRUE
+       RETURNING workflow_uuid`,
+      [
+        params.delayUntilEpochMS,
+        params.input,
+        params.serialization,
+        Date.now(),
+        params.workflowName,
+        classNameOrNull,
+        params.queueName,
+        params.deduplicationID,
+        StatusString.DELAYED,
+      ],
+    );
+    if (updated.rows.length > 0) {
+      return {
+        bouncedWorkflowID: updated.rows[0].workflow_uuid,
+        holderWorkflowID: null,
+        holderIsDebounced: false,
+        holderWorkflowName: null,
+        holderWorkflowClassName: null,
+      };
+    }
+    // No match: the key is unheld, or held by a non-debounced or name-colliding workflow.
+    const holder = await client.query<workflow_status>(
+      `SELECT workflow_uuid, is_debounced, name, class_name
+       FROM "${this.schemaName}".workflow_status
+       WHERE queue_name = $1 AND deduplication_id = $2`,
+      [params.queueName, params.deduplicationID],
+    );
+    if (holder.rows.length === 0) {
+      return {
+        bouncedWorkflowID: null,
+        holderWorkflowID: null,
+        holderIsDebounced: false,
+        holderWorkflowName: null,
+        holderWorkflowClassName: null,
+      };
+    }
+    return {
+      bouncedWorkflowID: null,
+      holderWorkflowID: holder.rows[0].workflow_uuid,
+      holderIsDebounced: holder.rows[0].is_debounced ?? false,
+      holderWorkflowName: holder.rows[0].name,
+      holderWorkflowClassName: holder.rows[0].class_name ?? null,
+    };
   }
 
   // Get the immediate (one-level) child workflow IDs for a set of workflows.
@@ -1516,7 +1643,8 @@ export class SystemDatabase {
             workflow_timeout_ms, workflow_deadline_epoch_ms, started_at_epoch_ms,
             deduplication_id, inputs, priority, queue_partition_key, forked_from,
             parent_workflow_id, serialization, delay_until_epoch_ms,
-            was_forked_from, rate_limited, completed_at, attributes, schedule_name
+            was_forked_from, rate_limited, completed_at, attributes, schedule_name,
+            debounce_deadline_epoch_ms, is_debounced
           FROM "${this.schemaName}".workflow_status
           WHERE workflow_uuid = $1`,
           [wfID],
@@ -1596,8 +1724,9 @@ export class SystemDatabase {
             workflow_timeout_ms, workflow_deadline_epoch_ms, started_at_epoch_ms,
             deduplication_id, inputs, priority, queue_partition_key, forked_from,
             parent_workflow_id, serialization, delay_until_epoch_ms,
-            was_forked_from, rate_limited, completed_at, attributes, schedule_name
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34)`,
+            was_forked_from, rate_limited, completed_at, attributes, schedule_name,
+            debounce_deadline_epoch_ms, is_debounced
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36)`,
           [
             status.workflow_uuid,
             status.status,
@@ -1635,6 +1764,8 @@ export class SystemDatabase {
             status.completed_at ?? null,
             status.attributes ? JSON.stringify(status.attributes) : null,
             status.schedule_name ?? null,
+            status.debounce_deadline_epoch_ms ?? null,
+            status.is_debounced ?? false,
           ],
         );
 
@@ -2508,10 +2639,13 @@ export class SystemDatabase {
 
   // ==================== Queues ====================
   async transitionDelayedWorkflows(): Promise<void> {
-    // Transition workflows from DELAYED to ENQUEUED when their delay has expired
+    // Transition workflows from DELAYED to ENQUEUED when their delay has expired.
+    // For debounced workflows, clear the deduplication ID in the same atomic update: it is a
+    // debounce key held only while DELAYED, so a later same-key debounce starts a fresh workflow.
     await this.pool.query(
       `UPDATE "${this.schemaName}".workflow_status
-       SET status = $1, updated_at = $2
+       SET status = $1, updated_at = $2,
+           deduplication_id = CASE WHEN is_debounced THEN NULL ELSE deduplication_id END
        WHERE status = $3 AND delay_until_epoch_ms <= $2`,
       [StatusString.ENQUEUED, Date.now(), StatusString.DELAYED],
     );
@@ -2765,6 +2899,8 @@ export class SystemDatabase {
       'completed_at',
       'attributes',
       'schedule_name',
+      'debounce_deadline_epoch_ms',
+      'is_debounced',
     ];
 
     input.loadInput = input.loadInput ?? true;
@@ -3663,8 +3799,10 @@ export class SystemDatabase {
           owner_xid,
           delay_until_epoch_ms,
           attributes,
-          schedule_name
-        ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $26, $27, $28, $29, $30)
+          schedule_name,
+          debounce_deadline_epoch_ms,
+          is_debounced
+        ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $26, $27, $28, $29, $30, $31, $32)
         ON CONFLICT (workflow_uuid)
           DO UPDATE SET
             recovery_attempts = CASE
@@ -3711,6 +3849,8 @@ export class SystemDatabase {
           initStatus.delayUntilEpochMS ?? null,
           initStatus.attributes ? JSON.stringify(initStatus.attributes) : null,
           initStatus.scheduleName ?? null,
+          initStatus.debounceDeadlineEpochMS ?? null,
+          initStatus.isDebounced ?? false,
         ],
       );
       if (rows.length === 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,6 @@ export const sleepConfig = {
 
 // The name of the internal queue used by DBOS
 export const INTERNAL_QUEUE_NAME = '_dbos_internal_queue';
-export const DEBOUNCER_WORKLOW_NAME = '_dbos_debouncer_workflow';
 
 /*
 A cancellable sleep function that returns a promise and a callback

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto';
 import { DBOS, DBOSClient, Debouncer } from '../src';
 import { DBOSConfig } from '../src/dbos-executor';
-import { DEBOUNCER_WORKLOW_NAME } from '../src/utils';
 import * as protocol from '../src/conductor/protocol';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
 
@@ -236,7 +235,7 @@ describe('workflow-attributes', () => {
     expect(JSON.parse(serialized.output[0].Attributes)).toEqual({ customer: 'acme', tier: 1 });
   });
 
-  test('debounced user workflow gets attributes; internal debouncer does not', async () => {
+  test('debounced user workflow gets attributes', async () => {
     const debouncer = new Debouncer({
       workflow: echoWorkflow,
       startWorkflowParams: { workflowAttributes: { source: 'debouncer' } },
@@ -244,12 +243,5 @@ describe('workflow-attributes', () => {
     const handle = await debouncer.debounce('key', 1000, 5);
     expect(await handle.getResult()).toBe(5);
     expect((await handle.getStatus())?.attributes).toEqual({ source: 'debouncer' });
-
-    // The internal debouncer workflow itself does not get the user's attributes.
-    const internalStatuses = await DBOS.listWorkflows({ workflowName: DEBOUNCER_WORKLOW_NAME });
-    expect(internalStatuses.length).toBeGreaterThan(0);
-    for (const status of internalStatuses) {
-      expect(status.attributes).toBeUndefined();
-    }
   });
 });

--- a/tests/debouncer.test.ts
+++ b/tests/debouncer.test.ts
@@ -1,5 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import { DBOS, Debouncer, DBOSConfig, StatusString, DBOSClient, DebouncerClient } from '../src';
-import { generateDBOSTestConfig, reexecuteWorkflowById, setUpDBOSTestSysDb } from './helpers';
+import { DBOSExecutor } from '../src/dbos-executor';
+import { DBOSQueueDuplicatedError } from '../src/error';
+import { INTERNAL_QUEUE_NAME } from '../src/utils';
+import { clearDebugTriggers, DebugAction, DEBUG_TRIGGER_STEP_COMMIT, setDebugTrigger } from '../src/debugpoint';
+import { PortableWorkflowError } from '../schemas/system_db_schema';
+import { generateDBOSTestConfig, reexecuteWorkflowById, setUpDBOSTestSysDb, Event } from './helpers';
 import assert from 'node:assert';
 
 describe('debouncer-tests', () => {
@@ -29,6 +35,110 @@ describe('debouncer-tests', () => {
   );
 
   const queue = { name: 'test-queue' };
+
+  // The dedup ID a debounce computes for `workflow` and a given key.
+  const dedupIDForKey = (key: string) => `.debouncerWorkflow-${key}`;
+  const getSysDB = () => DBOSExecutor.globalInstance!.systemDatabase;
+
+  // A workflow that signals when it starts and blocks until released, reset per test.
+  let blockStarted: Event;
+  let blockRelease: Event;
+  const blockingWorkflow = DBOS.registerWorkflow(
+    async (x: number) => {
+      blockStarted.set();
+      await blockRelease.wait();
+      return x;
+    },
+    { name: 'debouncerBlockingWorkflow' },
+  );
+
+  let deadlineChildRan = false;
+  const deadlineChild = DBOS.registerWorkflow(
+    async (x: number) => {
+      deadlineChildRan = true;
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerDeadlineChild' },
+  );
+  const deadlineDebouncer = new Debouncer({ workflow: deadlineChild });
+  // Debounces with a delay longer than the caller's own timeout, then returns the debounced workflow's ID.
+  const deadlineParent = DBOS.registerWorkflow(
+    async () => {
+      const handle = await deadlineDebouncer.debounce('deadline-key', 5000, 5);
+      return handle.workflowID;
+    },
+    { name: 'debouncerDeadlineParent' },
+  );
+
+  let replayChildRuns = 0;
+  let replayParentRuns = 0;
+  const replayChild = DBOS.registerWorkflow(
+    async (x: number) => {
+      replayChildRuns++;
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerReplayChild' },
+  );
+  const replayDebouncer = new Debouncer({ workflow: replayChild });
+  const replayParent = DBOS.registerWorkflow(
+    async () => {
+      replayParentRuns++;
+      const handle = await replayDebouncer.debounce('replay-key', 1000, 7);
+      return handle.workflowID;
+    },
+    { name: 'debouncerReplayParent' },
+  );
+
+  const leakOther = DBOS.registerWorkflow(
+    async (x: number) => {
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerLeakOther' },
+  );
+  const leakDebouncer = new Debouncer({ workflow });
+  // The first call creates the delayed workflow; the pinned second call bounces it, so the pinned ID goes unused.
+  const leakParent = DBOS.registerWorkflow(
+    async (pinnedID: string) => {
+      const first = await leakDebouncer.debounce('leak-key', 1000000000, 1);
+      const bounced = await DBOS.withNextWorkflowID(pinnedID, () => leakDebouncer.debounce('leak-key', 1000000000, 2));
+      assert.equal(bounced.workflowID, first.workflowID);
+      const next = await DBOS.startWorkflow(leakOther)(3);
+      return [first.workflowID, next.workflowID];
+    },
+    { name: 'debouncerLeakParent' },
+  );
+
+  let atomicRuns = 0;
+  const atomicWorkflow = DBOS.registerWorkflow(
+    async (x: number) => {
+      atomicRuns++;
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerAtomicWorkflow' },
+  );
+  const atomicDebouncer = new Debouncer({ workflow: atomicWorkflow });
+  const atomicParent = DBOS.registerWorkflow(
+    async () => {
+      const handle = await atomicDebouncer.debounce('atomic-key', 2000000000, 2);
+      return handle.workflowID;
+    },
+    { name: 'debouncerAtomicParent' },
+  );
+
+  const postCommitWorkflow = DBOS.registerWorkflow(
+    async (x: number) => {
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerPostCommitWorkflow' },
+  );
+  const postCommitDebouncer = new Debouncer({ workflow: postCommitWorkflow });
+  const postCommitParent = DBOS.registerWorkflow(
+    async () => {
+      const handle = await postCommitDebouncer.debounce('post-commit-key', 2000000000, 2);
+      return handle.workflowID;
+    },
+    { name: 'debouncerPostCommitParent' },
+  );
 
   test('test-debouncer-workflow', async () => {
     const firstValue = 0;
@@ -290,4 +400,404 @@ describe('debouncer-tests', () => {
     assert.equal(await fifthHandle.getResult(), sixthValue);
     await client.destroy();
   });
+
+  test('test-debounce-flip-clears-dedup', async () => {
+    blockStarted = new Event();
+    blockRelease = new Event();
+
+    const debouncer = new Debouncer({ workflow: blockingWorkflow });
+    // A huge period keeps the workflow DELAYED until a later bounce shortens it.
+    const handle = await debouncer.debounce('key', 1000000000, 1);
+
+    // While delayed, the workflow is marked debounced and holds the debounce key.
+    let status = await getSysDB().getWorkflowStatus(handle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    expect(status?.isDebounced).toBe(true);
+    expect(status?.deduplicationID).toBe('.debouncerBlockingWorkflow-key');
+
+    // A bounce shortens the delay and replaces the input; the same workflow runs.
+    const handle2 = await debouncer.debounce('key', 1000, 2);
+    expect(handle2.workflowID).toBe(handle.workflowID);
+
+    // Wait for the flip: the workflow starts but blocks, so it's in flight, not complete.
+    await blockStarted.wait();
+
+    // The flip cleared the debounce key; assert while still running since completion also clears it.
+    status = await getSysDB().getWorkflowStatus(handle.workflowID);
+    expect(status?.status).toBe(StatusString.PENDING);
+    expect(status?.deduplicationID).toBeUndefined();
+
+    // A same-key debounce therefore starts fresh even before the first workflow finishes.
+    const handle3 = await debouncer.debounce('key', 1000, 3);
+    expect(handle3.workflowID).not.toBe(handle.workflowID);
+
+    blockRelease.set();
+    expect(await handle2.getResult()).toBe(2);
+    expect(await handle3.getResult()).toBe(3);
+  }, 60000);
+
+  test('test-debounce-cancel-then-redebounce', async () => {
+    const debouncer = new Debouncer({ workflow });
+    const handle = await debouncer.debounce('key', 1000000000, 1);
+    const status = await getSysDB().getWorkflowStatus(handle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+
+    // Cancelling a delayed debounced workflow clears its debounce key.
+    await DBOS.cancelWorkflow(handle.workflowID);
+
+    // A new debounce with the same key therefore starts a fresh workflow.
+    const handle2 = await debouncer.debounce('key', 1000, 2);
+    expect(handle2.workflowID).not.toBe(handle.workflowID);
+    expect(await handle2.getResult()).toBe(2);
+  }, 30000);
+
+  test('test-debounce-deadline-caps-initial-delay', async () => {
+    // A huge period with a finite timeout: the delay is capped at the deadline.
+    const debouncer = new Debouncer({ workflow, debounceTimeoutMs: 1000000 });
+    const handle = await debouncer.debounce('key', 1000000000, 1);
+
+    const status = await getSysDB().getWorkflowStatus(handle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    expect(status?.isDebounced).toBe(true);
+    expect(status?.debounceDeadlineEpochMS).toBeDefined();
+    expect(status?.delayUntilEpochMS).toBeDefined();
+    expect(status!.delayUntilEpochMS!).toBeLessThanOrEqual(status!.debounceDeadlineEpochMS!);
+
+    await DBOS.cancelWorkflow(handle.workflowID);
+  });
+
+  test('test-debounce-user-dedup-conflict-raises', async () => {
+    // A non-debounced workflow occupies the debounce key on the internal queue.
+    const dedupID = dedupIDForKey('key');
+    const blocker = await DBOS.startWorkflow(workflow, {
+      queueName: INTERNAL_QUEUE_NAME,
+      enqueueOptions: { deduplicationID: dedupID, delaySeconds: 100000 },
+    })(1);
+
+    // The key is held by a non-debounced workflow, so debouncing it surfaces the dedup conflict rather than hijacking it.
+    const debouncer = new Debouncer({ workflow });
+    await expect(debouncer.debounce('key', 1000, 2)).rejects.toThrow(DBOSQueueDuplicatedError);
+
+    await DBOS.cancelWorkflow(blocker.workflowID);
+  });
+
+  test('test-debounce-fixed-workflow-id-reuse', async () => {
+    const debouncer = new Debouncer({ workflow });
+
+    // Pinning the same workflow ID across debounces of one key must still bounce the existing workflow (last input wins), not drop it on a workflow_uuid collision.
+    const wfid = randomUUID();
+    const firstHandle = await DBOS.withNextWorkflowID(wfid, () => debouncer.debounce('key', 2000, 1));
+    const secondHandle = await DBOS.withNextWorkflowID(wfid, () => debouncer.debounce('key', 2000, 2));
+    expect(firstHandle.workflowID).toBe(wfid);
+    expect(secondHandle.workflowID).toBe(wfid);
+    expect(await firstHandle.getResult()).toBe(2);
+    expect(await secondHandle.getResult()).toBe(2);
+
+    // A huge initial period then a short one under the same pinned ID must still shorten the delay so the workflow runs.
+    const wfid2 = randomUUID();
+    const thirdHandle = await DBOS.withNextWorkflowID(wfid2, () => debouncer.debounce('key2', 1000000000, 3));
+    const fourthHandle = await DBOS.withNextWorkflowID(wfid2, () => debouncer.debounce('key2', 1000, 4));
+    expect(thirdHandle.workflowID).toBe(wfid2);
+    expect(fourthHandle.workflowID).toBe(wfid2);
+    expect(await fourthHandle.getResult()).toBe(4);
+  }, 30000);
+
+  test('test-debounce-inworkflow-does-not-inherit-parent-deadline', async () => {
+    deadlineChildRan = false;
+
+    // Debounce inside a workflow whose timeout (2s) is shorter than the debounce delay (5s); the debounced workflow must not inherit the parent's deadline or it would be cancelled before running.
+    const parentHandle = await DBOS.startWorkflow(deadlineParent, { timeoutMS: 2000 })();
+    const childID = await parentHandle.getResult();
+
+    // The debounced workflow carries no inherited deadline while delayed.
+    const status = await getSysDB().getWorkflowStatus(childID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    expect(status?.deadlineEpochMS).toBeUndefined();
+
+    // It runs to completion after the delay rather than being cancelled.
+    const childHandle = DBOS.retrieveWorkflow<number>(childID);
+    expect(await childHandle.getResult()).toBe(5);
+    expect(deadlineChildRan).toBe(true);
+    expect((await childHandle.getStatus())?.status).toBe(StatusString.SUCCESS);
+  }, 60000);
+
+  test('test-debounce-inworkflow-replay-is-deterministic', async () => {
+    replayChildRuns = 0;
+    replayParentRuns = 0;
+
+    const parentHandle = await DBOS.startWorkflow(replayParent)();
+    const childID = await parentHandle.getResult();
+    expect(replayParentRuns).toBe(1);
+
+    // Force the parent to replay from its checkpoints: the bounce step and enqueue are checkpointed, so replay must re-run the body, return the same child ID, and not enqueue a second child.
+    const recoverHandle = await reexecuteWorkflowById(parentHandle.workflowID);
+    expect(await recoverHandle!.getResult()).toBe(childID);
+    expect(replayParentRuns).toBe(2);
+
+    // Exactly one child workflow exists for this key: replay did not double-enqueue.
+    const children = await DBOS.listWorkflows({ workflowName: 'debouncerReplayChild' });
+    expect(children.length).toBe(1);
+
+    // The single debounced child runs to completion exactly once.
+    const childHandle = DBOS.retrieveWorkflow<number>(childID);
+    expect(await childHandle.getResult()).toBe(7);
+    expect(replayChildRuns).toBe(1);
+  }, 60000);
+
+  test('test-debounce-retries-replayed-portable-dedup-error', async () => {
+    // Regression test: when a debounce's fresh enqueue loses the dedup race in a workflow using
+    // portable serialization, replay revives the checkpointed error as a PortableWorkflowError
+    // carrying only the original type name. The retry loop must still recognize that form and
+    // bounce the existing workflow instead of erroring.
+    const debouncer = new Debouncer({ workflow });
+    const sysDB = getSysDB();
+    const originalInit = sysDB.initWorkflowStatus.bind(sysDB);
+    let dedupInitCalls = 0;
+    const spy = jest.spyOn(sysDB, 'initWorkflowStatus').mockImplementation(async (initStatus, ownerXid, options) => {
+      // The first enqueue throws the exact object a replay produces from a checkpointed, portable-serialized dedup error; subsequent enqueues behave normally.
+      if (initStatus.deduplicationID === dedupIDForKey('portable-key')) {
+        dedupInitCalls++;
+        if (dedupInitCalls === 1) {
+          throw new PortableWorkflowError('Workflow was deduplicated', DBOSQueueDuplicatedError.name);
+        }
+      }
+      return originalInit(initStatus, ownerXid, options);
+    });
+
+    try {
+      const handle = await debouncer.debounce('portable-key', 500, 5);
+      // The loop recognized the replay-form dedup error and retried instead of propagating it.
+      expect(dedupInitCalls).toBe(2);
+      expect(await handle.getResult()).toBe(5);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30000);
+
+  test('test-debounce-rejects-caller-dedup-and-delay', async () => {
+    // A debounce owns the workflow's deduplication ID and delay, and priority/partition keys cannot apply to a debounced enqueue, so a caller that sets any of them must fail loudly rather than have it silently ignored or break later.
+
+    // Local: a caller-set deduplicationID is rejected.
+    let debouncer = new Debouncer({
+      workflow,
+      startWorkflowParams: { enqueueOptions: { deduplicationID: 'caller-dedup' } },
+    });
+    await expect(debouncer.debounce('k', 1000, 1)).rejects.toThrow('deduplicationID');
+
+    // Local: a caller-set delay is rejected.
+    debouncer = new Debouncer({ workflow, startWorkflowParams: { enqueueOptions: { delaySeconds: 100 } } });
+    await expect(debouncer.debounce('k', 1000, 1)).rejects.toThrow('delay');
+
+    // Local: a caller-set priority is rejected.
+    debouncer = new Debouncer({ workflow, startWorkflowParams: { enqueueOptions: { priority: 1 } } });
+    await expect(debouncer.debounce('k', 1000, 1)).rejects.toThrow('priority');
+
+    // Local: a caller-set partition key is rejected.
+    debouncer = new Debouncer({
+      workflow,
+      startWorkflowParams: { enqueueOptions: { queuePartitionKey: 'caller-partition' } },
+    });
+    await expect(debouncer.debounce('k', 1000, 1)).rejects.toThrow('partition key');
+
+    // No conflicting option left a workflow behind.
+    expect((await DBOS.listWorkflows({ workflowName: 'debouncerWorkflow' })).length).toBe(0);
+
+    const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+    try {
+      // Client: the same four options are rejected.
+      const dedupClient = new DebouncerClient(client, {
+        workflowName: 'debouncerWorkflow',
+        startWorkflowParams: { enqueueOptions: { deduplicationID: 'caller-dedup' } },
+      });
+      await expect(dedupClient.debounce('k', 1000, 1)).rejects.toThrow('deduplicationID');
+
+      const delayClient = new DebouncerClient(client, {
+        workflowName: 'debouncerWorkflow',
+        startWorkflowParams: { enqueueOptions: { delaySeconds: 100 } },
+      });
+      await expect(delayClient.debounce('k', 1000, 1)).rejects.toThrow('delay');
+
+      const priorityClient = new DebouncerClient(client, {
+        workflowName: 'debouncerWorkflow',
+        startWorkflowParams: { enqueueOptions: { priority: 1 } },
+      });
+      await expect(priorityClient.debounce('k', 1000, 1)).rejects.toThrow('priority');
+
+      const partitionClient = new DebouncerClient(client, {
+        workflowName: 'debouncerWorkflow',
+        startWorkflowParams: { enqueueOptions: { queuePartitionKey: 'caller-partition' } },
+      });
+      await expect(partitionClient.debounce('k', 1000, 1)).rejects.toThrow('partition key');
+    } finally {
+      await client.destroy();
+    }
+  });
+
+  test('test-debounce-bounce-path-does-not-leak-pinned-id', async () => {
+    // Regression test: a pinned workflow ID around a debounce that coalesces (bounce path) is captured by the debounce and must not stay armed on the workflow's context, or the next child workflow the parent starts would silently run under the pinned ID.
+    const pinnedID = randomUUID();
+    const [delayedID, nextID] = await (await DBOS.startWorkflow(leakParent)(pinnedID)).getResult();
+
+    // The next child workflow did not inherit the unused pinned ID.
+    expect(nextID).not.toBe(pinnedID);
+    expect(await DBOS.retrieveWorkflow<number>(nextID).getResult()).toBe(3);
+
+    await DBOS.cancelWorkflow(delayedID);
+  }, 30000);
+
+  test('test-debounce-pinned-id-survives-enqueue-dedup-race', async () => {
+    // Regression test: a fresh-enqueue attempt consumes a pinned workflow ID from the context before its INSERT can lose the dedup race. The retry loop must re-apply the pinned ID so the workflow is still created under it, not a generated UUID.
+    const debouncer = new Debouncer({ workflow });
+    const sysDB = getSysDB();
+    const originalInit = sysDB.initWorkflowStatus.bind(sysDB);
+    let initCalls = 0;
+    const spy = jest.spyOn(sysDB, 'initWorkflowStatus').mockImplementation(async (initStatus, ownerXid, options) => {
+      // The first enqueue's insert loses the dedup race after the pinned ID was already consumed; later calls behave normally.
+      if (initStatus.deduplicationID === dedupIDForKey('pin-race-key')) {
+        initCalls++;
+        if (initCalls === 1) {
+          throw new DBOSQueueDuplicatedError('racer', 'queue', 'dedup');
+        }
+      }
+      return originalInit(initStatus, ownerXid, options);
+    });
+
+    try {
+      const wfid = randomUUID();
+      const handle = await DBOS.withNextWorkflowID(wfid, () => debouncer.debounce('pin-race-key', 500, 7));
+
+      // The retried enqueue reused the pinned ID rather than minting a random one.
+      expect(initCalls).toBeGreaterThanOrEqual(2);
+      expect(handle.workflowID).toBe(wfid);
+      expect(await handle.getResult()).toBe(7);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30000);
+
+  test('test-debounce-key-collision-between-workflows', async () => {
+    // Regression test: "colw"+"b-k" and "colw-b"+"k" both yield dedup ID ".colw-b-k".
+    // The collider must surface the conflict, not overwrite the other workflow's row.
+    const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+    try {
+      const debouncerA = new DebouncerClient(client, { workflowName: 'colw' });
+      const debouncerB = new DebouncerClient(client, { workflowName: 'colw-b' });
+
+      // A huge period keeps workflow "colw" DELAYED, holding dedup ID ".colw-b-k".
+      const handleA = await debouncerA.debounce('b-k', 1000000000, 1);
+      let status = await getSysDB().getWorkflowStatus(handleA.workflowID);
+      expect(status?.status).toBe(StatusString.DELAYED);
+      expect(status?.deduplicationID).toBe('.colw-b-k');
+
+      // The colliding debounce for workflow "colw-b" raises instead of hijacking the row.
+      await expect(debouncerB.debounce('k', 1000, 2)).rejects.toThrow(DBOSQueueDuplicatedError);
+
+      // The victim is untouched: still DELAYED under its own name.
+      status = await getSysDB().getWorkflowStatus(handleA.workflowID);
+      expect(status?.status).toBe(StatusString.DELAYED);
+      expect(status?.workflowName).toBe('colw');
+
+      // A same-name bounce still coalesces onto the existing workflow.
+      const handleA2 = await debouncerA.debounce('b-k', 1000000000, 3);
+      expect(handleA2.workflowID).toBe(handleA.workflowID);
+
+      await DBOS.cancelWorkflow(handleA.workflowID);
+    } finally {
+      await client.destroy();
+    }
+  });
+
+  test('test-debounce-bounce-atomic-with-checkpoint', async () => {
+    // Regression test (exactly-once): an in-workflow bounce commits atomically with its step
+    // checkpoint. If the checkpoint write fails, the bounce must roll back with it; otherwise a
+    // recovered parent would re-bounce or re-enqueue work that already committed, running it twice.
+    atomicRuns = 0;
+
+    // A fresh debounced workflow, kept DELAYED by a huge period.
+    const wHandle = await atomicDebouncer.debounce('atomic-key', 1000000000, 1);
+    let status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    const delayBefore = status!.delayUntilEpochMS!;
+    expect(delayBefore).toBeDefined();
+
+    // The bounce's checkpoint write fails once, after the bounce UPDATE ran in the same transaction.
+    type RecordOpFn = (...args: unknown[]) => Promise<unknown>;
+    const sysDBInternals = getSysDB() as unknown as { recordOperationResultInternal: RecordOpFn };
+    const originalRecord = sysDBInternals.recordOperationResultInternal.bind(getSysDB());
+    let armed = true;
+    const spy = jest.spyOn(sysDBInternals, 'recordOperationResultInternal').mockImplementation((...args: unknown[]) => {
+      if (armed && args[3] === 'DBOS.debounceDelayedWorkflow') {
+        armed = false;
+        throw new Error('crash before checkpoint commit');
+      }
+      return originalRecord(...args);
+    });
+
+    let parentID: string;
+    try {
+      const parentHandle = await DBOS.startWorkflow(atomicParent)();
+      parentID = parentHandle.workflowID;
+      await expect(parentHandle.getResult()).rejects.toThrow('crash before checkpoint commit');
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The failed checkpoint rolled back the bounce with it: the delay (set in the same UPDATE as the inputs) is unchanged.
+    status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    expect(status?.delayUntilEpochMS).toBe(delayBefore);
+
+    // Recovery replays the parent: no checkpoint exists, so the bounce re-executes and lands exactly once.
+    const recoverHandle = await reexecuteWorkflowById(parentID);
+    expect(await recoverHandle!.getResult()).toBe(wHandle.workflowID);
+
+    status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status!.delayUntilEpochMS!).toBeGreaterThan(delayBefore);
+
+    // Exactly one workflow exists for the key; shortening the delay runs it exactly once with the bounced input.
+    expect((await DBOS.listWorkflows({ workflowName: 'debouncerAtomicWorkflow' })).length).toBe(1);
+    const finalHandle = await atomicDebouncer.debounce('atomic-key', 500, 2);
+    expect(finalHandle.workflowID).toBe(wHandle.workflowID);
+    expect(await finalHandle.getResult()).toBe(2);
+    expect(atomicRuns).toBe(1);
+  }, 60000);
+
+  test('test-debounce-bounce-checkpoint-survives-post-commit-crash', async () => {
+    // Regression test (exactly-once): a crash immediately after the atomic bounce+checkpoint
+    // commit must replay through the checkpoint on recovery -- same handle, no second bounce.
+    const wHandle = await postCommitDebouncer.debounce('post-commit-key', 1000000000, 1);
+    let status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status?.status).toBe(StatusString.DELAYED);
+    const delayBefore = status!.delayUntilEpochMS!;
+    expect(delayBefore).toBeDefined();
+
+    // Crash the parent right after the bounce's transaction commits.
+    const action = new DebugAction();
+    action.callback = () => {
+      throw new Error('crash after checkpoint commit');
+    };
+    setDebugTrigger(DEBUG_TRIGGER_STEP_COMMIT, action);
+    let parentID: string;
+    try {
+      const parentHandle = await DBOS.startWorkflow(postCommitParent)();
+      parentID = parentHandle.workflowID;
+      await expect(parentHandle.getResult()).rejects.toThrow('crash after checkpoint commit');
+    } finally {
+      clearDebugTriggers();
+    }
+
+    // The bounce and its checkpoint both committed before the crash.
+    status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status!.delayUntilEpochMS!).toBeGreaterThan(delayBefore);
+    const delayAfterCrash = status!.delayUntilEpochMS!;
+
+    // Replay short-circuits through the checkpoint: same handle, and no re-executed bounce re-extends the delay.
+    const recoverHandle = await reexecuteWorkflowById(parentID);
+    expect(await recoverHandle!.getResult()).toBe(wHandle.workflowID);
+
+    status = await getSysDB().getWorkflowStatus(wHandle.workflowID);
+    expect(status?.delayUntilEpochMS).toBe(delayAfterCrash);
+
+    await DBOS.cancelWorkflow(wHandle.workflowID);
+  }, 60000);
 });

--- a/tests/debouncer.test.ts
+++ b/tests/debouncer.test.ts
@@ -5,6 +5,7 @@ import { DBOSQueueDuplicatedError } from '../src/error';
 import { INTERNAL_QUEUE_NAME } from '../src/utils';
 import { clearDebugTriggers, DebugAction, DEBUG_TRIGGER_STEP_COMMIT, setDebugTrigger } from '../src/debugpoint';
 import { PortableWorkflowError } from '../schemas/system_db_schema';
+import { DBOSJSON, DBOSPortableJSON, deserializeResError, serializeResError } from '../src/serialization';
 import { generateDBOSTestConfig, reexecuteWorkflowById, setUpDBOSTestSysDb, Event } from './helpers';
 import assert from 'node:assert';
 
@@ -39,6 +40,13 @@ describe('debouncer-tests', () => {
   // The dedup ID a debounce computes for `workflow` and a given key.
   const dedupIDForKey = (key: string) => `.debouncerWorkflow-${key}`;
   const getSysDB = () => DBOSExecutor.globalInstance!.systemDatabase;
+
+  const portableWorkflow = DBOS.registerWorkflow(
+    async (x: number) => {
+      return Promise.resolve(x);
+    },
+    { name: 'debouncerPortableWorkflow', serialization: 'portable' },
+  );
 
   // A workflow that signals when it starts and blocks until released, reset per test.
   let blockStarted: Event;
@@ -549,16 +557,33 @@ describe('debouncer-tests', () => {
     // portable serialization, replay revives the checkpointed error as a PortableWorkflowError
     // carrying only the original type name. The retry loop must still recognize that form and
     // bounce the existing workflow instead of erroring.
+
+    // Round-trip a real dedup error through portable serialization to produce the exact replay form.
+    const sererr = await serializeResError(
+      new DBOSQueueDuplicatedError('racer', 'queue', 'dedup'),
+      DBOSJSON,
+      'portable',
+    );
+    let replayForm: Error | undefined;
+    try {
+      replayForm = await deserializeResError(sererr.serializedValue, sererr.serialization, DBOSJSON);
+    } catch (e) {
+      replayForm = e as Error;
+    }
+    expect(replayForm).toBeInstanceOf(PortableWorkflowError);
+    // The portable format records the error's runtime name; it must be the class name, not 'Error'.
+    expect(replayForm.name).toBe('DBOSQueueDuplicatedError');
+
     const debouncer = new Debouncer({ workflow });
     const sysDB = getSysDB();
     const originalInit = sysDB.initWorkflowStatus.bind(sysDB);
     let dedupInitCalls = 0;
     const spy = jest.spyOn(sysDB, 'initWorkflowStatus').mockImplementation(async (initStatus, ownerXid, options) => {
-      // The first enqueue throws the exact object a replay produces from a checkpointed, portable-serialized dedup error; subsequent enqueues behave normally.
+      // The first enqueue throws the replay-form error; subsequent enqueues behave normally.
       if (initStatus.deduplicationID === dedupIDForKey('portable-key')) {
         dedupInitCalls++;
         if (dedupInitCalls === 1) {
-          throw new PortableWorkflowError('Workflow was deduplicated', DBOSQueueDuplicatedError.name);
+          throw replayForm;
         }
       }
       return originalInit(initStatus, ownerXid, options);
@@ -573,6 +598,46 @@ describe('debouncer-tests', () => {
       spy.mockRestore();
     }
   }, 30000);
+
+  test('test-debouncer-client-portable-serialization', async () => {
+    // A DebouncerClient given serializationType 'portable' must write portable-format inputs on
+    // both the fresh enqueue and the bounce, so a portable-registered workflow stays readable
+    // across languages.
+    const client = await DBOSClient.create({ systemDatabaseUrl: config.systemDatabaseUrl! });
+    try {
+      const debouncer = new DebouncerClient(client, {
+        workflowName: 'debouncerPortableWorkflow',
+        serializationType: 'portable',
+      });
+
+      // The fresh enqueue records portable inputs.
+      const firstHandle = await debouncer.debounce('pkey', 1000000000, 1);
+      let status = await getSysDB().getWorkflowStatus(firstHandle.workflowID);
+      expect(status?.status).toBe(StatusString.DELAYED);
+      expect(status?.serialization).toBe(DBOSPortableJSON.name());
+      expect(JSON.parse(status!.input!)).toEqual({ positionalArgs: [1] });
+
+      // A bounce replaces the inputs without changing the serialization format.
+      const secondHandle = await debouncer.debounce('pkey', 1000, 2);
+      expect(secondHandle.workflowID).toBe(firstHandle.workflowID);
+      status = await getSysDB().getWorkflowStatus(firstHandle.workflowID);
+      expect(status?.serialization).toBe(DBOSPortableJSON.name());
+      expect(JSON.parse(status!.input!)).toEqual({ positionalArgs: [2] });
+      expect(await secondHandle.getResult()).toBe(2);
+
+      // A client bounce of a workflow debounced server-side keeps the registration's portable format.
+      const localDebouncer = new Debouncer({ workflow: portableWorkflow });
+      const thirdHandle = await localDebouncer.debounce('pkey2', 1000000000, 3);
+      const fourthHandle = await debouncer.debounce('pkey2', 1000, 4);
+      expect(fourthHandle.workflowID).toBe(thirdHandle.workflowID);
+      status = await getSysDB().getWorkflowStatus(thirdHandle.workflowID);
+      expect(status?.serialization).toBe(DBOSPortableJSON.name());
+      expect(JSON.parse(status!.input!)).toEqual({ positionalArgs: [4] });
+      expect(await fourthHandle.getResult()).toBe(4);
+    } finally {
+      await client.destroy();
+    }
+  }, 60000);
 
   test('test-debounce-rejects-caller-dedup-and-delay', async () => {
     // A debounce owns the workflow's deduplication ID and delay, and priority/partition keys cannot apply to a debounced enqueue, so a caller that sets any of them must fail loudly rather than have it silently ignored or break later.


### PR DESCRIPTION
Reimplement the debouncer to use `DELAYED` workflows instead of an internal workflow with signaling mechanism. This both simplifies and improves the performance of the debouncer, eliminating the rounds of communication in the previous implementation. Analogous to https://github.com/dbos-inc/dbos-transact-py/pull/752

Migration note: this eliminates `_dbos_debouncer_workflow`. If using debouncers but not using versioning, upon upgrading to the version containing this PR, you should cancel any leftover `_dbos_debouncer_workflow` as they will not be recovered. Actual running workflows will not be affected. This notice will be added to the release notes of the next version.