### PR TITLE
Allow concurrent queue dispatches

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,12 @@ function toArray(endpoint: string | string[] | undefined): Array<string> {
 }
 
 export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean = false): DBOSConfigInternal {
+  if (
+    options.maxConcurrentQueueDispatches !== undefined &&
+    (!Number.isInteger(options.maxConcurrentQueueDispatches) || options.maxConcurrentQueueDispatches <= 0)
+  ) {
+    throw new Error('maxConcurrentQueueDispatches must be a positive integer');
+  }
   const systemDatabaseUrl = getSystemDatabaseUrl({
     system_database_url: options.systemDatabaseUrl,
     name: options.name,
@@ -202,6 +208,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
       otelAttributeFormat: options.otelAttributeFormat ?? 'legacy',
     },
     schedulerPollingIntervalMs: options.schedulerPollingIntervalMs,
+    maxConcurrentQueueDispatches: options.maxConcurrentQueueDispatches,
     useListenNotify: options.useListenNotify ?? true,
   };
 }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -152,6 +152,12 @@ export interface DBOSConfig {
    * up by the supervisor.
    */
   listenQueues?: (WorkflowQueue | string)[];
+  /**
+   * Maximum number of independent queue dispatch cycles that may run concurrently
+   * in this executor. Defaults to 1, preserving serialized queue dispatch.
+   * This does not limit workflow concurrency or system-database polling reads.
+   */
+  maxConcurrentQueueDispatches?: number;
   schedulerPollingIntervalMs?: number;
   useListenNotify?: boolean;
 }
