### PR TITLE
Key send idempotency key by recipient ID

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -531,7 +531,7 @@ export class DBOSClient {
    * @param destinationID - The ID of the destination workflow.
    * @param message - The message to send. This can be any serializable object.
    * @param topic - An optional topic to send the message to. If not provided, the default topic will be used.
-   * @param idempotencyKey - An optional idempotency key to ensure that the message is only sent once.
+   * @param idempotencyKey - An optional idempotency key to ensure that the message is only sent once per destination.
    * @returns A Promise that resolves when the message has been sent.
    */
   async send<T>(
@@ -541,14 +541,13 @@ export class DBOSClient {
     idempotencyKey?: string,
     options?: ClientSendOptions,
   ): Promise<void> {
-    const messageUUID = idempotencyKey ?? randomUUID();
     const sermsg = await serializeValue(message, this.serializer, options?.serializationType);
     await this.systemDatabase.sendDirect(
       destinationID,
       sermsg.serializedValue,
       topic,
       sermsg.serialization,
-      messageUUID,
+      idempotencyKey,
     );
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2055,10 +2055,10 @@ export class SystemDatabase {
     message: string | null,
     topic: string | undefined,
     serialization: string | null,
-    messageUUID?: string,
+    idempotencyKey?: string,
   ): Promise<void> {
     topic = topic ?? this.nullTopic;
-    messageUUID = messageUUID ?? randomUUID();
+    const messageUUID = idempotencyKey ? `${idempotencyKey}::${destinationID}` : randomUUID();
     const client: PoolClient = await this.pool.connect();
 
     try {
@@ -2093,10 +2093,11 @@ export class SystemDatabase {
     message: string | null,
     topic: string | undefined,
     serialization: string | null,
-    messageUUID?: string,
+    idempotencyKey?: string,
   ): Promise<void> {
     topic = topic ?? this.nullTopic;
-    messageUUID = messageUUID ?? randomUUID();
+    // Same per-destination scoping as send() above.
+    const messageUUID = idempotencyKey ? `${idempotencyKey}::${destinationID}` : randomUUID();
     try {
       await this.pool.query(
         `INSERT INTO "${this.schemaName}".notifications (destination_uuid, topic, message, serialization, message_uuid)

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -166,6 +166,11 @@ describe('dbos-tests', () => {
     static async sendFromStepIdemWF(dest: string, msg: string, key: string) {
       await SendIdempotencyTestClass.sendFromStepWithKey(dest, msg, key);
     }
+
+    @DBOS.workflow()
+    static async recvOneShort() {
+      return String(await DBOS.recv<string>(undefined, { timeoutSeconds: 3 }));
+    }
   }
 
   test('send-idempotency-key', async () => {
@@ -224,6 +229,23 @@ describe('dbos-tests', () => {
     await SendIdempotencyTestClass.sendFromStepIdemWF(destUUID4, 'hello_step_dup', stepIdemKey);
     // The second recv times out (returns null), proving only one message was delivered.
     expect(await handle4.getResult()).toBe('hello_step-null');
+  });
+
+  test('send-idempotency-key-scoped-per-destination', async () => {
+    // An idempotency key is scoped per destination: the same key sent to two
+    // different workflows must deliver to both (matching Python and Go, where
+    // message_uuid is `${key}::${destinationID}`).
+    const destA = randomUUID();
+    const destB = randomUUID();
+    const handleA = await DBOS.startWorkflow(SendIdempotencyTestClass, { workflowID: destA }).recvOneShort();
+    const handleB = await DBOS.startWorkflow(SendIdempotencyTestClass, { workflowID: destB }).recvOneShort();
+
+    const key = randomUUID();
+    await DBOS.send(destA, 'to_A', undefined, key);
+    await DBOS.send(destB, 'to_B', undefined, key);
+
+    expect(await handleA.getResult()).toBe('to_A');
+    expect(await handleB.getResult()).toBe('to_B');
   });
 
   test('simple-workflow-events', async () => {


### PR DESCRIPTION
Workflow notifications idempotency key must be scoped to their recipient, i.e., the same dedup key should work across multiple workflow instances.

pl/pgsql `send_message` has the same issue.