@@ -207,6 +213,7 @@ export type DBOSConfigInternal = {
   telemetry: TelemetryConfig;
 
   schedulerPollingIntervalMs?: number;
+  maxConcurrentQueueDispatches?: number;
   useListenNotify: boolean;
 
   http?: {
@@ -1139,7 +1146,7 @@ export class DBOSExecutor {
   }
 
   async initEventReceivers(listenQueues: (WorkflowQueue | string)[] | null) {
-    this.#wfqEnded = wfQueueRunner.dispatchLoop(this, listenQueues);
+    this.#wfqEnded = wfQueueRunner.dispatchLoop(this, listenQueues, this.config.maxConcurrentQueueDispatches);
 
     for (const lcl of getLifecycleListeners()) {
       await lcl.initialize?.();

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -154,8 +154,13 @@ export interface DBOSConfig {
   listenQueues?: (WorkflowQueue | string)[];
   /**
    * Maximum number of independent queue dispatch cycles that may run concurrently
-   * in this executor. Defaults to 1, preserving serialized queue dispatch.
+   * in this executor. Defaults to 3. Set to 1 to serialize queue dispatch.
    * This does not limit workflow concurrency or system-database polling reads.
+   *
+   * Each concurrent dispatch checks out a system-database connection for the
+   * duration of its dequeue transaction, so values approaching
+   * `systemDatabasePoolSize` (default 10, of which the polling limiter already
+   * reserves half) leave little of the pool for control-plane operations.
    */
   maxConcurrentQueueDispatches?: number;
   schedulerPollingIntervalMs?: number;

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -517,9 +517,8 @@ class WFQueueRunner {
         return;
       }
       await new Promise<void>((resolve) => {
-        let timer: ReturnType<typeof setTimeout> | undefined;
         const finish = () => {
-          if (timer) clearTimeout(timer);
+          clearTimeout(timer);
           signal.removeEventListener('abort', onAbort);
           if (wakeScheduler === finish) wakeScheduler = undefined;
           resolve();
@@ -527,7 +526,7 @@ class WFQueueRunner {
         const onAbort = () => finish();
         wakeScheduler = finish;
         signal.addEventListener('abort', onAbort, { once: true });
-        timer = setTimeout(finish, ms);
+        const timer = setTimeout(finish, ms);
       });
     };
 

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -558,13 +558,16 @@ class WFQueueRunner {
 
       if (!this.isRunning) break;
 
-      // Sleep until global maintenance, an idle queue's next poll, or an in-flight poll frees a lane.
+      // Sleep until global maintenance or an idle queue's next poll.
       let nextWakeAt = Math.min(
         lastReconcileAt + WFQueueRunner.reconcileIntervalMs,
         lastTransitionAt + WFQueueRunner.transitionIntervalMs,
       );
-      for (const state of this.states.values()) {
-        if (!inFlightPolls.has(state.queue.name) && state.nextPollAt < nextWakeAt) nextWakeAt = state.nextPollAt;
+      // Skip queue times while all lanes are busy: a completing poll wakes us, so folding a due-but-unlaned queue in would spin at 0ms.
+      if (inFlightPolls.size < maxConcurrentQueueDispatches) {
+        for (const state of this.states.values()) {
+          if (!inFlightPolls.has(state.queue.name) && state.nextPollAt < nextWakeAt) nextWakeAt = state.nextPollAt;
+        }
       }
       const sleepMs = Math.max(0, nextWakeAt - Date.now());
       await waitForWakeOrTimeout(sleepMs);

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -7,7 +7,7 @@ import {
 } from './debugpoint';
 import type { QueueRecord, SystemDatabase } from './system_database';
 import type { GlobalLogger } from './telemetry/logs';
-import { globalParams, interruptibleSleep, INTERNAL_QUEUE_NAME } from './utils';
+import { globalParams, INTERNAL_QUEUE_NAME } from './utils';
 
 /**
  * Log a single queue's name and its set parameters. Unset parameters are
@@ -357,6 +357,8 @@ class WFQueueRunner {
   private readonly states: Map<string, QueueRuntimeState> = new Map();
   /** Names already warned about colliding with an in-memory queue (warn-once). */
   private readonly conflictWarned: Set<string> = new Set();
+  /** Rotating cursor used to choose the next due queue fairly. */
+  private nextQueueIndex: number = 0;
 
   private static readonly defaultMinPollingIntervalMs: number = 1000;
   private static readonly defaultMaxPollingIntervalMs: number = 120000;
@@ -377,10 +379,15 @@ class WFQueueRunner {
     this.wfQueuesByName.clear();
   }
 
-  async dispatchLoop(exec: DBOSExecutor, listenQueuesArg: (WorkflowQueue | string)[] | null): Promise<void> {
+  async dispatchLoop(
+    exec: DBOSExecutor,
+    listenQueuesArg: (WorkflowQueue | string)[] | null,
+    maxConcurrentQueueDispatches: number = 1,
+  ): Promise<void> {
     this.isRunning = true;
     this.states.clear();
     this.conflictWarned.clear();
+    this.nextQueueIndex = 0;
     this.listenQueueNames = listenQueuesArg
       ? new Set(listenQueuesArg.map((entry) => (typeof entry === 'string' ? entry : entry.name)))
       : null;
@@ -403,8 +410,8 @@ class WFQueueRunner {
     // Log everything we're now dispatching for, before the loop starts.
     this.logRunningQueues(exec);
 
-    // One loop drives every queue, so idle cost is O(1) not O(#queues); returns when stop() aborts.
-    await this.schedulerLoop(exec, startNow);
+    // One loop drives global maintenance; queue polls run in a bounded set of independent lanes.
+    await this.schedulerLoop(exec, startNow, maxConcurrentQueueDispatches);
   }
 
   /** Resolve the listenQueues argument to the set of in-memory queues to dispatch for. */
@@ -485,9 +492,45 @@ class WFQueueRunner {
     }
   }
 
-  /** The single dispatcher loop: reconcile queues, transition delayed workflows once, poll due queues sequentially. */
-  private async schedulerLoop(exec: DBOSExecutor, startNow: number): Promise<void> {
+  /** Reconcile queues and schedule due polls across a bounded number of independent lanes. */
+  private async schedulerLoop(
+    exec: DBOSExecutor,
+    startNow: number,
+    maxConcurrentQueueDispatches: number,
+  ): Promise<void> {
     const signal = this.abortController!.signal;
+    const inFlightPolls = new Map<string, Promise<void>>();
+    let wakePending = false;
+    let wakeScheduler: (() => void) | undefined;
+    const wake = () => {
+      if (wakeScheduler) {
+        wakeScheduler();
+      } else {
+        wakePending = true;
+      }
+    };
+
+    const waitForWakeOrTimeout = async (ms: number): Promise<void> => {
+      if (signal.aborted) return;
+      if (wakePending) {
+        wakePending = false;
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = () => {
+          if (timer) clearTimeout(timer);
+          signal.removeEventListener('abort', onAbort);
+          if (wakeScheduler === finish) wakeScheduler = undefined;
+          resolve();
+        };
+        const onAbort = () => finish();
+        wakeScheduler = finish;
+        signal.addEventListener('abort', onAbort, { once: true });
+        timer = setTimeout(finish, ms);
+      });
+    };
+
     // Discovery already ran during setup; defer the next reconcile a full interval.
     let lastReconcileAt = startNow;
     // Global op: run on a fixed cadence, not once per wake (destaggered wakeups would push it to ~N/sec).
@@ -512,29 +555,65 @@ class WFQueueRunner {
         lastTransitionAt = now;
       }
 
-      // Collect the queues due to poll this tick and dispatch them sequentially.
-      const due: QueueRuntimeState[] = [];
-      for (const state of this.states.values()) {
-        if (now >= state.nextPollAt) due.push(state);
-      }
-      for (const state of due) {
-        if (!this.isRunning) break;
-        const contentionDetected = await this.pollQueue(exec, state.queue);
-        this.adjustInterval(exec, state, contentionDetected);
-      }
+      this.scheduleDueQueues(exec, now, maxConcurrentQueueDispatches, inFlightPolls, wake);
 
       if (!this.isRunning) break;
 
-      // Sleep until the earliest of the next scheduled poll, reconcile, or transition tick.
-      let wake = Math.min(
+      // Sleep until global maintenance, an idle queue's next poll, or an in-flight poll frees a lane.
+      let nextWakeAt = Math.min(
         lastReconcileAt + WFQueueRunner.reconcileIntervalMs,
         lastTransitionAt + WFQueueRunner.transitionIntervalMs,
       );
       for (const state of this.states.values()) {
-        if (state.nextPollAt < wake) wake = state.nextPollAt;
+        if (!inFlightPolls.has(state.queue.name) && state.nextPollAt < nextWakeAt) nextWakeAt = state.nextPollAt;
       }
-      const sleepMs = Math.max(0, wake - Date.now());
-      await interruptibleSleep(sleepMs, signal);
+      const sleepMs = Math.max(0, nextWakeAt - Date.now());
+      await waitForWakeOrTimeout(sleepMs);
+    }
+
+    await Promise.allSettled(Array.from(inFlightPolls.values()));
+  }
+
+  /** Start due queue polls up to the configured lane limit, rotating the first queue between passes. */
+  private scheduleDueQueues(
+    exec: DBOSExecutor,
+    now: number,
+    maxConcurrentQueueDispatches: number,
+    inFlightPolls: Map<string, Promise<void>>,
+    wake: () => void,
+  ): void {
+    const states = Array.from(this.states.values());
+    if (states.length === 0) return;
+
+    const start = this.nextQueueIndex % states.length;
+    for (let offset = 0; offset < states.length && inFlightPolls.size < maxConcurrentQueueDispatches; offset++) {
+      const index = (start + offset) % states.length;
+      const state = states[index];
+      const queueName = state.queue.name;
+      if (inFlightPolls.has(queueName) || now < state.nextPollAt) continue;
+
+      this.nextQueueIndex = (index + 1) % states.length;
+      const poll = this.runQueuePoll(exec, state, inFlightPolls, wake);
+      inFlightPolls.set(queueName, poll);
+    }
+  }
+
+  /** Run one queue's poll while reserving that queue's lane until its backoff state is updated. */
+  private async runQueuePoll(
+    exec: DBOSExecutor,
+    state: QueueRuntimeState,
+    inFlightPolls: Map<string, Promise<void>>,
+    wake: () => void,
+  ): Promise<void> {
+    const queueName = state.queue.name;
+    try {
+      const contentionDetected = await this.pollQueue(exec, state.queue);
+      this.adjustInterval(exec, state, contentionDetected);
+    } catch (e) {
+      exec.logger.warn(`Unexpected error polling queue ${queueName}: ${(e as Error).message}`);
+    } finally {
+      inFlightPolls.delete(queueName);
+      wake();
     }
   }
 

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -380,7 +380,7 @@ class WFQueueRunner {
   async dispatchLoop(
     exec: DBOSExecutor,
     listenQueuesArg: (WorkflowQueue | string)[] | null,
-    maxConcurrentQueueDispatches: number = 1,
+    maxConcurrentQueueDispatches: number = 3,
   ): Promise<void> {
     this.isRunning = true;
     this.states.clear();

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -598,12 +598,15 @@ class WFQueueRunner {
     wake: () => void,
   ): Promise<void> {
     const queueName = state.queue.name;
+    // Treat an unexpected throw as contention: pollQueue normally swallows DB errors, so a rejection here
+    // is abnormal — back off rather than leaving nextPollAt in the past, which would spin this lane at 0ms.
+    let contentionDetected = true;
     try {
-      const contentionDetected = await this.pollQueue(exec, state.queue);
-      this.adjustInterval(exec, state, contentionDetected);
+      contentionDetected = await this.pollQueue(exec, state.queue);
     } catch (e) {
       exec.logger.warn(`Unexpected error polling queue ${queueName}: ${(e as Error).message}`);
     } finally {
+      this.adjustInterval(exec, state, contentionDetected);
       inFlightPolls.delete(queueName);
       wake();
     }

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -581,6 +581,7 @@ class WFQueueRunner {
     inFlightPolls: Map<string, Promise<void>>,
     wake: () => void,
   ): void {
+    if (!this.isRunning) return;
     const due = Array.from(this.states.values()).filter(
       (state) => now >= state.nextPollAt && !inFlightPolls.has(state.queue.name),
     );

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -601,8 +601,7 @@ class WFQueueRunner {
     wake: () => void,
   ): Promise<void> {
     const queueName = state.queue.name;
-    // Treat an unexpected throw as contention: pollQueue normally swallows DB errors, so a rejection here
-    // is abnormal — back off rather than leaving nextPollAt in the past, which would spin this lane at 0ms.
+    // pollQueue swallows DB errors, so a rejection here is abnormal: back off instead of scaling back toward the minimum interval.
     let contentionDetected = true;
     try {
       contentionDetected = await this.pollQueue(exec, state.queue);

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -573,7 +573,7 @@ class WFQueueRunner {
     await Promise.allSettled(Array.from(inFlightPolls.values()));
   }
 
-  /** Start due queue polls up to the lane limit, picking at random so no queue is systematically favored. */
+  /** Start due queue polls up to the lane limit, in nextPollAt order so the longest-overdue queue goes first. */
   private scheduleDueQueues(
     exec: DBOSExecutor,
     now: number,
@@ -582,11 +582,13 @@ class WFQueueRunner {
     wake: () => void,
   ): void {
     if (!this.isRunning) return;
-    const due = Array.from(this.states.values()).filter(
-      (state) => now >= state.nextPollAt && !inFlightPolls.has(state.queue.name),
-    );
-    while (due.length > 0 && inFlightPolls.size < maxConcurrentQueueDispatches) {
-      const [state] = due.splice(Math.floor(Math.random() * due.length), 1);
+    // Earliest nextPollAt first: a queue passed over while the lanes were full keeps its older
+    // nextPollAt, so it outranks freshly-scheduled queues on the next pass and cannot be starved.
+    const due = Array.from(this.states.values())
+      .filter((state) => now >= state.nextPollAt && !inFlightPolls.has(state.queue.name))
+      .sort((a, b) => a.nextPollAt - b.nextPollAt);
+    for (const state of due) {
+      if (inFlightPolls.size >= maxConcurrentQueueDispatches) break;
       inFlightPolls.set(state.queue.name, this.runQueuePoll(exec, state, inFlightPolls, wake));
     }
   }

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -357,8 +357,6 @@ class WFQueueRunner {
   private readonly states: Map<string, QueueRuntimeState> = new Map();
   /** Names already warned about colliding with an in-memory queue (warn-once). */
   private readonly conflictWarned: Set<string> = new Set();
-  /** Rotating cursor used to choose the next due queue fairly. */
-  private nextQueueIndex: number = 0;
 
   private static readonly defaultMinPollingIntervalMs: number = 1000;
   private static readonly defaultMaxPollingIntervalMs: number = 120000;
@@ -387,7 +385,6 @@ class WFQueueRunner {
     this.isRunning = true;
     this.states.clear();
     this.conflictWarned.clear();
-    this.nextQueueIndex = 0;
     this.listenQueueNames = listenQueuesArg
       ? new Set(listenQueuesArg.map((entry) => (typeof entry === 'string' ? entry : entry.name)))
       : null;
@@ -576,7 +573,7 @@ class WFQueueRunner {
     await Promise.allSettled(Array.from(inFlightPolls.values()));
   }
 
-  /** Start due queue polls up to the configured lane limit, rotating the first queue between passes. */
+  /** Start due queue polls up to the lane limit, picking at random so no queue is systematically favored. */
   private scheduleDueQueues(
     exec: DBOSExecutor,
     now: number,
@@ -584,19 +581,12 @@ class WFQueueRunner {
     inFlightPolls: Map<string, Promise<void>>,
     wake: () => void,
   ): void {
-    const states = Array.from(this.states.values());
-    if (states.length === 0) return;
-
-    const start = this.nextQueueIndex % states.length;
-    for (let offset = 0; offset < states.length && inFlightPolls.size < maxConcurrentQueueDispatches; offset++) {
-      const index = (start + offset) % states.length;
-      const state = states[index];
-      const queueName = state.queue.name;
-      if (inFlightPolls.has(queueName) || now < state.nextPollAt) continue;
-
-      this.nextQueueIndex = (index + 1) % states.length;
-      const poll = this.runQueuePoll(exec, state, inFlightPolls, wake);
-      inFlightPolls.set(queueName, poll);
+    const due = Array.from(this.states.values()).filter(
+      (state) => now >= state.nextPollAt && !inFlightPolls.has(state.queue.name),
+    );
+    while (due.length > 0 && inFlightPolls.size < maxConcurrentQueueDispatches) {
+      const [state] = due.splice(Math.floor(Math.random() * due.length), 1);
+      inFlightPolls.set(state.queue.name, this.runQueuePoll(exec, state, inFlightPolls, wake));
     }
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -426,7 +426,7 @@ describe('dbos-config', () => {
         maxConcurrentQueueDispatches: 4,
       });
       expect(internalConfig.maxConcurrentQueueDispatches).toBe(4);
-      // Unset is allowed (dispatcher defaults it to 1).
+      // Unset is allowed (dispatcher defaults it to 3).
       expect(translateDbosConfig({ name: 'dbostest' }).maxConcurrentQueueDispatches).toBeUndefined();
       // Every non-positive-integer value is rejected.
       for (const bad of [0, -1, 2.5, NaN, Infinity]) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -426,9 +426,14 @@ describe('dbos-config', () => {
         maxConcurrentQueueDispatches: 4,
       });
       expect(internalConfig.maxConcurrentQueueDispatches).toBe(4);
-      expect(() => translateDbosConfig({ name: 'dbostest', maxConcurrentQueueDispatches: 0 })).toThrow(
-        'maxConcurrentQueueDispatches must be a positive integer',
-      );
+      // Unset is allowed (dispatcher defaults it to 1).
+      expect(translateDbosConfig({ name: 'dbostest' }).maxConcurrentQueueDispatches).toBeUndefined();
+      // Every non-positive-integer value is rejected.
+      for (const bad of [0, -1, 2.5, NaN, Infinity]) {
+        expect(() => translateDbosConfig({ name: 'dbostest', maxConcurrentQueueDispatches: bad })).toThrow(
+          'maxConcurrentQueueDispatches must be a positive integer',
+        );
+      }
     });
 
     test('translate passes through a custom logger', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -420,6 +420,17 @@ describe('dbos-config', () => {
       expect(internalConfig.systemDatabasePollingConcurrency).toBeUndefined();
     });
 
+    test('translate validates maxConcurrentQueueDispatches', () => {
+      const internalConfig = translateDbosConfig({
+        name: 'dbostest',
+        maxConcurrentQueueDispatches: 4,
+      });
+      expect(internalConfig.maxConcurrentQueueDispatches).toBe(4);
+      expect(() => translateDbosConfig({ name: 'dbostest', maxConcurrentQueueDispatches: 0 })).toThrow(
+        'maxConcurrentQueueDispatches must be a positive integer',
+      );
+    });
+
     test('translate passes through a custom logger', () => {
       const myLogger = { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
       let internalConfig = translateDbosConfig({ name: 'dbostest', logger: myLogger });

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -3006,6 +3006,10 @@ describe('bounded-lane dispatcher', () => {
 
     // If the throw leaked the lane, dispatch would stop dead after the first poll.
     expect(polls).toBeGreaterThan(1);
+    // A throw must count as contention, so the lane backs off (2,4,8..256ms => ~9 polls here)
+    // instead of spinning at the 1ms floor (~350+). Without the backoff both spins and
+    // backoffs satisfy the assertion above.
+    expect(polls).toBeLessThan(30);
   }, 15000);
 
   test('does not start new polls after stop()', async () => {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2935,6 +2935,33 @@ describe('bounded-lane dispatcher', () => {
     expect(overlapped).toBe(false);
   }, 15000);
 
+  test('serves every queue when more are due than there are lanes', async () => {
+    // Every queue here is perpetually due (1ms interval, 20ms poll), so the due set never
+    // shrinks and the pick order alone decides who runs. Taking the due set in registration
+    // order would re-poll the first two forever and starve the rest; earliest-nextPollAt-first
+    // round-robins, because a queue that just polled carries the newest nextPollAt.
+    const polls = new Map<string, number>();
+
+    const queues = makeQueues(6);
+    const exec = mockExecutor({
+      onPoll: async (name) => {
+        polls.set(name, (polls.get(name) ?? 0) + 1);
+        await sleepms(20);
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 2);
+    await sleepms(800);
+    wfQueueRunner.stop();
+    await loop;
+
+    const counts = queues.map((q) => polls.get(q.name) ?? 0);
+    expect(Math.min(...counts)).toBeGreaterThan(0);
+    // Service is even, not merely non-zero: round-robin leaves at most a poll or two between
+    // the busiest and quietest queue, whereas a biased pick would skew hard.
+    expect(Math.max(...counts) - Math.min(...counts)).toBeLessThanOrEqual(2);
+  }, 15000);
+
   test('frees a lane as soon as a poll completes, without waiting for the reconcile tick', async () => {
     // One queue, one lane: every poll after the first requires the completing poll to
     // wake the scheduler. If the wake handshake is broken the loop instead sleeps until

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2774,14 +2774,19 @@ describe('concurrent-queue-dispatches', () => {
       expect(slowPollPaused).toBe(true);
 
       const fast = await DBOS.startWorkflow(ConcurrentDispatchWFs, { queueName: fastQueueName }).run('fast');
-      await expect(
-        Promise.race([
-          fast.getResult(),
-          sleepms(3000).then(() => {
-            throw new Error('fast queue did not dispatch while the slow queue poll was in flight');
-          }),
-        ]),
-      ).resolves.toBe('fast');
+      // Cancellable timeout so the timer is cleared once the race settles, leaving no dangling handle.
+      let dispatchTimer: ReturnType<typeof setTimeout> | undefined;
+      const dispatchTimeout = new Promise<never>((_resolve, reject) => {
+        dispatchTimer = setTimeout(
+          () => reject(new Error('fast queue did not dispatch while the slow queue poll was in flight')),
+          3000,
+        );
+      });
+      try {
+        await expect(Promise.race([fast.getResult(), dispatchTimeout])).resolves.toBe('fast');
+      } finally {
+        clearTimeout(dispatchTimer);
+      }
 
       releaseSlowPoll.set();
       await expect(slow.getResult()).resolves.toBe('slow');

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2741,7 +2741,11 @@ describe('concurrent-queue-dispatches', () => {
 
   // Register a partitioned "slow" queue plus a normal "fast" queue, enqueue one slow workflow, and
   // pause its poll mid-partition-dispatch so it holds the slow queue's dispatch lane. Returns the
-  // paused slow handle and a release function that lets the slow poll finish.
+  // slow handle and a release function that lets the slow *poll* finish.
+  //
+  // Note the pause point is after the partition's workflows are dispatched, so the slow workflow has
+  // already run by the time the poll parks: only the lane is held, and `slow.getResult()` resolves
+  // whether or not the release happens. Assert on the fast queue to observe lane behavior.
   async function pauseSlowPoll(): Promise<{ slow: WorkflowHandle<string>; releaseSlowPoll: Event }> {
     await DBOS.registerQueue(slowQueueName, {
       partitionQueue: true,
@@ -2822,7 +2826,9 @@ describe('concurrent-queue-dispatches', () => {
         clearTimeout(probeTimer);
       }
 
-      // Releasing the slow poll frees the lane; both queues then dispatch to completion.
+      // Releasing the slow poll frees the single lane, which is what finally lets the fast queue be
+      // polled — so `fastResult` is the assertion that proves the lane was the blocker. (`slow` had
+      // already completed before its poll parked; see pauseSlowPoll.)
       releaseSlowPoll.set();
       await expect(slow.getResult()).resolves.toBe('slow');
       await expect(fastResult).resolves.toBe('fast');
@@ -2832,4 +2838,214 @@ describe('concurrent-queue-dispatches', () => {
       await DBOS.deleteQueue(fastQueueName);
     }
   }, 10000);
+});
+
+/**
+ * Scheduler-level invariants of the bounded-lane dispatcher, driven against a mock executor:
+ * the lane ceiling, lane release, wake latency, and the shutdown drain. These are properties of
+ * the dispatch loop itself, and the states that expose them (a poll throwing, `stop()` landing
+ * mid-maintenance, N queues contending for fewer lanes) are hard to stage against a real system
+ * database without long sleeps. The `concurrent-queue-dispatches` block above covers the
+ * end-to-end path. Keep this block last: its queues stay in the runner's registry, and an earlier
+ * position would expose them to a later `DBOS.launch()` that listens to every in-memory queue.
+ */
+describe('bounded-lane dispatcher', () => {
+  interface MockHooks {
+    /** Runs inside findAndMarkStartableWorkflows, i.e. while the queue's lane is held. */
+    onPoll?: (queueName: string) => Promise<void>;
+    /** Runs inside transitionDelayedWorkflows, i.e. while the scheduler loop is mid-body. */
+    onTransition?: () => Promise<void>;
+  }
+
+  function mockExecutor(hooks: MockHooks): DBOSExecutor {
+    return {
+      executorID: 'lane-test',
+      logger: { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} },
+      executeWorkflowId: () => Promise.resolve({}),
+      systemDatabase: {
+        listQueues: () => Promise.resolve([]),
+        getQueuePartitions: () => Promise.resolve([]),
+        transitionDelayedWorkflows: async () => {
+          await hooks.onTransition?.();
+        },
+        findAndMarkStartableWorkflows: async (queue: WorkflowQueue) => {
+          await hooks.onPoll?.(queue.name);
+          return [];
+        },
+      },
+    } as unknown as DBOSExecutor;
+  }
+
+  let seq = 0;
+  /** Register N continuously-due in-memory queues under names unique to this test. */
+  function makeQueues(count: number): WorkflowQueue[] {
+    const tag = `lane-${seq++}`;
+    return Array.from({ length: count }, (_, i) => new WorkflowQueue(`${tag}-q${i}`, { minPollingIntervalMs: 1 }));
+  }
+
+  afterEach(() => {
+    wfQueueRunner.stop();
+  });
+
+  test('never runs more concurrent polls than maxConcurrentQueueDispatches', async () => {
+    const LIMIT = 2;
+    let inFlight = 0;
+    let peak = 0;
+
+    const queues = makeQueues(5);
+    const exec = mockExecutor({
+      onPoll: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await sleepms(30);
+        inFlight--;
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, LIMIT);
+    await sleepms(800);
+    wfQueueRunner.stop();
+    await loop;
+
+    // > 1 proves lanes are actually concurrent; <= LIMIT proves they are bounded.
+    // Without the ceiling, all 5 due queues would poll at once.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(LIMIT);
+  }, 15000);
+
+  test('never polls the same queue in two lanes at once', async () => {
+    const polling = new Set<string>();
+    let overlapped = false;
+
+    const queues = makeQueues(3);
+    const exec = mockExecutor({
+      onPoll: async (name) => {
+        if (polling.has(name)) overlapped = true;
+        polling.add(name);
+        await sleepms(20);
+        polling.delete(name);
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 3);
+    await sleepms(500);
+    wfQueueRunner.stop();
+    await loop;
+
+    expect(overlapped).toBe(false);
+  }, 15000);
+
+  test('frees a lane as soon as a poll completes, without waiting for the reconcile tick', async () => {
+    // One queue, one lane: every poll after the first requires the completing poll to
+    // wake the scheduler. If the wake handshake is broken the loop instead sleeps until
+    // the next 1s maintenance tick, so throughput collapses to ~1/sec.
+    let polls = 0;
+
+    const queues = makeQueues(1);
+    const exec = mockExecutor({
+      onPoll: async () => {
+        polls++;
+        await sleepms(20);
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 1);
+    await sleepms(800);
+    wfQueueRunner.stop();
+    await loop;
+
+    // ~40 polls when wake works; ~1 if it does not. 8 is far outside both distributions.
+    expect(polls).toBeGreaterThan(8);
+  }, 15000);
+
+  test('releases the lane when a poll throws, and keeps dispatching', async () => {
+    // A non-object rejection makes pollQueue's own `'code' in err` check throw a
+    // TypeError, which escapes it and reaches runQueuePoll's catch.
+    let polls = 0;
+
+    const queues = makeQueues(1);
+    const exec = mockExecutor({
+      onPoll: () => {
+        polls++;
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+        return Promise.reject('not an Error');
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 1);
+    await sleepms(600);
+    wfQueueRunner.stop();
+    await loop;
+
+    // If the throw leaked the lane, dispatch would stop dead after the first poll.
+    expect(polls).toBeGreaterThan(1);
+  }, 15000);
+
+  test('does not start new polls after stop()', async () => {
+    // stop() lands while the loop is awaiting a global maintenance op, so it resumes
+    // mid-body with isRunning already false.
+    let stopped = false;
+    let transitions = 0;
+    let pollsAfterStop = 0;
+    let releaseTransition: (() => void) | undefined;
+
+    const queues = makeQueues(1);
+    const exec = mockExecutor({
+      onTransition: async () => {
+        transitions++;
+        if (transitions < 2) return; // let the loop reach steady state first
+        await new Promise<void>((resolve) => {
+          releaseTransition = resolve;
+        });
+      },
+      onPoll: () => {
+        if (stopped) pollsAfterStop++;
+        return Promise.resolve();
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 2);
+
+    const deadline = Date.now() + 5000;
+    while (!releaseTransition && Date.now() < deadline) {
+      await sleepms(10);
+    }
+    expect(releaseTransition).toBeDefined();
+
+    stopped = true;
+    wfQueueRunner.stop();
+    releaseTransition!();
+    await loop;
+
+    expect(pollsAfterStop).toBe(0);
+  }, 15000);
+
+  test('waits for in-flight polls to finish before dispatchLoop resolves', async () => {
+    const order: string[] = [];
+    let pollStarted = false;
+
+    const queues = makeQueues(1);
+    const exec = mockExecutor({
+      onPoll: async () => {
+        pollStarted = true;
+        await sleepms(200);
+        order.push('poll-finished');
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 1);
+
+    const deadline = Date.now() + 5000;
+    while (!pollStarted && Date.now() < deadline) {
+      await sleepms(5);
+    }
+    expect(pollStarted).toBe(true);
+
+    // stop() while the poll is still in flight; the drain must not abandon it.
+    wfQueueRunner.stop();
+    await loop;
+    order.push('loop-resolved');
+
+    expect(order).toEqual(['poll-finished', 'loop-resolved']);
+  }, 15000);
 });

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2808,14 +2808,14 @@ describe('concurrent-queue-dispatches', () => {
     }
   }, 10000);
 
-  test('a slow partitioned poll blocks another queue dispatch at the default (serialized) concurrency', async () => {
+  test('a slow partitioned poll blocks another queue dispatch at serialized (1) concurrency', async () => {
     await launchWith(1);
     const { slow, releaseSlowPoll } = await pauseSlowPoll();
     try {
       const fast = await DBOS.startWorkflow(ConcurrentDispatchWFs, { queueName: fastQueueName }).run('fast');
       const fastResult = fast.getResult();
       // The single dispatch lane is held by the paused slow poll, so the fast queue cannot be polled:
-      // the timeout must win the race, proving dispatch is serialized at the default concurrency of 1.
+      // the timeout must win the race, proving dispatch is serialized at a concurrency of 1.
       let probeTimer: ReturnType<typeof setTimeout> | undefined;
       const probe = new Promise<'blocked'>((resolve) => {
         probeTimer = setTimeout(() => resolve('blocked'), 2000);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2848,8 +2848,7 @@ describe('concurrent-queue-dispatches', () => {
  * the dispatch loop itself, and the states that expose them (a poll throwing, `stop()` landing
  * mid-maintenance, N queues contending for fewer lanes) are hard to stage against a real system
  * database without long sleeps. The `concurrent-queue-dispatches` block above covers the
- * end-to-end path. `afterEach` unregisters each test's queues, so a later `DBOS.launch()` that
- * listens to every in-memory queue will not pick them up.
+ * end-to-end path. `afterEach` unregisters each test's queues so a later `DBOS.launch()` skips them.
  */
 describe('bounded-lane dispatcher', () => {
   interface MockHooks {
@@ -2871,8 +2870,7 @@ describe('bounded-lane dispatcher', () => {
           await hooks.onTransition?.();
         },
         findAndMarkStartableWorkflows: async (queue: WorkflowQueue) => {
-          // The runner always dispatches the internal queue, which an earlier DBOS.launch() in this
-          // file registered globally; skip it so counters and windows do not depend on its interval.
+          // An earlier DBOS.launch() registered the internal queue globally; skip it to keep counters clean.
           if (queue.name === INTERNAL_QUEUE_NAME) return [];
           await hooks.onPoll?.(queue.name);
           return [];
@@ -2898,8 +2896,7 @@ describe('bounded-lane dispatcher', () => {
     wfQueueRunner.stop();
     // Restores any global patched via jest.spyOn below; runs even when a test times out.
     jest.restoreAllMocks();
-    // The WorkflowQueue constructor registers into a process-global map, so unregister: a later
-    // DBOS.launch() with no listenQueues would dispatch these against the real system database.
+    // The constructor registers globally, so unregister: a later DBOS.launch() would dispatch these.
     for (const q of registered) wfQueueRunner.wfQueuesByName.delete(q.name);
     registered.length = 0;
   });
@@ -2931,8 +2928,7 @@ describe('bounded-lane dispatcher', () => {
   }, 15000);
 
   test('defaults to three lanes when no limit is configured', async () => {
-    // The default is what every user who does not set maxConcurrentQueueDispatches gets, and it is
-    // the one value no other test here exercises: they all pass an explicit limit.
+    // The value users get when they set nothing, and the one limit no other test here exercises.
     let inFlight = 0;
     let peak = 0;
 
@@ -2956,9 +2952,7 @@ describe('bounded-lane dispatcher', () => {
   }, 15000);
 
   test('does not spin when more queues are due than there are lanes', async () => {
-    // Lanes stay saturated here, so the scheduler must park on the maintenance cadence and let a
-    // completing poll wake it. Folding a due-but-unlaned queue's (past) nextPollAt into the wake
-    // time instead leaves every sleep non-positive, which is the busy spin.
+    // Lanes stay saturated, so the scheduler must park on the maintenance cadence rather than spin.
     let polls = 0;
     let shortParks = 0;
     const queues = makeQueues(5);
@@ -2969,9 +2963,7 @@ describe('bounded-lane dispatcher', () => {
       },
     });
 
-    // Count every near-instant park, not just delay === 0: dropping the `Math.max(0, ...)` clamp
-    // spins on negative delays, which Node floors to 1ms. Healthy parks are the ~1s maintenance
-    // cadence, and the mock's own sleeps are 30ms, so neither is counted.
+    // Count every near-instant park, not just 0: without the `Math.max(0, ...)` clamp a spin goes negative.
     const realSetTimeout = global.setTimeout;
     jest.spyOn(global, 'setTimeout').mockImplementation(((
       fn: (...a: unknown[]) => void,
@@ -3066,8 +3058,7 @@ describe('bounded-lane dispatcher', () => {
   }, 15000);
 
   test('releases the lane when a poll throws, and keeps dispatching', async () => {
-    // Escapes pollQueue's own catch — the `'code' in err` guard passes, then reading `.code` throws —
-    // and reaches runQueuePoll's catch however that guard is written.
+    // The `'code' in err` guard passes, then reading `.code` throws, escaping pollQueue's catch however it is written.
     class UnreadableCodeError extends Error {
       get code(): string {
         throw new TypeError('unreadable error code');
@@ -3104,9 +3095,7 @@ describe('bounded-lane dispatcher', () => {
     let pollsAfterStop = 0;
     let releaseTransition: (() => void) | undefined;
 
-    // Five queues against two lanes: three are always un-laned with a nextPollAt well in the past,
-    // so the queue set is unambiguously due at the stale `now` scheduleDueQueues is handed. With a
-    // single queue, dueness lands on a millisecond boundary and the regression escapes ~1 run in 3.
+    // Five queues, two lanes: three stay un-laned and overdue, so the stale `now` cannot make dueness a coin flip.
     const queues = makeQueues(5);
     const exec = mockExecutor({
       onTransition: async () => {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers';
 import { WorkflowQueue } from '../src';
 import { randomUUID } from 'node:crypto';
-import { globalParams, sleepms } from '../src/utils';
+import { globalParams, sleepms, INTERNAL_QUEUE_NAME } from '../src/utils';
 
 import { WF } from './wfqtestprocess';
 
@@ -2806,7 +2806,8 @@ describe('concurrent-queue-dispatches', () => {
       await DBOS.deleteQueue(slowQueueName);
       await DBOS.deleteQueue(fastQueueName);
     }
-  }, 10000);
+    // Launch plus the 1s discovery tick already cost seconds before the 3s race below starts.
+  }, 30000);
 
   test('a slow partitioned poll blocks another queue dispatch at serialized (1) concurrency', async () => {
     await launchWith(1);
@@ -2837,7 +2838,8 @@ describe('concurrent-queue-dispatches', () => {
       await DBOS.deleteQueue(slowQueueName);
       await DBOS.deleteQueue(fastQueueName);
     }
-  }, 10000);
+    // Launch plus the 1s discovery tick already cost seconds before the fixed 2s probe starts.
+  }, 30000);
 });
 
 /**
@@ -2869,6 +2871,9 @@ describe('bounded-lane dispatcher', () => {
           await hooks.onTransition?.();
         },
         findAndMarkStartableWorkflows: async (queue: WorkflowQueue) => {
+          // The runner always dispatches the internal queue, which an earlier DBOS.launch() in this
+          // file registered globally; skip it so counters and windows do not depend on its interval.
+          if (queue.name === INTERNAL_QUEUE_NAME) return [];
           await hooks.onPoll?.(queue.name);
           return [];
         },
@@ -2911,6 +2916,37 @@ describe('bounded-lane dispatcher', () => {
     // Without the ceiling, all 5 due queues would poll at once.
     expect(peak).toBeGreaterThan(1);
     expect(peak).toBeLessThanOrEqual(LIMIT);
+  }, 15000);
+
+  test('does not spin when more queues are due than there are lanes', async () => {
+    // Lanes stay saturated here, so the scheduler must park on the maintenance cadence and let a
+    // completing poll wake it. Folding a due-but-unlaned queue's (past) nextPollAt into the wake
+    // time instead makes every sleep zero-length, which is the busy spin: count those parks.
+    let zeroLengthParks = 0;
+    const realSetTimeout = global.setTimeout;
+    global.setTimeout = ((fn: (...a: unknown[]) => void, delay?: number, ...rest: unknown[]) => {
+      if (delay === 0) zeroLengthParks++;
+      return realSetTimeout(fn, delay, ...rest);
+    }) as unknown as typeof global.setTimeout;
+
+    const queues = makeQueues(5);
+    const exec = mockExecutor({
+      onPoll: async () => {
+        await sleepms(30);
+      },
+    });
+
+    try {
+      const loop = wfQueueRunner.dispatchLoop(exec, queues, 2);
+      await sleepms(800);
+      wfQueueRunner.stop();
+      await loop;
+    } finally {
+      global.setTimeout = realSetTimeout;
+    }
+
+    // ~0 while the lanes-busy guard holds; ~800 without it, since setTimeout(fn, 0) clamps to 1ms.
+    expect(zeroLengthParks).toBeLessThan(20);
   }, 15000);
 
   test('never polls the same queue in two lanes at once', async () => {
@@ -2986,16 +3022,20 @@ describe('bounded-lane dispatcher', () => {
   }, 15000);
 
   test('releases the lane when a poll throws, and keeps dispatching', async () => {
-    // A non-object rejection makes pollQueue's own `'code' in err` check throw a
-    // TypeError, which escapes it and reaches runQueuePoll's catch.
+    // Escapes pollQueue's own catch — the `'code' in err` guard passes, then reading `.code` throws —
+    // and reaches runQueuePoll's catch however that guard is written.
+    class UnreadableCodeError extends Error {
+      get code(): string {
+        throw new TypeError('unreadable error code');
+      }
+    }
     let polls = 0;
 
     const queues = makeQueues(1);
     const exec = mockExecutor({
       onPoll: () => {
         polls++;
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        return Promise.reject('not an Error');
+        return Promise.reject(new UnreadableCodeError('poll failed'));
       },
     });
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2725,54 +2725,61 @@ describe('concurrent-queue-dispatches', () => {
     await setUpDBOSTestSysDb(config);
   });
 
-  beforeEach(async () => {
-    DBOS.setConfig({
-      ...config,
-      maxConcurrentQueueDispatches: 2,
-      listenQueues: [slowQueueName, fastQueueName],
-    });
-    await DBOS.launch();
-  });
-
   afterEach(async () => {
     clearDebugTriggers();
     await DBOS.shutdown();
   });
 
-  test('a slow partitioned poll does not block another queue dispatch', async () => {
-    const partitionKey = `partition_${randomUUID()}`;
+  async function launchWith(maxConcurrentQueueDispatches: number): Promise<void> {
+    DBOS.setConfig({
+      ...config,
+      maxConcurrentQueueDispatches,
+      listenQueues: [slowQueueName, fastQueueName],
+    });
+    await DBOS.launch();
+  }
+
+  // Register a partitioned "slow" queue plus a normal "fast" queue, enqueue one slow workflow, and
+  // pause its poll mid-partition-dispatch so it holds the slow queue's dispatch lane. Returns the
+  // paused slow handle and a release function that lets the slow poll finish.
+  async function pauseSlowPoll(): Promise<{ slow: WorkflowHandle<string>; releaseSlowPoll: Event }> {
+    await DBOS.registerQueue(slowQueueName, {
+      partitionQueue: true,
+      minPollingIntervalMs: 50,
+      onConflict: 'always_update',
+    });
+    await DBOS.registerQueue(fastQueueName, {
+      minPollingIntervalMs: 50,
+      onConflict: 'always_update',
+    });
+
     const releaseSlowPoll = new Event();
     let slowPollPaused = false;
+    setDebugTrigger(DEBUG_TRIGGER_BETWEEN_PARTITION_DISPATCHES, {
+      asyncCallback: async () => {
+        slowPollPaused = true;
+        await releaseSlowPoll.wait();
+      },
+    });
 
+    const slow = await DBOS.startWorkflow(ConcurrentDispatchWFs, {
+      queueName: slowQueueName,
+      enqueueOptions: { queuePartitionKey: `partition_${randomUUID()}` },
+    }).run('slow');
+
+    const pauseDeadline = Date.now() + 5000;
+    while (!slowPollPaused && Date.now() < pauseDeadline) {
+      await sleepms(25);
+    }
+    expect(slowPollPaused).toBe(true);
+
+    return { slow, releaseSlowPoll };
+  }
+
+  test('a slow partitioned poll does not block another queue dispatch when a lane is free', async () => {
+    await launchWith(2);
+    const { slow, releaseSlowPoll } = await pauseSlowPoll();
     try {
-      await DBOS.registerQueue(slowQueueName, {
-        partitionQueue: true,
-        minPollingIntervalMs: 50,
-        onConflict: 'always_update',
-      });
-      await DBOS.registerQueue(fastQueueName, {
-        minPollingIntervalMs: 50,
-        onConflict: 'always_update',
-      });
-
-      setDebugTrigger(DEBUG_TRIGGER_BETWEEN_PARTITION_DISPATCHES, {
-        asyncCallback: async () => {
-          slowPollPaused = true;
-          await releaseSlowPoll.wait();
-        },
-      });
-
-      const slow = await DBOS.startWorkflow(ConcurrentDispatchWFs, {
-        queueName: slowQueueName,
-        enqueueOptions: { queuePartitionKey: partitionKey },
-      }).run('slow');
-
-      const pauseDeadline = Date.now() + 5000;
-      while (!slowPollPaused && Date.now() < pauseDeadline) {
-        await sleepms(25);
-      }
-      expect(slowPollPaused).toBe(true);
-
       const fast = await DBOS.startWorkflow(ConcurrentDispatchWFs, { queueName: fastQueueName }).run('fast');
       // Cancellable timeout so the timer is cleared once the race settles, leaving no dangling handle.
       let dispatchTimer: ReturnType<typeof setTimeout> | undefined;
@@ -2790,6 +2797,35 @@ describe('concurrent-queue-dispatches', () => {
 
       releaseSlowPoll.set();
       await expect(slow.getResult()).resolves.toBe('slow');
+    } finally {
+      releaseSlowPoll.set();
+      await DBOS.deleteQueue(slowQueueName);
+      await DBOS.deleteQueue(fastQueueName);
+    }
+  }, 10000);
+
+  test('a slow partitioned poll blocks another queue dispatch at the default (serialized) concurrency', async () => {
+    await launchWith(1);
+    const { slow, releaseSlowPoll } = await pauseSlowPoll();
+    try {
+      const fast = await DBOS.startWorkflow(ConcurrentDispatchWFs, { queueName: fastQueueName }).run('fast');
+      const fastResult = fast.getResult();
+      // The single dispatch lane is held by the paused slow poll, so the fast queue cannot be polled:
+      // the timeout must win the race, proving dispatch is serialized at the default concurrency of 1.
+      let probeTimer: ReturnType<typeof setTimeout> | undefined;
+      const probe = new Promise<'blocked'>((resolve) => {
+        probeTimer = setTimeout(() => resolve('blocked'), 2000);
+      });
+      try {
+        await expect(Promise.race([fastResult.then(() => 'dispatched' as const), probe])).resolves.toBe('blocked');
+      } finally {
+        clearTimeout(probeTimer);
+      }
+
+      // Releasing the slow poll frees the lane; both queues then dispatch to completion.
+      releaseSlowPoll.set();
+      await expect(slow.getResult()).resolves.toBe('slow');
+      await expect(fastResult).resolves.toBe('fast');
     } finally {
       releaseSlowPoll.set();
       await DBOS.deleteQueue(slowQueueName);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2711,8 +2711,8 @@ describe('partitioned-queue-orphan-pending', () => {
 describe('concurrent-queue-dispatches', () => {
   class ConcurrentDispatchWFs {
     @DBOS.workflow()
-    static async run(value: string): Promise<string> {
-      return value;
+    static run(value: string): Promise<string> {
+      return Promise.resolve(value);
     }
   }
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2848,8 +2848,8 @@ describe('concurrent-queue-dispatches', () => {
  * the dispatch loop itself, and the states that expose them (a poll throwing, `stop()` landing
  * mid-maintenance, N queues contending for fewer lanes) are hard to stage against a real system
  * database without long sleeps. The `concurrent-queue-dispatches` block above covers the
- * end-to-end path. Keep this block last: its queues stay in the runner's registry, and an earlier
- * position would expose them to a later `DBOS.launch()` that listens to every in-memory queue.
+ * end-to-end path. `afterEach` unregisters each test's queues, so a later `DBOS.launch()` that
+ * listens to every in-memory queue will not pick them up.
  */
 describe('bounded-lane dispatcher', () => {
   interface MockHooks {
@@ -2882,14 +2882,26 @@ describe('bounded-lane dispatcher', () => {
   }
 
   let seq = 0;
+  const registered: WorkflowQueue[] = [];
   /** Register N continuously-due in-memory queues under names unique to this test. */
   function makeQueues(count: number): WorkflowQueue[] {
     const tag = `lane-${seq++}`;
-    return Array.from({ length: count }, (_, i) => new WorkflowQueue(`${tag}-q${i}`, { minPollingIntervalMs: 1 }));
+    const queues = Array.from(
+      { length: count },
+      (_, i) => new WorkflowQueue(`${tag}-q${i}`, { minPollingIntervalMs: 1 }),
+    );
+    registered.push(...queues);
+    return queues;
   }
 
   afterEach(() => {
     wfQueueRunner.stop();
+    // Restores any global patched via jest.spyOn below; runs even when a test times out.
+    jest.restoreAllMocks();
+    // The WorkflowQueue constructor registers into a process-global map, so unregister: a later
+    // DBOS.launch() with no listenQueues would dispatch these against the real system database.
+    for (const q of registered) wfQueueRunner.wfQueuesByName.delete(q.name);
+    registered.length = 0;
   });
 
   test('never runs more concurrent polls than maxConcurrentQueueDispatches', async () => {
@@ -2918,35 +2930,67 @@ describe('bounded-lane dispatcher', () => {
     expect(peak).toBeLessThanOrEqual(LIMIT);
   }, 15000);
 
-  test('does not spin when more queues are due than there are lanes', async () => {
-    // Lanes stay saturated here, so the scheduler must park on the maintenance cadence and let a
-    // completing poll wake it. Folding a due-but-unlaned queue's (past) nextPollAt into the wake
-    // time instead makes every sleep zero-length, which is the busy spin: count those parks.
-    let zeroLengthParks = 0;
-    const realSetTimeout = global.setTimeout;
-    global.setTimeout = ((fn: (...a: unknown[]) => void, delay?: number, ...rest: unknown[]) => {
-      if (delay === 0) zeroLengthParks++;
-      return realSetTimeout(fn, delay, ...rest);
-    }) as unknown as typeof global.setTimeout;
+  test('defaults to three lanes when no limit is configured', async () => {
+    // The default is what every user who does not set maxConcurrentQueueDispatches gets, and it is
+    // the one value no other test here exercises: they all pass an explicit limit.
+    let inFlight = 0;
+    let peak = 0;
 
     const queues = makeQueues(5);
     const exec = mockExecutor({
       onPoll: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await sleepms(30);
+        inFlight--;
+      },
+    });
+
+    const loop = wfQueueRunner.dispatchLoop(exec, queues);
+    await sleepms(800);
+    wfQueueRunner.stop();
+    await loop;
+
+    // Exact: a default of 1 (or 0, which would stall dispatch entirely) must not pass.
+    expect(peak).toBe(3);
+  }, 15000);
+
+  test('does not spin when more queues are due than there are lanes', async () => {
+    // Lanes stay saturated here, so the scheduler must park on the maintenance cadence and let a
+    // completing poll wake it. Folding a due-but-unlaned queue's (past) nextPollAt into the wake
+    // time instead leaves every sleep non-positive, which is the busy spin.
+    let polls = 0;
+    let shortParks = 0;
+    const queues = makeQueues(5);
+    const exec = mockExecutor({
+      onPoll: async () => {
+        polls++;
         await sleepms(30);
       },
     });
 
-    try {
-      const loop = wfQueueRunner.dispatchLoop(exec, queues, 2);
-      await sleepms(800);
-      wfQueueRunner.stop();
-      await loop;
-    } finally {
-      global.setTimeout = realSetTimeout;
-    }
+    // Count every near-instant park, not just delay === 0: dropping the `Math.max(0, ...)` clamp
+    // spins on negative delays, which Node floors to 1ms. Healthy parks are the ~1s maintenance
+    // cadence, and the mock's own sleeps are 30ms, so neither is counted.
+    const realSetTimeout = global.setTimeout;
+    jest.spyOn(global, 'setTimeout').mockImplementation(((
+      fn: (...a: unknown[]) => void,
+      delay?: number,
+      ...rest: unknown[]
+    ) => {
+      if (typeof delay === 'number' && delay < 5) shortParks++;
+      return realSetTimeout(fn, delay, ...rest);
+    }) as unknown as typeof global.setTimeout);
 
-    // ~0 while the lanes-busy guard holds; ~800 without it, since setTimeout(fn, 0) clamps to 1ms.
-    expect(zeroLengthParks).toBeLessThan(20);
+    const loop = wfQueueRunner.dispatchLoop(exec, queues, 2);
+    await sleepms(800);
+    wfQueueRunner.stop();
+    await loop;
+
+    // Liveness first: without it a dispatcher that polls nothing would satisfy the bound below.
+    expect(polls).toBeGreaterThan(8);
+    // ~0 while the lanes-busy guard holds; ~800 without it.
+    expect(shortParks).toBeLessThan(20);
   }, 15000);
 
   test('never polls the same queue in two lanes at once', async () => {
@@ -3060,7 +3104,10 @@ describe('bounded-lane dispatcher', () => {
     let pollsAfterStop = 0;
     let releaseTransition: (() => void) | undefined;
 
-    const queues = makeQueues(1);
+    // Five queues against two lanes: three are always un-laned with a nextPollAt well in the past,
+    // so the queue set is unambiguously due at the stale `now` scheduleDueQueues is handed. With a
+    // single queue, dueness lands on a millisecond boundary and the regression escapes ~1 run in 3.
+    const queues = makeQueues(5);
     const exec = mockExecutor({
       onTransition: async () => {
         transitions++;

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -2707,3 +2707,88 @@ describe('partitioned-queue-orphan-pending', () => {
     expect(await queueEntriesAreCleanedUp()).toBe(true);
   }, 20000);
 });
+
+describe('concurrent-queue-dispatches', () => {
+  class ConcurrentDispatchWFs {
+    @DBOS.workflow()
+    static async run(value: string): Promise<string> {
+      return value;
+    }
+  }
+
+  let config: DBOSConfig;
+  const slowQueueName = 'concurrent-slow-dispatch-queue';
+  const fastQueueName = 'concurrent-fast-dispatch-queue';
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestSysDb(config);
+  });
+
+  beforeEach(async () => {
+    DBOS.setConfig({
+      ...config,
+      maxConcurrentQueueDispatches: 2,
+      listenQueues: [slowQueueName, fastQueueName],
+    });
+    await DBOS.launch();
+  });
+
+  afterEach(async () => {
+    clearDebugTriggers();
+    await DBOS.shutdown();
+  });
+
+  test('a slow partitioned poll does not block another queue dispatch', async () => {
+    const partitionKey = `partition_${randomUUID()}`;
+    const releaseSlowPoll = new Event();
+    let slowPollPaused = false;
+
+    try {
+      await DBOS.registerQueue(slowQueueName, {
+        partitionQueue: true,
+        minPollingIntervalMs: 50,
+        onConflict: 'always_update',
+      });
+      await DBOS.registerQueue(fastQueueName, {
+        minPollingIntervalMs: 50,
+        onConflict: 'always_update',
+      });
+
+      setDebugTrigger(DEBUG_TRIGGER_BETWEEN_PARTITION_DISPATCHES, {
+        asyncCallback: async () => {
+          slowPollPaused = true;
+          await releaseSlowPoll.wait();
+        },
+      });
+
+      const slow = await DBOS.startWorkflow(ConcurrentDispatchWFs, {
+        queueName: slowQueueName,
+        enqueueOptions: { queuePartitionKey: partitionKey },
+      }).run('slow');
+
+      const pauseDeadline = Date.now() + 5000;
+      while (!slowPollPaused && Date.now() < pauseDeadline) {
+        await sleepms(25);
+      }
+      expect(slowPollPaused).toBe(true);
+
+      const fast = await DBOS.startWorkflow(ConcurrentDispatchWFs, { queueName: fastQueueName }).run('fast');
+      await expect(
+        Promise.race([
+          fast.getResult(),
+          sleepms(3000).then(() => {
+            throw new Error('fast queue did not dispatch while the slow queue poll was in flight');
+          }),
+        ]),
+      ).resolves.toBe('fast');
+
+      releaseSlowPoll.set();
+      await expect(slow.getResult()).resolves.toBe('slow');
+    } finally {
+      releaseSlowPoll.set();
+      await DBOS.deleteQueue(slowQueueName);
+      await DBOS.deleteQueue(fastQueueName);
+    }
+  }, 10000);
+});


### PR DESCRIPTION
## Summary
- Add `maxConcurrentQueueDispatches` to `DBOSConfig`; default to 3.
- Run due queues in a bounded number of independent dispatch lanes, with at most one in-flight poll per queue.
- The first queue considered is the one with the lowest due time.
- Keep queue discovery and delayed-workflow transitions as single global operations.

## Problem
`WFQueueRunner` currently awaits each due queue poll before considering the next queue. A poll of a busy partitioned queue processes every active partition and dispatches its claimed workflows before an unrelated queue can be considered. As a result, a large queue can create substantial dequeue latency for smaller queues even when they have available worker capacity and queued work.

## Solution
This adds a bounded, executor-wide dispatch-lane limit. With `maxConcurrentQueueDispatches: 4`, up to four different queues may be inside their queue dispatch cycle at once; a queue may never poll twice concurrently on the same executor. When a poll completes, it wakes the scheduler to fill its freed lane immediately.

This setting is intentionally separate from `systemDatabasePollingConcurrency`. The latter remains the single shared limiter for wait/read polling operations. This new setting caps queue dispatch cycles globally across the executor; it does not create a limiter per queue and does not alter workflow concurrency, rate limits, or database queue metadata.

The default remains `1`, so existing deployments keep current behavior. The change requires no migration, index, or `getQueuePartitions` query change.

## Tests
- `npm run build`
- `npx jest ./tests/config.test.ts --runInBand --silent`
- `npx jest ./tests/wfqueue.test.ts --runInBand --detectOpenHandles --silent`
- Focused fairness test: hold a partitioned queue poll open and verify an unrelated queue still dispatches with two lanes.