### PR TITLE
Add print only flags to dbos migrate

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -75,7 +75,8 @@ program
 program
   .command('migrate')
   .description('Perform a database migration')
-  .action(async () => {
+  .option('--print-only', 'Print the migration SQL to stdout without executing anything')
+  .action(async (options: { printOnly?: boolean }) => {
     const configFile = await readConfigFile();
     let config = getDbosConfig(configFile);
     const runtimeConfig = getRuntimeConfig(configFile);
@@ -83,7 +84,9 @@ program
       [config] = overwriteConfigForDBOSCloud(config, runtimeConfig, configFile);
     }
 
-    await runAndLog(configFile.database?.migrate ?? [], config, migrate);
+    await runAndLog(configFile.database?.migrate ?? [], config, (cmds, url, logger) =>
+      migrate(cmds, url, logger, options.printOnly ?? false),
+    );
   });
 
 program

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -76,16 +76,18 @@ program
   .command('migrate')
   .description('Perform a database migration')
   .option('--print-only', 'Print the migration SQL to stdout without executing anything')
-  .action(async (options: { printOnly?: boolean }) => {
+  .option('-s, --schema <string>', 'The schema name for DBOS system tables (default: dbos)')
+  .action(async (options: { printOnly?: boolean; schema?: string }) => {
     const configFile = await readConfigFile();
     let config = getDbosConfig(configFile);
     const runtimeConfig = getRuntimeConfig(configFile);
     if (process.env.DBOS__CLOUD === 'true') {
       [config] = overwriteConfigForDBOSCloud(config, runtimeConfig, configFile);
     }
+    const schemaName = options.schema ?? configFile.system_database_schema_name ?? 'dbos';
 
     await runAndLog(configFile.database?.migrate ?? [], config, (cmds, url, logger) =>
-      migrate(cmds, url, logger, options.printOnly ?? false),
+      migrate(cmds, url, logger, options.printOnly ?? false, schemaName),
     );
   });
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -75,9 +75,17 @@ program
 program
   .command('migrate')
   .description('Perform a database migration')
-  .option('--print-only', 'Print the migration SQL to stdout without executing anything')
+  .option(
+    '--print-migrations <all|N>',
+    "Print the SQL of all migrations ('--print-migrations all') or of migrations from a number onward ('--print-migrations 3') instead of running them",
+  )
+  .option(
+    '--print-user-role',
+    'Print the SQL granting the application role (--app-role) access to DBOS system tables instead of executing it',
+  )
+  .option('-r, --app-role <string>', 'The role with which you will run your DBOS application')
   .option('-s, --schema <string>', 'The schema name for DBOS system tables (default: dbos)')
-  .action(async (options: { printOnly?: boolean; schema?: string }) => {
+  .action(async (options: { printMigrations?: string; printUserRole?: boolean; appRole?: string; schema?: string }) => {
     const configFile = await readConfigFile();
     let config = getDbosConfig(configFile);
     const runtimeConfig = getRuntimeConfig(configFile);
@@ -87,7 +95,12 @@ program
     const schemaName = options.schema ?? configFile.system_database_schema_name ?? 'dbos';
 
     await runAndLog(configFile.database?.migrate ?? [], config, (cmds, url, logger) =>
-      migrate(cmds, url, logger, options.printOnly ?? false, schemaName),
+      migrate(cmds, url, logger, {
+        schemaName,
+        printMigrations: options.printMigrations,
+        printUserRole: options.printUserRole,
+        appRole: options.appRole,
+      }),
     );
   });
 

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,151 +1,145 @@
 import { execSync, SpawnSyncReturns } from 'child_process';
-import { Client } from 'pg';
 import { GlobalLogger } from '../telemetry/logs';
-import { ensureSystemDatabase } from '../system_database';
+import { ensureSystemDatabase, getDbosSchemaPermissionsSql } from '../system_database';
 import { allMigrations } from '../sysdb_migrations/internal/migrations';
-import { getCurrentSysDBVersion } from '../sysdb_migrations/migration_runner';
+import { maskDatabaseUrl } from '../database_utils';
 
-function freshDatabaseGuard(schemaName: string): string {
-  return `DO $$
-DECLARE
-  current_version bigint;
-BEGIN
-  SELECT "version" INTO current_version FROM "${schemaName}"."dbos_migrations" ORDER BY "version" DESC LIMIT 1;
-  IF current_version IS NOT NULL THEN
-    RAISE EXCEPTION 'DBOS schema "${schemaName}" is already at version %; this script is for fresh databases only. Use dbos migrate instead.', current_version;
-  END IF;
-END
-$$;`;
-}
+export type MigrateOptions = {
+  schemaName?: string;
+  printMigrations?: string;
+  printUserRole?: boolean;
+  appRole?: string;
+};
 
-function deltaVersionGuard(schemaName: string, fromVersion: number): string {
-  return `DO $$
-DECLARE
-  current_version bigint;
-BEGIN
-  SELECT "version" INTO current_version FROM "${schemaName}"."dbos_migrations" ORDER BY "version" DESC LIMIT 1;
-  IF current_version IS DISTINCT FROM ${fromVersion} THEN
-    RAISE EXCEPTION 'DBOS schema "${schemaName}" is at version % but this delta script requires version ${fromVersion}. Regenerate it with dbos migrate --print-only.', current_version;
-  END IF;
-END
-$$;`;
-}
+type PrintedSection = { comment?: string; statements: string[] };
 
-type PrintedSection = { comment: string; statements: string[] };
-
-function printedSections(schemaName: string, fromVersion: number): PrintedSection[] {
+function migrationSections(schemaName: string, startMigration: number): PrintedSection[] {
   const migrations = allMigrations(schemaName);
   const sections: PrintedSection[] = [];
-  if (fromVersion > 0) {
-    sections.push({
-      comment: `-- abort unless the database is exactly at DBOS schema version ${fromVersion}`,
-      statements: [deltaVersionGuard(schemaName, fromVersion)],
-    });
-  }
-  for (let i = fromVersion; i < migrations.length; i++) {
-    const m = migrations[i];
-    const stmts = (m.pg ?? []).map((s) => {
-      const stmt = s.trim();
-      return stmt.endsWith(';') ? stmt : `${stmt};`;
-    });
-    if (stmts.length === 0) continue;
-    sections.push({ comment: `-- migration ${i + 1}${m.name ? `: ${m.name}` : ''}`, statements: stmts });
-    if (fromVersion === 0 && stmts.some((s) => /create table .*"dbos_migrations"/i.test(s))) {
-      sections.push({
-        comment: '-- abort if this database has already been migrated (fresh databases only)',
-        statements: [freshDatabaseGuard(schemaName)],
-      });
+  let tableExists = startMigration > 1;
+  let versionRowExists = startMigration > 1;
+  for (let i = startMigration; i <= migrations.length; i++) {
+    const m = migrations[i - 1];
+    const stmts = (m.pg ?? [])
+      .map((s) => s.trim())
+      .filter((s) => s !== '')
+      .map((s) => (s.endsWith(';') ? s : `${s};`));
+    const statements = [...stmts];
+    if (!tableExists) {
+      tableExists = stmts.some((s) => /create table .*"dbos_migrations"/i.test(s));
     }
+    // Per-migration version bookkeeping, mirroring the runner: an interrupted
+    // apply can be resumed from the next migration number. The runner records
+    // nothing until a migration has created the dbos_migrations table.
+    if (tableExists) {
+      if (versionRowExists) {
+        statements.push(`UPDATE "${schemaName}"."dbos_migrations" SET "version" = ${i};`);
+      } else {
+        statements.push(`INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${i});`);
+        versionRowExists = true;
+      }
+    }
+    if (statements.length === 0) continue;
+    sections.push({
+      comment: stmts.length > 0 ? `-- Migration ${i}${m.name ? `: ${m.name}` : ''}` : undefined,
+      statements,
+    });
   }
-  sections.push({
-    comment: '-- record applied migration version',
-    statements: [
-      fromVersion === 0
-        ? `INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`
-        : `UPDATE "${schemaName}"."dbos_migrations" SET "version" = ${migrations.length};`,
-    ],
-  });
   return sections;
 }
 
 /**
- * Individual executable statements, in order, for tests and tooling.
- * fromVersion 0 generates the full fresh-database script; N > 0 generates a
- * delta upgrading a database at version N. Empty if already at the latest version.
+ * Individual executable statements, in order, for migrations startMigration
+ * (1-based) through the latest, including per-migration version bookkeeping.
  */
-export function generateMigrationStatements(schemaName: string = 'dbos', fromVersion: number = 0): string[] {
-  if (fromVersion >= allMigrations(schemaName).length) return [];
-  return printedSections(schemaName, fromVersion).flatMap((s) => s.statements);
+export function generateMigrationStatements(schemaName: string = 'dbos', startMigration: number = 1): string[] {
+  return migrationSections(schemaName, startMigration).flatMap((s) => s.statements);
 }
 
-export function generateMigrationSQL(schemaName: string = 'dbos', fromVersion: number = 0): string {
-  const latest = allMigrations(schemaName).length;
-  if (fromVersion >= latest) {
-    return `-- Database is already at the latest DBOS schema version (${fromVersion}); nothing to do.`;
+/**
+ * The SQL script for migrations startMigration (1-based) through the latest:
+ * pure SQL and -- comments, applicable with plain psql. Never touches a database.
+ */
+export function generateMigrationSQL(schemaName: string = 'dbos', startMigration: number = 1): string {
+  const lines: string[] = [
+    '-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).',
+  ];
+  if (startMigration === 1) {
+    lines.push('-- This script is for FRESH databases only.');
   }
-  const lines =
-    fromVersion === 0
-      ? [
-          '-- DBOS system database migration SQL',
-          '-- For FRESH databases only: the script aborts if the dbos_migrations table',
-          '-- already contains a row. Use `dbos migrate` for existing databases.',
-          '-- Run with psql in autocommit mode (the default); some statements use',
-          '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
-        ]
-      : [
-          `-- DBOS system database migration SQL (delta: version ${fromVersion} -> ${latest})`,
-          `-- Upgrades a database at DBOS schema version ${fromVersion}; aborts if the current`,
-          '-- version differs.',
-          '-- Run with psql in autocommit mode (the default); some statements use',
-          '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
-        ];
-  for (const section of printedSections(schemaName, fromVersion)) {
-    lines.push('', section.comment, ...section.statements);
+  for (const section of migrationSections(schemaName, startMigration)) {
+    if (section.comment) lines.push(section.comment);
+    lines.push(...section.statements);
   }
   return lines.join('\n');
 }
 
-/**
- * Best-effort read of the current DBOS schema version. Returns 0 (fresh) if the
- * database is unreachable or the schema/table is missing. Never writes and
- * never emits output, so --print-only stdout/stderr stay pure SQL.
- */
-async function tryGetCurrentVersion(systemDatabaseUrl: string, schemaName: string): Promise<number> {
-  const client = new Client({ connectionString: systemDatabaseUrl, connectionTimeoutMillis: 5000 });
-  try {
-    await client.connect();
-    return await getCurrentSysDBVersion(client, schemaName);
-  } catch {
+// Wait for the write to flush: the CLI exits via process.exit(), which would
+// otherwise truncate piped output.
+function writeAndFlush(stream: NodeJS.WriteStream, text: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    stream.write(text, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function fail(message: string): Promise<number> {
+  await writeAndFlush(process.stderr, message + '\n');
+  return 1;
+}
+
+function quotedIdentifierError(name: string, kind: string): string | undefined {
+  return name.includes('"') || name.includes("'") ? `${kind} names containing quotes are not supported` : undefined;
+}
+
+async function runPrintMode(systemDatabaseUrl: string, options: MigrateOptions): Promise<number> {
+  const schemaName = options.schemaName ?? 'dbos';
+  if (options.printMigrations !== undefined && options.printUserRole) {
+    return await fail('--print-user-role cannot be combined with --print-migrations');
+  }
+
+  if (options.printUserRole) {
+    if (!options.appRole) return await fail('--print-user-role requires --app-role');
+    const error = quotedIdentifierError(schemaName, 'Schema') ?? quotedIdentifierError(options.appRole, 'Role');
+    if (error) return await fail(error);
+    const lines = [
+      `-- Permissions on DBOS schema ${schemaName} for role ${options.appRole}`,
+      ...getDbosSchemaPermissionsSql(schemaName, options.appRole).map((s) => `${s};`),
+    ];
+    await writeAndFlush(process.stdout, lines.join('\n') + '\n');
     return 0;
-  } finally {
-    try {
-      await client.end();
-    } catch {
-      // ignore
+  }
+
+  const value = options.printMigrations!;
+  const error = quotedIdentifierError(schemaName, 'Schema');
+  if (error) return await fail(error);
+  const latest = allMigrations(schemaName).length;
+  let start = 1;
+  if (value !== 'all') {
+    if (!/^-?\d+$/.test(value)) {
+      return await fail(`Invalid --print-migrations value '${value}': expected 'all' or a migration number`);
+    }
+    start = Number(value);
+    if (start < 1 || start > latest) {
+      return await fail(`Migration ${start} does not exist: valid migrations are 1 through ${latest}`);
     }
   }
+  const header = `-- DBOS system database migrations for ${maskDatabaseUrl(systemDatabaseUrl)}`;
+  await writeAndFlush(process.stdout, `${header}\n${generateMigrationSQL(schemaName, start)}\n`);
+  return 0;
 }
 
 export async function migrate(
   migrationCommands: string[],
   systemDatabaseUrl: string,
   logger: GlobalLogger,
-  printOnly: boolean = false,
-  schemaName: string = 'dbos',
+  options: MigrateOptions = {},
 ) {
-  if (printOnly) {
+  const schemaName = options.schemaName ?? 'dbos';
+  if (options.printMigrations !== undefined || options.printUserRole) {
     // User-defined migration commands from dbos-config.yaml are shell commands,
-    // not SQL, so they are skipped here. Nothing is logged in this mode: stdout
-    // must stay pure SQL/comments so it can be piped into a .sql file.
-    const fromVersion = await tryGetCurrentVersion(systemDatabaseUrl, schemaName);
-    // Wait for the write to flush: the CLI exits via process.exit(), which
-    // would otherwise truncate piped output.
-    await new Promise<void>((resolve, reject) => {
-      process.stdout.write(generateMigrationSQL(schemaName, fromVersion) + '\n', (err) =>
-        err ? reject(err) : resolve(),
-      );
-    });
-    return 0;
+    // not SQL, so they are skipped here. Nothing is logged in print modes:
+    // stdout must stay pure SQL/comments so it can be piped into a .sql file.
+    return await runPrintMode(systemDatabaseUrl, options);
   }
 
   let status = 0;

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -13,11 +13,18 @@ export type MigrateOptions = {
 
 type PrintedSection = { comment?: string; statements: string[] };
 
+const CREATES_MIGRATIONS_TABLE = /create table .*"dbos_migrations"/i;
+
 function migrationSections(schemaName: string, startMigration: number): PrintedSection[] {
   const migrations = allMigrations(schemaName);
   const sections: PrintedSection[] = [];
-  let tableExists = startMigration > 1;
-  let versionRowExists = startMigration > 1;
+  // A database at version V has run migrations 1..V, so the dbos_migrations
+  // table (and its single version row) exists iff the migration creating it
+  // is before startMigration.
+  let tableExists = migrations
+    .slice(0, startMigration - 1)
+    .some((m) => (m.pg ?? []).some((s) => CREATES_MIGRATIONS_TABLE.test(s)));
+  let versionRowExists = tableExists;
   for (let i = startMigration; i <= migrations.length; i++) {
     const m = migrations[i - 1];
     const stmts = (m.pg ?? [])
@@ -26,7 +33,7 @@ function migrationSections(schemaName: string, startMigration: number): PrintedS
       .map((s) => (s.endsWith(';') ? s : `${s};`));
     const statements = [...stmts];
     if (!tableExists) {
-      tableExists = stmts.some((s) => /create table .*"dbos_migrations"/i.test(s));
+      tableExists = stmts.some((s) => CREATES_MIGRATIONS_TABLE.test(s));
     }
     // Per-migration version bookkeeping, mirroring the runner: an interrupted
     // apply can be resumed from the next migration number. The runner records
@@ -62,6 +69,7 @@ export function generateMigrationStatements(schemaName: string = 'dbos', startMi
  */
 export function generateMigrationSQL(schemaName: string = 'dbos', startMigration: number = 1): string {
   const lines: string[] = [
+    '-- This script is for PostgreSQL only.',
     '-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).',
   ];
   if (startMigration === 1) {

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -3,25 +3,62 @@ import { GlobalLogger } from '../telemetry/logs';
 import { ensureSystemDatabase } from '../system_database';
 import { allMigrations } from '../sysdb_migrations/internal/migrations';
 
-export function generateMigrationSQL(schemaName: string = 'dbos'): string {
+function freshDatabaseGuard(schemaName: string): string {
+  return `DO $$
+DECLARE
+  current_version bigint;
+BEGIN
+  SELECT "version" INTO current_version FROM "${schemaName}"."dbos_migrations" ORDER BY "version" DESC LIMIT 1;
+  IF current_version IS NOT NULL THEN
+    RAISE EXCEPTION 'DBOS schema "${schemaName}" is already at version %; this script is for fresh databases only. Use dbos migrate instead.', current_version;
+  END IF;
+END
+$$;`;
+}
+
+type PrintedSection = { comment: string; statements: string[] };
+
+function printedSections(schemaName: string): PrintedSection[] {
   const migrations = allMigrations(schemaName);
+  const sections: PrintedSection[] = [];
+  for (let i = 0; i < migrations.length; i++) {
+    const m = migrations[i];
+    const stmts = (m.pg ?? []).map((s) => {
+      const stmt = s.trim();
+      return stmt.endsWith(';') ? stmt : `${stmt};`;
+    });
+    if (stmts.length === 0) continue;
+    sections.push({ comment: `-- migration ${i + 1}${m.name ? `: ${m.name}` : ''}`, statements: stmts });
+    if (stmts.some((s) => /create table .*"dbos_migrations"/i.test(s))) {
+      sections.push({
+        comment: '-- abort if this database has already been migrated (fresh databases only)',
+        statements: [freshDatabaseGuard(schemaName)],
+      });
+    }
+  }
+  sections.push({
+    comment: '-- record applied migration version',
+    statements: [`INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`],
+  });
+  return sections;
+}
+
+/** Individual executable statements, in order, for tests and tooling. */
+export function generateMigrationStatements(schemaName: string = 'dbos'): string[] {
+  return printedSections(schemaName).flatMap((s) => s.statements);
+}
+
+export function generateMigrationSQL(schemaName: string = 'dbos'): string {
   const lines: string[] = [
     '-- DBOS system database migration SQL',
+    '-- For FRESH databases only: the script aborts if the dbos_migrations table',
+    '-- already contains a row. Use `dbos migrate` for existing databases.',
     '-- Run with psql in autocommit mode (the default); some statements use',
     '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
   ];
-  for (let i = 0; i < migrations.length; i++) {
-    const m = migrations[i];
-    const stmts = m.pg ?? [];
-    if (stmts.length === 0) continue;
-    lines.push('', `-- migration ${i + 1}${m.name ? `: ${m.name}` : ''}`);
-    for (const s of stmts) {
-      const stmt = s.trim();
-      lines.push(stmt.endsWith(';') ? stmt : `${stmt};`);
-    }
+  for (const section of printedSections(schemaName)) {
+    lines.push('', section.comment, ...section.statements);
   }
-  lines.push('', '-- record applied migration version');
-  lines.push(`INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`);
   return lines.join('\n');
 }
 
@@ -30,6 +67,7 @@ export async function migrate(
   systemDatabaseUrl: string,
   logger: GlobalLogger,
   printOnly: boolean = false,
+  schemaName: string = 'dbos',
 ) {
   if (printOnly) {
     if (migrationCommands.length > 0) {
@@ -37,7 +75,7 @@ export async function migrate(
         'Skipping user-defined migration commands from dbos-config.yaml in --print-only mode (they are shell commands, not SQL).',
       );
     }
-    process.stdout.write(generateMigrationSQL() + '\n');
+    process.stdout.write(generateMigrationSQL(schemaName) + '\n');
     return 0;
   }
 
@@ -56,7 +94,7 @@ export async function migrate(
 
   logger.info('Creating DBOS system database.');
   try {
-    await ensureSystemDatabase(systemDatabaseUrl, logger);
+    await ensureSystemDatabase(systemDatabaseUrl, logger, undefined, schemaName);
   } catch (e) {
     if (e instanceof Error) {
       logger.error(`Error creating DBOS system database: ${e.message}`);

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,7 +1,9 @@
 import { execSync, SpawnSyncReturns } from 'child_process';
+import { Client } from 'pg';
 import { GlobalLogger } from '../telemetry/logs';
 import { ensureSystemDatabase } from '../system_database';
 import { allMigrations } from '../sysdb_migrations/internal/migrations';
+import { getCurrentSysDBVersion } from '../sysdb_migrations/migration_runner';
 
 function freshDatabaseGuard(schemaName: string): string {
   return `DO $$
@@ -16,12 +18,31 @@ END
 $$;`;
 }
 
+function deltaVersionGuard(schemaName: string, fromVersion: number): string {
+  return `DO $$
+DECLARE
+  current_version bigint;
+BEGIN
+  SELECT "version" INTO current_version FROM "${schemaName}"."dbos_migrations" ORDER BY "version" DESC LIMIT 1;
+  IF current_version IS DISTINCT FROM ${fromVersion} THEN
+    RAISE EXCEPTION 'DBOS schema "${schemaName}" is at version % but this delta script requires version ${fromVersion}. Regenerate it with dbos migrate --print-only.', current_version;
+  END IF;
+END
+$$;`;
+}
+
 type PrintedSection = { comment: string; statements: string[] };
 
-function printedSections(schemaName: string): PrintedSection[] {
+function printedSections(schemaName: string, fromVersion: number): PrintedSection[] {
   const migrations = allMigrations(schemaName);
   const sections: PrintedSection[] = [];
-  for (let i = 0; i < migrations.length; i++) {
+  if (fromVersion > 0) {
+    sections.push({
+      comment: `-- abort unless the database is exactly at DBOS schema version ${fromVersion}`,
+      statements: [deltaVersionGuard(schemaName, fromVersion)],
+    });
+  }
+  for (let i = fromVersion; i < migrations.length; i++) {
     const m = migrations[i];
     const stmts = (m.pg ?? []).map((s) => {
       const stmt = s.trim();
@@ -29,7 +50,7 @@ function printedSections(schemaName: string): PrintedSection[] {
     });
     if (stmts.length === 0) continue;
     sections.push({ comment: `-- migration ${i + 1}${m.name ? `: ${m.name}` : ''}`, statements: stmts });
-    if (stmts.some((s) => /create table .*"dbos_migrations"/i.test(s))) {
+    if (fromVersion === 0 && stmts.some((s) => /create table .*"dbos_migrations"/i.test(s))) {
       sections.push({
         comment: '-- abort if this database has already been migrated (fresh databases only)',
         statements: [freshDatabaseGuard(schemaName)],
@@ -38,28 +59,71 @@ function printedSections(schemaName: string): PrintedSection[] {
   }
   sections.push({
     comment: '-- record applied migration version',
-    statements: [`INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`],
+    statements: [
+      fromVersion === 0
+        ? `INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`
+        : `UPDATE "${schemaName}"."dbos_migrations" SET "version" = ${migrations.length};`,
+    ],
   });
   return sections;
 }
 
-/** Individual executable statements, in order, for tests and tooling. */
-export function generateMigrationStatements(schemaName: string = 'dbos'): string[] {
-  return printedSections(schemaName).flatMap((s) => s.statements);
+/**
+ * Individual executable statements, in order, for tests and tooling.
+ * fromVersion 0 generates the full fresh-database script; N > 0 generates a
+ * delta upgrading a database at version N. Empty if already at the latest version.
+ */
+export function generateMigrationStatements(schemaName: string = 'dbos', fromVersion: number = 0): string[] {
+  if (fromVersion >= allMigrations(schemaName).length) return [];
+  return printedSections(schemaName, fromVersion).flatMap((s) => s.statements);
 }
 
-export function generateMigrationSQL(schemaName: string = 'dbos'): string {
-  const lines: string[] = [
-    '-- DBOS system database migration SQL',
-    '-- For FRESH databases only: the script aborts if the dbos_migrations table',
-    '-- already contains a row. Use `dbos migrate` for existing databases.',
-    '-- Run with psql in autocommit mode (the default); some statements use',
-    '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
-  ];
-  for (const section of printedSections(schemaName)) {
+export function generateMigrationSQL(schemaName: string = 'dbos', fromVersion: number = 0): string {
+  const latest = allMigrations(schemaName).length;
+  if (fromVersion >= latest) {
+    return `-- Database is already at the latest DBOS schema version (${fromVersion}); nothing to do.`;
+  }
+  const lines =
+    fromVersion === 0
+      ? [
+          '-- DBOS system database migration SQL',
+          '-- For FRESH databases only: the script aborts if the dbos_migrations table',
+          '-- already contains a row. Use `dbos migrate` for existing databases.',
+          '-- Run with psql in autocommit mode (the default); some statements use',
+          '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
+        ]
+      : [
+          `-- DBOS system database migration SQL (delta: version ${fromVersion} -> ${latest})`,
+          `-- Upgrades a database at DBOS schema version ${fromVersion}; aborts if the current`,
+          '-- version differs.',
+          '-- Run with psql in autocommit mode (the default); some statements use',
+          '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
+        ];
+  for (const section of printedSections(schemaName, fromVersion)) {
     lines.push('', section.comment, ...section.statements);
   }
   return lines.join('\n');
+}
+
+/**
+ * Best-effort read of the current DBOS schema version. Returns 0 (fresh) if the
+ * database is unreachable or the schema/table is missing. Never writes and
+ * never emits output, so --print-only stdout/stderr stay pure SQL.
+ */
+async function tryGetCurrentVersion(systemDatabaseUrl: string, schemaName: string): Promise<number> {
+  const client = new Client({ connectionString: systemDatabaseUrl, connectionTimeoutMillis: 5000 });
+  try {
+    await client.connect();
+    return await getCurrentSysDBVersion(client, schemaName);
+  } catch {
+    return 0;
+  } finally {
+    try {
+      await client.end();
+    } catch {
+      // ignore
+    }
+  }
 }
 
 export async function migrate(
@@ -70,12 +134,17 @@ export async function migrate(
   schemaName: string = 'dbos',
 ) {
   if (printOnly) {
-    if (migrationCommands.length > 0) {
-      console.warn(
-        'Skipping user-defined migration commands from dbos-config.yaml in --print-only mode (they are shell commands, not SQL).',
+    // User-defined migration commands from dbos-config.yaml are shell commands,
+    // not SQL, so they are skipped here. Nothing is logged in this mode: stdout
+    // must stay pure SQL/comments so it can be piped into a .sql file.
+    const fromVersion = await tryGetCurrentVersion(systemDatabaseUrl, schemaName);
+    // Wait for the write to flush: the CLI exits via process.exit(), which
+    // would otherwise truncate piped output.
+    await new Promise<void>((resolve, reject) => {
+      process.stdout.write(generateMigrationSQL(schemaName, fromVersion) + '\n', (err) =>
+        err ? reject(err) : resolve(),
       );
-    }
-    process.stdout.write(generateMigrationSQL(schemaName) + '\n');
+    });
     return 0;
   }
 

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,8 +1,46 @@
 import { execSync, SpawnSyncReturns } from 'child_process';
 import { GlobalLogger } from '../telemetry/logs';
 import { ensureSystemDatabase } from '../system_database';
+import { allMigrations } from '../sysdb_migrations/internal/migrations';
 
-export async function migrate(migrationCommands: string[], systemDatabaseUrl: string, logger: GlobalLogger) {
+export function generateMigrationSQL(schemaName: string = 'dbos'): string {
+  const migrations = allMigrations(schemaName);
+  const lines: string[] = [
+    '-- DBOS system database migration SQL',
+    '-- Run with psql in autocommit mode (the default); some statements use',
+    '-- CREATE INDEX CONCURRENTLY and cannot run inside a transaction block.',
+  ];
+  for (let i = 0; i < migrations.length; i++) {
+    const m = migrations[i];
+    const stmts = m.pg ?? [];
+    if (stmts.length === 0) continue;
+    lines.push('', `-- migration ${i + 1}${m.name ? `: ${m.name}` : ''}`);
+    for (const s of stmts) {
+      const stmt = s.trim();
+      lines.push(stmt.endsWith(';') ? stmt : `${stmt};`);
+    }
+  }
+  lines.push('', '-- record applied migration version');
+  lines.push(`INSERT INTO "${schemaName}"."dbos_migrations" ("version") VALUES (${migrations.length});`);
+  return lines.join('\n');
+}
+
+export async function migrate(
+  migrationCommands: string[],
+  systemDatabaseUrl: string,
+  logger: GlobalLogger,
+  printOnly: boolean = false,
+) {
+  if (printOnly) {
+    if (migrationCommands.length > 0) {
+      console.warn(
+        'Skipping user-defined migration commands from dbos-config.yaml in --print-only mode (they are shell commands, not SQL).',
+      );
+    }
+    process.stdout.write(generateMigrationSQL() + '\n');
+    return 0;
+  }
+
   let status = 0;
 
   try {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -310,6 +310,24 @@ export interface MetricData {
   value: number;
 }
 
+/** The statements granting permissions on all entities in the system schema to a role. */
+export function getDbosSchemaPermissionsSql(schemaName: string, roleName: string): string[] {
+  return [
+    // Grant usage on the system schema
+    `GRANT USAGE ON SCHEMA "${schemaName}" TO "${roleName}"`,
+    // Grant all privileges on all existing tables in the system schema (includes views)
+    `GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "${schemaName}" TO "${roleName}"`,
+    // Grant all privileges on all sequences in the system schema
+    `GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "${schemaName}" TO "${roleName}"`,
+    // Grant execute on all functions and procedures in the system schema
+    `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA "${schemaName}" TO "${roleName}"`,
+    // Grant default privileges for future objects in the system schema
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT ALL ON TABLES TO "${roleName}"`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT ALL ON SEQUENCES TO "${roleName}"`,
+    `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT EXECUTE ON FUNCTIONS TO "${roleName}"`,
+  ];
+}
+
 export async function grantDbosSchemaPermissions(
   databaseUrl: string,
   roleName: string,
@@ -322,38 +340,10 @@ export async function grantDbosSchemaPermissions(
   await client.connect();
 
   try {
-    // Grant usage on the schema
-    const grantUsageSql = `GRANT USAGE ON SCHEMA "${schemaName}" TO "${roleName}"`;
-    logger.info(grantUsageSql);
-    await client.query(grantUsageSql);
-
-    // Grant all privileges on all existing tables in schema (includes views)
-    const grantTablesSql = `GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA "${schemaName}" TO "${roleName}"`;
-    logger.info(grantTablesSql);
-    await client.query(grantTablesSql);
-
-    // Grant all privileges on all sequences in schema
-    const grantSequencesSql = `GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA "${schemaName}" TO "${roleName}"`;
-    logger.info(grantSequencesSql);
-    await client.query(grantSequencesSql);
-
-    // Grant execute on all functions and procedures in schema
-    const grantFunctionsSql = `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA "${schemaName}" TO "${roleName}"`;
-    logger.info(grantFunctionsSql);
-    await client.query(grantFunctionsSql);
-
-    // Grant default privileges for future objects in schema
-    const alterTablesSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT ALL ON TABLES TO "${roleName}"`;
-    logger.info(alterTablesSql);
-    await client.query(alterTablesSql);
-
-    const alterSequencesSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT ALL ON SEQUENCES TO "${roleName}"`;
-    logger.info(alterSequencesSql);
-    await client.query(alterSequencesSql);
-
-    const alterFunctionsSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA "${schemaName}" GRANT EXECUTE ON FUNCTIONS TO "${roleName}"`;
-    logger.info(alterFunctionsSql);
-    await client.query(alterFunctionsSql);
+    for (const sql of getDbosSchemaPermissionsSql(schemaName, roleName)) {
+      logger.info(sql);
+      await client.query(sql);
+    }
   } catch (e) {
     logger.error(`Failed to grant permissions to role ${roleName}: ${(e as Error).message}`);
     throw e;

--- a/tests/migrate_print.test.ts
+++ b/tests/migrate_print.test.ts
@@ -1,10 +1,38 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
 import { Client } from 'pg';
 import { migrate, generateMigrationSQL, generateMigrationStatements } from '../src/cli/migrate';
 import { allMigrations } from '../src/sysdb_migrations/internal/migrations';
+import { runSysMigrationsPg } from '../src/sysdb_migrations/migration_runner';
+import { ensureSystemDatabase } from '../src/system_database';
 import { GlobalLogger } from '../src/telemetry/logs';
 import { generateDBOSTestConfig } from './helpers';
 
 const FUNNY_SCHEMA = 'F8nny_sCHem@-n@m3';
+const LATEST_VERSION = allMigrations().length;
+const UNREACHABLE_URL = 'postgres://nobody:nopass@nonexistent-host.invalid:1/no_such_db';
+
+/** Print the migration SQL in-process, capturing stdout. */
+async function printMigrationSQL(systemDatabaseUrl: string, schemaName?: string): Promise<string> {
+  let out = '';
+  const stdoutSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown, encodingOrCb?: unknown, cb?: unknown) => {
+      out += String(chunk);
+      const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+      if (typeof callback === 'function') (callback as () => void)();
+      return true;
+    });
+  try {
+    const status = await migrate([], systemDatabaseUrl, new GlobalLogger(), true, schemaName);
+    expect(status).toBe(0);
+  } finally {
+    stdoutSpy.mockRestore();
+  }
+  return out;
+}
 
 describe('migrate --print-only', () => {
   test('generateMigrationSQL emits complete, terminated SQL with version bookkeeping', () => {
@@ -57,28 +85,68 @@ describe('migrate --print-only', () => {
     expect(sql).not.toContain('"dbos".');
   });
 
-  test('migrate with printOnly writes SQL to stdout and executes nothing', async () => {
-    let out = '';
-    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
-      out += String(chunk);
-      return true;
-    });
+  test('delta script upgrades from version N with a version guard and no fresh prelude', () => {
+    const fromVersion = 20;
+    const sql = generateMigrationSQL('dbos', fromVersion);
+    expect(sql).toContain(`-- DBOS system database migration SQL (delta: version ${fromVersion} -> ${LATEST_VERSION})`);
+    expect(sql).toContain(`IF current_version IS DISTINCT FROM ${fromVersion} THEN`);
+    expect(sql).toContain(`this delta script requires version ${fromVersion}`);
+    // No fresh-database prelude or guard.
+    expect(sql).not.toContain('CREATE SCHEMA');
+    expect(sql).not.toContain('-- migration 1:');
+    expect(sql).not.toContain(`-- migration ${fromVersion}:`);
+    expect(sql).not.toContain('fresh databases only');
+    expect(sql).not.toContain('INSERT INTO "dbos"."dbos_migrations"');
+    // Applies exactly N+1..latest and records the version with an UPDATE.
+    expect(sql).toContain(`-- migration ${fromVersion + 1}:`);
+    expect(sql.trimEnd().endsWith(`UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST_VERSION};`)).toBe(true);
+    // The guard is the first statement, before any migration.
+    expect(sql.indexOf('IS DISTINCT FROM')).toBeLessThan(sql.indexOf(`-- migration ${fromVersion + 1}:`));
+  });
+
+  test('at the latest version, prints only a nothing-to-do comment', () => {
+    expect(generateMigrationSQL('dbos', LATEST_VERSION)).toBe(
+      `-- Database is already at the latest DBOS schema version (${LATEST_VERSION}); nothing to do.`,
+    );
+    expect(generateMigrationStatements('dbos', LATEST_VERSION)).toEqual([]);
+  });
+
+  test('migrate with printOnly on an unreachable database silently prints the full fresh script', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      const status = await migrate(
-        ['echo should-not-run'],
-        'postgres://nonexistent-host:1/no_such_db',
-        new GlobalLogger(),
-        true,
-      );
-      expect(status).toBe(0);
+      const out = await printMigrationSQL(UNREACHABLE_URL);
       expect(out).toBe(generateMigrationSQL() + '\n');
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('--print-only'));
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
     } finally {
-      stdoutSpy.mockRestore();
       warnSpy.mockRestore();
+      errorSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
+
+  test('spawned CLI with unreachable database prints pure SQL to stdout, nothing to stderr, exit 0', () => {
+    const cliPath = path.resolve(__dirname, '..', 'dist', 'src', 'cli', 'cli.js');
+    const workDir = mkdtempSync(path.join(tmpdir(), 'dbos-migrate-print-'));
+    try {
+      writeFileSync(
+        path.join(workDir, 'dbos-config.yaml'),
+        `name: migrateprinttest\nsystem_database_url: ${UNREACHABLE_URL}\n`,
+      );
+      const res = spawnSync(process.execPath, [cliPath, 'migrate', '--print-only'], {
+        cwd: workDir,
+        encoding: 'utf-8',
+      });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toBe('');
+      expect(res.stdout).toBe(generateMigrationSQL() + '\n');
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }, 30000);
 
   test('printed SQL applies end-to-end to a fresh database with a special-character schema', async () => {
     const config = generateDBOSTestConfig();
@@ -97,6 +165,9 @@ describe('migrate --print-only', () => {
     const client = new Client({ connectionString: dbUrl.toString() });
     await client.connect();
     try {
+      // Connection OK but schema/table missing: the CLI prints the full fresh script.
+      expect(await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA)).toBe(generateMigrationSQL(FUNNY_SCHEMA) + '\n');
+
       // Apply each printed statement in autocommit, as psql would.
       const statements = generateMigrationStatements(FUNNY_SCHEMA);
       for (const stmt of statements) {
@@ -128,6 +199,84 @@ describe('migrate --print-only', () => {
       expect(guard).toBeDefined();
       await expect(client.query(guard)).rejects.toThrow(
         `DBOS schema "${FUNNY_SCHEMA}" is already at version ${allMigrations().length}; this script is for fresh databases only. Use dbos migrate instead.`,
+      );
+    } finally {
+      await client.end();
+      const cleanupClient = new Client({ connectionString: baseUrl.toString() });
+      await cleanupClient.connect();
+      await cleanupClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+      await cleanupClient.end();
+    }
+  }, 60000);
+
+  test('delta script end-to-end: partial database, delta print, apply, latest, guard mismatch', async () => {
+    const partialVersion = 20;
+    const config = generateDBOSTestConfig();
+    const baseUrl = new URL(config.systemDatabaseUrl!);
+    baseUrl.pathname = '/postgres';
+    const dbName = 'migrate_print_delta_test_db';
+    const dbUrl = new URL(baseUrl.toString());
+    dbUrl.pathname = `/${dbName}`;
+
+    const adminClient = new Client({ connectionString: baseUrl.toString() });
+    await adminClient.connect();
+    await adminClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+    await adminClient.query(`CREATE DATABASE ${dbName};`);
+    await adminClient.end();
+
+    const client = new Client({ connectionString: dbUrl.toString() });
+    await client.connect();
+    try {
+      // Build a genuinely partial database: run the real migration runner
+      // through migration N only.
+      await runSysMigrationsPg(client, allMigrations(FUNNY_SCHEMA).slice(0, partialVersion), FUNNY_SCHEMA, {
+        onWarn: () => {},
+      });
+      const partialRows = await client.query<{ version: string }>(
+        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
+      );
+      expect(Number(partialRows.rows[0].version)).toBe(partialVersion);
+
+      // The CLI connects, detects version N, and prints only the delta.
+      const printed = await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA);
+      expect(printed).toBe(generateMigrationSQL(FUNNY_SCHEMA, partialVersion) + '\n');
+      expect(printed).toContain(`(delta: version ${partialVersion} -> ${LATEST_VERSION})`);
+      expect(printed).toContain(`IF current_version IS DISTINCT FROM ${partialVersion} THEN`);
+      expect(printed).toContain(`-- migration ${partialVersion + 1}:`);
+      expect(printed).not.toContain('CREATE SCHEMA');
+      expect(printed).not.toContain(`-- migration ${partialVersion}:`);
+      expect(printed).not.toContain('fresh databases only');
+      expect(printed).toContain(`"${FUNNY_SCHEMA}"."dbos_migrations"`);
+
+      // Apply the delta statement by statement in autocommit, as psql would.
+      const deltaStatements = generateMigrationStatements(FUNNY_SCHEMA, partialVersion);
+      for (const stmt of deltaStatements) {
+        await client.query(stmt);
+      }
+      const versionRows = await client.query<{ version: string }>(
+        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
+      );
+      expect(versionRows.rows.length).toBe(1);
+      expect(Number(versionRows.rows[0].version)).toBe(LATEST_VERSION);
+
+      // A real migration pass treats the delta-migrated database as up-to-date.
+      await ensureSystemDatabase(dbUrl.toString(), new GlobalLogger(), undefined, FUNNY_SCHEMA);
+      const afterEnsure = await client.query<{ version: string }>(
+        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
+      );
+      expect(afterEnsure.rows.length).toBe(1);
+      expect(Number(afterEnsure.rows[0].version)).toBe(LATEST_VERSION);
+
+      // At the latest version the CLI prints only the nothing-to-do comment.
+      expect(await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA)).toBe(
+        `-- Database is already at the latest DBOS schema version (${LATEST_VERSION}); nothing to do.\n`,
+      );
+
+      // Guard mismatch: the version-N delta guard aborts on a database at a different version.
+      const guard = deltaStatements[0];
+      expect(guard).toContain('IS DISTINCT FROM');
+      await expect(client.query(guard)).rejects.toThrow(
+        `DBOS schema "${FUNNY_SCHEMA}" is at version ${LATEST_VERSION} but this delta script requires version ${partialVersion}. Regenerate it with dbos migrate --print-only.`,
       );
     } finally {
       await client.end();

--- a/tests/migrate_print.test.ts
+++ b/tests/migrate_print.test.ts
@@ -1,10 +1,15 @@
-import { migrate, generateMigrationSQL } from '../src/cli/migrate';
+import { Client } from 'pg';
+import { migrate, generateMigrationSQL, generateMigrationStatements } from '../src/cli/migrate';
 import { allMigrations } from '../src/sysdb_migrations/internal/migrations';
 import { GlobalLogger } from '../src/telemetry/logs';
+import { generateDBOSTestConfig } from './helpers';
+
+const FUNNY_SCHEMA = 'F8nny_sCHem@-n@m3';
 
 describe('migrate --print-only', () => {
   test('generateMigrationSQL emits complete, terminated SQL with version bookkeeping', () => {
     const sql = generateMigrationSQL();
+    expect(sql).toContain('-- For FRESH databases only');
     expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "dbos";');
     expect(sql).toContain(
       'create table "dbos"."dbos_migrations" ("version" bigint not null, constraint "dbos_migrations_pkey" primary key ("version"));',
@@ -17,6 +22,33 @@ describe('migrate --print-only', () => {
     for (const line of sql.split('\n')) {
       expect(line).not.toMatch(/\[(info|warn|error)\]/);
     }
+  });
+
+  test('fail-fast guard follows the dbos_migrations table creation', () => {
+    const sql = generateMigrationSQL();
+    const createIdx = sql.indexOf('create table "dbos"."dbos_migrations"');
+    const guardIdx = sql.indexOf('this script is for fresh databases only. Use dbos migrate instead.');
+    const nextMigrationIdx = sql.indexOf('-- migration 3');
+    expect(createIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeGreaterThan(createIdx);
+    expect(guardIdx).toBeLessThan(nextMigrationIdx);
+    expect(sql).toContain('RAISE EXCEPTION');
+    expect(sql).toContain(`SELECT "version" INTO current_version FROM "dbos"."dbos_migrations"`);
+  });
+
+  test('generateMigrationSQL double-quotes identifiers for a schema with special characters', () => {
+    const sql = generateMigrationSQL(FUNNY_SCHEMA);
+    expect(sql).toContain(`CREATE SCHEMA IF NOT EXISTS "${FUNNY_SCHEMA}";`);
+    expect(sql).toContain(`create table "${FUNNY_SCHEMA}"."dbos_migrations"`);
+    expect(sql).toContain(`create table "${FUNNY_SCHEMA}"."workflow_status"`);
+    expect(sql).toContain(`DBOS schema "${FUNNY_SCHEMA}" is already at version %`);
+    const version = allMigrations().length;
+    expect(
+      sql.trimEnd().endsWith(`INSERT INTO "${FUNNY_SCHEMA}"."dbos_migrations" ("version") VALUES (${version});`),
+    ).toBe(true);
+    expect(sql).not.toContain('"dbos".');
+    // The schema name never appears unquoted before a dot (which psql would fold or reject).
+    expect(sql).not.toMatch(new RegExp(`[^"]F8nny_sCHem@-n@m3"?\\.`));
   });
 
   test('generateMigrationSQL substitutes the schema name', () => {
@@ -47,4 +79,62 @@ describe('migrate --print-only', () => {
       warnSpy.mockRestore();
     }
   });
+
+  test('printed SQL applies end-to-end to a fresh database with a special-character schema', async () => {
+    const config = generateDBOSTestConfig();
+    const baseUrl = new URL(config.systemDatabaseUrl!);
+    baseUrl.pathname = '/postgres';
+    const dbName = 'migrate_print_sql_test_db';
+    const dbUrl = new URL(baseUrl.toString());
+    dbUrl.pathname = `/${dbName}`;
+
+    const adminClient = new Client({ connectionString: baseUrl.toString() });
+    await adminClient.connect();
+    await adminClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+    await adminClient.query(`CREATE DATABASE ${dbName};`);
+    await adminClient.end();
+
+    const client = new Client({ connectionString: dbUrl.toString() });
+    await client.connect();
+    try {
+      // Apply each printed statement in autocommit, as psql would.
+      const statements = generateMigrationStatements(FUNNY_SCHEMA);
+      for (const stmt of statements) {
+        await client.query(stmt);
+      }
+
+      const schemaExists = await client.query<{ exists: boolean }>(
+        'SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = $1)',
+        [FUNNY_SCHEMA],
+      );
+      expect(schemaExists.rows[0].exists).toBe(true);
+
+      for (const table of ['dbos_migrations', 'workflow_status', 'operation_outputs', 'notifications', 'streams']) {
+        const tableExists = await client.query<{ exists: boolean }>(
+          'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2)',
+          [FUNNY_SCHEMA, table],
+        );
+        expect(tableExists.rows[0].exists).toBe(true);
+      }
+
+      const versionRows = await client.query<{ version: string }>(
+        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
+      );
+      expect(versionRows.rows.length).toBe(1);
+      expect(Number(versionRows.rows[0].version)).toBe(allMigrations().length);
+
+      // Re-running the fail-fast guard on the now-migrated database aborts.
+      const guard = statements.find((s) => s.includes('fresh databases only'))!;
+      expect(guard).toBeDefined();
+      await expect(client.query(guard)).rejects.toThrow(
+        `DBOS schema "${FUNNY_SCHEMA}" is already at version ${allMigrations().length}; this script is for fresh databases only. Use dbos migrate instead.`,
+      );
+    } finally {
+      await client.end();
+      const cleanupClient = new Client({ connectionString: baseUrl.toString() });
+      await cleanupClient.connect();
+      await cleanupClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+      await cleanupClient.end();
+    }
+  }, 60000);
 });

--- a/tests/migrate_print.test.ts
+++ b/tests/migrate_print.test.ts
@@ -78,10 +78,11 @@ describe('migrate --print-migrations and --print-user-role', () => {
     const lines = out.split('\n');
     expect(lines[0]).toBe(`-- DBOS system database migrations for ${maskDatabaseUrl(UNREACHABLE_URL)}`);
     expect(lines[0]).not.toContain('nopass');
-    expect(lines[1]).toBe(
+    expect(lines[1]).toBe('-- This script is for PostgreSQL only.');
+    expect(lines[2]).toBe(
       '-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).',
     );
-    expect(lines[2]).toBe('-- This script is for FRESH databases only.');
+    expect(lines[3]).toBe('-- This script is for FRESH databases only.');
 
     // The migrations themselves create the schema and the dbos_migrations table.
     expect(out).toContain('-- Migration 1: 20240123182943_schema');
@@ -127,6 +128,18 @@ describe('migrate --print-migrations and --print-user-role', () => {
     expect(out).toContain('UPDATE "dbos"."dbos_migrations" SET "version" = 10;');
     expect(out).toContain(`UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST};`);
     expect(out).not.toContain('DO $$');
+  });
+
+  test('print-migrations 2 inserts the version row since migration 2 creates the table', async () => {
+    const { status, out, err } = await runMigrate(UNREACHABLE_URL, { printMigrations: '2' });
+    expect(status).toBe(0);
+    expect(err).toBe('');
+    expect(out).not.toContain('CREATE SCHEMA');
+    // Migration 2 creates the (empty) dbos_migrations table, so the first
+    // bookkeeping statement must be an INSERT, then UPDATEs from there on.
+    expect(out).toContain('INSERT INTO "dbos"."dbos_migrations" ("version") VALUES (2);');
+    expect(out.match(/INSERT INTO "dbos"\."dbos_migrations"/g)).toHaveLength(1);
+    expect(out).toContain('UPDATE "dbos"."dbos_migrations" SET "version" = 3;');
   });
 
   test('invalid print-migrations values are rejected on stderr with nothing on stdout', async () => {

--- a/tests/migrate_print.test.ts
+++ b/tests/migrate_print.test.ts
@@ -1,0 +1,50 @@
+import { migrate, generateMigrationSQL } from '../src/cli/migrate';
+import { allMigrations } from '../src/sysdb_migrations/internal/migrations';
+import { GlobalLogger } from '../src/telemetry/logs';
+
+describe('migrate --print-only', () => {
+  test('generateMigrationSQL emits complete, terminated SQL with version bookkeeping', () => {
+    const sql = generateMigrationSQL();
+    expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "dbos";');
+    expect(sql).toContain(
+      'create table "dbos"."dbos_migrations" ("version" bigint not null, constraint "dbos_migrations_pkey" primary key ("version"));',
+    );
+    expect(sql).toContain('create table "dbos"."operation_outputs"');
+    expect(sql).toContain('create table "dbos"."workflow_status"');
+    const version = allMigrations().length;
+    expect(sql.trimEnd().endsWith(`INSERT INTO "dbos"."dbos_migrations" ("version") VALUES (${version});`)).toBe(true);
+    // Only SQL and -- comments; every statement is terminated with a semicolon.
+    for (const line of sql.split('\n')) {
+      expect(line).not.toMatch(/\[(info|warn|error)\]/);
+    }
+  });
+
+  test('generateMigrationSQL substitutes the schema name', () => {
+    const sql = generateMigrationSQL('custom_schema');
+    expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "custom_schema";');
+    expect(sql).not.toContain('"dbos".');
+  });
+
+  test('migrate with printOnly writes SQL to stdout and executes nothing', async () => {
+    let out = '';
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      out += String(chunk);
+      return true;
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const status = await migrate(
+        ['echo should-not-run'],
+        'postgres://nonexistent-host:1/no_such_db',
+        new GlobalLogger(),
+        true,
+      );
+      expect(status).toBe(0);
+      expect(out).toBe(generateMigrationSQL() + '\n');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('--print-only'));
+    } finally {
+      stdoutSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/tests/migrate_print.test.ts
+++ b/tests/migrate_print.test.ts
@@ -3,132 +3,257 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { Client } from 'pg';
-import { migrate, generateMigrationSQL, generateMigrationStatements } from '../src/cli/migrate';
+import { migrate, generateMigrationSQL, generateMigrationStatements, MigrateOptions } from '../src/cli/migrate';
 import { allMigrations } from '../src/sysdb_migrations/internal/migrations';
-import { runSysMigrationsPg } from '../src/sysdb_migrations/migration_runner';
+import { getCurrentSysDBVersion } from '../src/sysdb_migrations/migration_runner';
 import { ensureSystemDatabase } from '../src/system_database';
+import { maskDatabaseUrl } from '../src/database_utils';
 import { GlobalLogger } from '../src/telemetry/logs';
 import { generateDBOSTestConfig } from './helpers';
 
 const FUNNY_SCHEMA = 'F8nny_sCHem@-n@m3';
-const LATEST_VERSION = allMigrations().length;
+const LATEST = allMigrations().length;
 const UNREACHABLE_URL = 'postgres://nobody:nopass@nonexistent-host.invalid:1/no_such_db';
 
-/** Print the migration SQL in-process, capturing stdout. */
-async function printMigrationSQL(systemDatabaseUrl: string, schemaName?: string): Promise<string> {
+type CliResult = { status: number; out: string; err: string };
+
+/** Run migrate() in-process, capturing stdout and stderr. */
+async function runMigrate(url: string, options: MigrateOptions): Promise<CliResult> {
   let out = '';
-  const stdoutSpy = jest
-    .spyOn(process.stdout, 'write')
-    .mockImplementation((chunk: unknown, encodingOrCb?: unknown, cb?: unknown) => {
-      out += String(chunk);
+  let err = '';
+  const impl = (sink: (s: string) => void) =>
+    ((chunk: unknown, encodingOrCb?: unknown, cb?: unknown) => {
+      sink(String(chunk));
       const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
       if (typeof callback === 'function') (callback as () => void)();
       return true;
-    });
+    }) as typeof process.stdout.write;
+  const outSpy = jest.spyOn(process.stdout, 'write').mockImplementation(impl((s) => (out += s)));
+  const errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(impl((s) => (err += s)));
   try {
-    const status = await migrate([], systemDatabaseUrl, new GlobalLogger(), true, schemaName);
-    expect(status).toBe(0);
+    const status = await migrate([], url, new GlobalLogger(), options);
+    return { status, out, err };
   } finally {
-    stdoutSpy.mockRestore();
+    outSpy.mockRestore();
+    errSpy.mockRestore();
   }
-  return out;
 }
 
-describe('migrate --print-only', () => {
-  test('generateMigrationSQL emits complete, terminated SQL with version bookkeeping', () => {
-    const sql = generateMigrationSQL();
-    expect(sql).toContain('-- For FRESH databases only');
-    expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "dbos";');
-    expect(sql).toContain(
-      'create table "dbos"."dbos_migrations" ("version" bigint not null, constraint "dbos_migrations_pkey" primary key ("version"));',
+function testUrls(dbName: string): { adminUrl: string; dbUrl: string } {
+  const config = generateDBOSTestConfig();
+  const adminUrl = new URL(config.systemDatabaseUrl!);
+  adminUrl.pathname = '/postgres';
+  const dbUrl = new URL(adminUrl.toString());
+  dbUrl.pathname = `/${dbName}`;
+  return { adminUrl: adminUrl.toString(), dbUrl: dbUrl.toString() };
+}
+
+async function recreateDatabase(adminUrl: string, dbName: string): Promise<void> {
+  const client = new Client({ connectionString: adminUrl });
+  await client.connect();
+  try {
+    await client.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+    await client.query(`CREATE DATABASE ${dbName};`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function dropDatabase(adminUrl: string, dbName: string): Promise<void> {
+  const client = new Client({ connectionString: adminUrl });
+  await client.connect();
+  try {
+    await client.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
+  } finally {
+    await client.end();
+  }
+}
+
+describe('migrate --print-migrations and --print-user-role', () => {
+  test('print-migrations all: headers, per-migration bookkeeping, pure SQL, no database needed', async () => {
+    const { status, out, err } = await runMigrate(UNREACHABLE_URL, { printMigrations: 'all' });
+    expect(status).toBe(0);
+    expect(err).toBe('');
+
+    const lines = out.split('\n');
+    expect(lines[0]).toBe(`-- DBOS system database migrations for ${maskDatabaseUrl(UNREACHABLE_URL)}`);
+    expect(lines[0]).not.toContain('nopass');
+    expect(lines[1]).toBe(
+      '-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).',
     );
-    expect(sql).toContain('create table "dbos"."operation_outputs"');
-    expect(sql).toContain('create table "dbos"."workflow_status"');
-    const version = allMigrations().length;
-    expect(sql.trimEnd().endsWith(`INSERT INTO "dbos"."dbos_migrations" ("version") VALUES (${version});`)).toBe(true);
-    // Only SQL and -- comments; every statement is terminated with a semicolon.
-    for (const line of sql.split('\n')) {
+    expect(lines[2]).toBe('-- This script is for FRESH databases only.');
+
+    // The migrations themselves create the schema and the dbos_migrations table.
+    expect(out).toContain('-- Migration 1: 20240123182943_schema');
+    expect(out).toContain('CREATE SCHEMA IF NOT EXISTS "dbos";');
+    expect(out).toContain('-- Migration 2: 20240123182944_dbos_migrations');
+
+    // Per-migration bookkeeping mirrors the runner: nothing before the
+    // dbos_migrations table exists, INSERT once, then UPDATE per migration.
+    expect(out).not.toContain('("version") VALUES (1)');
+    expect(out).toContain('INSERT INTO "dbos"."dbos_migrations" ("version") VALUES (2);');
+    expect(out.match(/INSERT INTO "dbos"\."dbos_migrations"/g)).toHaveLength(1);
+    for (let i = 3; i <= LATEST; i++) {
+      expect(out).toContain(`UPDATE "dbos"."dbos_migrations" SET "version" = ${i};`);
+    }
+    expect(out.trimEnd().endsWith(`UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST};`)).toBe(true);
+
+    // No guard blocks, no role grants, no log noise.
+    expect(out).not.toContain('DO $$');
+    expect(out).not.toContain('GRANT');
+    for (const line of lines) {
       expect(line).not.toMatch(/\[(info|warn|error)\]/);
     }
   });
 
-  test('fail-fast guard follows the dbos_migrations table creation', () => {
-    const sql = generateMigrationSQL();
-    const createIdx = sql.indexOf('create table "dbos"."dbos_migrations"');
-    const guardIdx = sql.indexOf('this script is for fresh databases only. Use dbos migrate instead.');
-    const nextMigrationIdx = sql.indexOf('-- migration 3');
-    expect(createIdx).toBeGreaterThan(-1);
-    expect(guardIdx).toBeGreaterThan(createIdx);
-    expect(guardIdx).toBeLessThan(nextMigrationIdx);
-    expect(sql).toContain('RAISE EXCEPTION');
-    expect(sql).toContain(`SELECT "version" INTO current_version FROM "dbos"."dbos_migrations"`);
+  test('print-migrations 1 is identical to all', async () => {
+    const all = await runMigrate(UNREACHABLE_URL, { printMigrations: 'all' });
+    const one = await runMigrate(UNREACHABLE_URL, { printMigrations: '1' });
+    expect(one.status).toBe(0);
+    expect(one.out).toBe(all.out);
+    expect(generateMigrationSQL('dbos', 1)).toBe(generateMigrationSQL());
   });
 
-  test('generateMigrationSQL double-quotes identifiers for a schema with special characters', () => {
-    const sql = generateMigrationSQL(FUNNY_SCHEMA);
-    expect(sql).toContain(`CREATE SCHEMA IF NOT EXISTS "${FUNNY_SCHEMA}";`);
-    expect(sql).toContain(`create table "${FUNNY_SCHEMA}"."dbos_migrations"`);
-    expect(sql).toContain(`create table "${FUNNY_SCHEMA}"."workflow_status"`);
-    expect(sql).toContain(`DBOS schema "${FUNNY_SCHEMA}" is already at version %`);
-    const version = allMigrations().length;
-    expect(
-      sql.trimEnd().endsWith(`INSERT INTO "${FUNNY_SCHEMA}"."dbos_migrations" ("version") VALUES (${version});`),
-    ).toBe(true);
-    expect(sql).not.toContain('"dbos".');
-    // The schema name never appears unquoted before a dot (which psql would fold or reject).
-    expect(sql).not.toMatch(new RegExp(`[^"]F8nny_sCHem@-n@m3"?\\.`));
+  test('print-migrations N omits the prelude and earlier migrations', async () => {
+    const { status, out, err } = await runMigrate(UNREACHABLE_URL, { printMigrations: '10' });
+    expect(status).toBe(0);
+    expect(err).toBe('');
+    expect(out).not.toContain('CREATE SCHEMA');
+    expect(out).not.toContain('FRESH databases');
+    expect(out).not.toContain('-- Migration 9');
+    expect(out).not.toContain('INSERT INTO "dbos"."dbos_migrations"');
+    expect(out).toContain('-- Migration 10');
+    expect(out).toContain('-- Migration 11');
+    expect(out).toContain('UPDATE "dbos"."dbos_migrations" SET "version" = 10;');
+    expect(out).toContain(`UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST};`);
+    expect(out).not.toContain('DO $$');
   });
 
-  test('generateMigrationSQL substitutes the schema name', () => {
-    const sql = generateMigrationSQL('custom_schema');
-    expect(sql).toContain('CREATE SCHEMA IF NOT EXISTS "custom_schema";');
-    expect(sql).not.toContain('"dbos".');
+  test('invalid print-migrations values are rejected on stderr with nothing on stdout', async () => {
+    for (const bad of ['0', String(LATEST + 1), '-1']) {
+      const res = await runMigrate(UNREACHABLE_URL, { printMigrations: bad });
+      expect(res.status).toBe(1);
+      expect(res.out).toBe('');
+      expect(res.err).toBe(`Migration ${bad} does not exist: valid migrations are 1 through ${LATEST}\n`);
+    }
+    const res = await runMigrate(UNREACHABLE_URL, { printMigrations: 'foo' });
+    expect(res.status).toBe(1);
+    expect(res.out).toBe('');
+    expect(res.err).toBe(`Invalid --print-migrations value 'foo': expected 'all' or a migration number\n`);
   });
 
-  test('delta script upgrades from version N with a version guard and no fresh prelude', () => {
-    const fromVersion = 20;
-    const sql = generateMigrationSQL('dbos', fromVersion);
-    expect(sql).toContain(`-- DBOS system database migration SQL (delta: version ${fromVersion} -> ${LATEST_VERSION})`);
-    expect(sql).toContain(`IF current_version IS DISTINCT FROM ${fromVersion} THEN`);
-    expect(sql).toContain(`this delta script requires version ${fromVersion}`);
-    // No fresh-database prelude or guard.
-    expect(sql).not.toContain('CREATE SCHEMA');
-    expect(sql).not.toContain('-- migration 1:');
-    expect(sql).not.toContain(`-- migration ${fromVersion}:`);
-    expect(sql).not.toContain('fresh databases only');
-    expect(sql).not.toContain('INSERT INTO "dbos"."dbos_migrations"');
-    // Applies exactly N+1..latest and records the version with an UPDATE.
-    expect(sql).toContain(`-- migration ${fromVersion + 1}:`);
-    expect(sql.trimEnd().endsWith(`UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST_VERSION};`)).toBe(true);
-    // The guard is the first statement, before any migration.
-    expect(sql.indexOf('IS DISTINCT FROM')).toBeLessThan(sql.indexOf(`-- migration ${fromVersion + 1}:`));
+  test('schema and role names containing quotes are rejected', async () => {
+    let res = await runMigrate(UNREACHABLE_URL, { printMigrations: 'all', schemaName: 'bad"schema' });
+    expect(res.status).toBe(1);
+    expect(res.out).toBe('');
+    expect(res.err).toBe('Schema names containing quotes are not supported\n');
+
+    res = await runMigrate(UNREACHABLE_URL, { printUserRole: true, appRole: "bad'role" });
+    expect(res.status).toBe(1);
+    expect(res.out).toBe('');
+    expect(res.err).toBe('Role names containing quotes are not supported\n');
   });
 
-  test('at the latest version, prints only a nothing-to-do comment', () => {
-    expect(generateMigrationSQL('dbos', LATEST_VERSION)).toBe(
-      `-- Database is already at the latest DBOS schema version (${LATEST_VERSION}); nothing to do.`,
+  test('print-user-role requires app-role, excludes print-migrations, and emits only grant SQL', async () => {
+    let res = await runMigrate(UNREACHABLE_URL, { printUserRole: true });
+    expect(res.status).toBe(1);
+    expect(res.out).toBe('');
+    expect(res.err).toBe('--print-user-role requires --app-role\n');
+
+    res = await runMigrate(UNREACHABLE_URL, { printMigrations: 'all', printUserRole: true, appRole: 'my-app-role' });
+    expect(res.status).toBe(1);
+    expect(res.out).toBe('');
+    expect(res.err).toBe('--print-user-role cannot be combined with --print-migrations\n');
+
+    res = await runMigrate(UNREACHABLE_URL, { printUserRole: true, appRole: 'my-app-role', schemaName: FUNNY_SCHEMA });
+    expect(res.status).toBe(0);
+    expect(res.err).toBe('');
+    const lines = res.out.trimEnd().split('\n');
+    expect(lines[0]).toBe(`-- Permissions on DBOS schema ${FUNNY_SCHEMA} for role my-app-role`);
+    expect(lines).toHaveLength(8);
+    expect(lines).toContain(`GRANT USAGE ON SCHEMA "${FUNNY_SCHEMA}" TO "my-app-role";`);
+    expect(lines).toContain(
+      `ALTER DEFAULT PRIVILEGES IN SCHEMA "${FUNNY_SCHEMA}" GRANT EXECUTE ON FUNCTIONS TO "my-app-role";`,
     );
-    expect(generateMigrationStatements('dbos', LATEST_VERSION)).toEqual([]);
-  });
-
-  test('migrate with printOnly on an unreachable database silently prints the full fresh script', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const out = await printMigrationSQL(UNREACHABLE_URL);
-      expect(out).toBe(generateMigrationSQL() + '\n');
-      expect(warnSpy).not.toHaveBeenCalled();
-      expect(errorSpy).not.toHaveBeenCalled();
-      expect(logSpy).not.toHaveBeenCalled();
-    } finally {
-      warnSpy.mockRestore();
-      errorSpy.mockRestore();
-      logSpy.mockRestore();
+    for (const line of lines) {
+      expect(line.startsWith('--') || line.startsWith('GRANT') || line.startsWith('ALTER')).toBe(true);
     }
   });
 
-  test('spawned CLI with unreachable database prints pure SQL to stdout, nothing to stderr, exit 0', () => {
+  test('printed statements apply to a fresh database and the runner then treats it as migrated', async () => {
+    const dbName = 'migrate_print_sql_test_db';
+    const { adminUrl, dbUrl } = testUrls(dbName);
+    await recreateDatabase(adminUrl, dbName);
+
+    const { status, out, err } = await runMigrate(dbUrl, { printMigrations: 'all', schemaName: FUNNY_SCHEMA });
+    expect(status).toBe(0);
+    expect(err).toBe('');
+    expect(out).toContain(`CREATE SCHEMA IF NOT EXISTS "${FUNNY_SCHEMA}";`);
+    // The schema name never appears unquoted before a dot (psql would fold or reject it).
+    expect(out).not.toMatch(/[^"]F8nny_sCHem@-n@m3"?\./);
+    expect(out).not.toContain('"dbos".');
+
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      // Apply each printed statement in autocommit, as psql would.
+      for (const stmt of generateMigrationStatements(FUNNY_SCHEMA)) {
+        await client.query(stmt);
+      }
+      const versionRows = await client.query<{ version: string }>(
+        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
+      );
+      expect(versionRows.rows).toHaveLength(1);
+      expect(Number(versionRows.rows[0].version)).toBe(LATEST);
+
+      // A real migration pass treats the scripted database as fully migrated.
+      await ensureSystemDatabase(dbUrl, new GlobalLogger(), undefined, FUNNY_SCHEMA);
+      expect(await getCurrentSysDBVersion(client, FUNNY_SCHEMA)).toBe(LATEST);
+      const afterEnsure = await client.query(`SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`);
+      expect(afterEnsure.rows).toHaveLength(1);
+    } finally {
+      await client.end();
+      await dropDatabase(adminUrl, dbName);
+    }
+  }, 60000);
+
+  test('a partial database is completed by the print-migrations latest output', async () => {
+    const dbName = 'migrate_print_partial_test_db';
+    const { adminUrl, dbUrl } = testUrls(dbName);
+    await recreateDatabase(adminUrl, dbName);
+
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      // Truncate the full script right after the version latest-1 bookkeeping.
+      const statements = generateMigrationStatements('dbos');
+      const marker = `UPDATE "dbos"."dbos_migrations" SET "version" = ${LATEST - 1};`;
+      const markerIdx = statements.indexOf(marker);
+      expect(markerIdx).toBeGreaterThan(-1);
+      for (const stmt of statements.slice(0, markerIdx + 1)) {
+        await client.query(stmt);
+      }
+      expect(await getCurrentSysDBVersion(client, 'dbos')).toBe(LATEST - 1);
+
+      // The last migration printed alone applies on top of version latest-1.
+      const { status, out } = await runMigrate(dbUrl, { printMigrations: String(LATEST) });
+      expect(status).toBe(0);
+      expect(out).not.toContain('CREATE SCHEMA');
+      expect(out).not.toContain('DO $$');
+      for (const stmt of generateMigrationStatements('dbos', LATEST)) {
+        await client.query(stmt);
+      }
+      expect(await getCurrentSysDBVersion(client, 'dbos')).toBe(LATEST);
+
+      await ensureSystemDatabase(dbUrl, new GlobalLogger());
+      expect(await getCurrentSysDBVersion(client, 'dbos')).toBe(LATEST);
+    } finally {
+      await client.end();
+      await dropDatabase(adminUrl, dbName);
+    }
+  }, 60000);
+
+  test('spawned CLI prints pure SQL to stdout, nothing to stderr, exit 0 with unreachable database', async () => {
     const cliPath = path.resolve(__dirname, '..', 'dist', 'src', 'cli', 'cli.js');
     const workDir = mkdtempSync(path.join(tmpdir(), 'dbos-migrate-print-'));
     try {
@@ -136,154 +261,43 @@ describe('migrate --print-only', () => {
         path.join(workDir, 'dbos-config.yaml'),
         `name: migrateprinttest\nsystem_database_url: ${UNREACHABLE_URL}\n`,
       );
-      const res = spawnSync(process.execPath, [cliPath, 'migrate', '--print-only'], {
-        cwd: workDir,
-        encoding: 'utf-8',
-      });
+      const spawn = (...args: string[]) =>
+        spawnSync(process.execPath, [cliPath, 'migrate', ...args], { cwd: workDir, encoding: 'utf-8' });
+
+      let res = spawn('--print-migrations', 'all');
       expect(res.status).toBe(0);
       expect(res.stderr).toBe('');
-      expect(res.stdout).toBe(generateMigrationSQL() + '\n');
+      expect(res.stdout).toBe((await runMigrate(UNREACHABLE_URL, { printMigrations: 'all' })).out);
+
+      res = spawn('--print-user-role', '-r', 'my_app_role', '-s', 'custom_schema');
+      expect(res.status).toBe(0);
+      expect(res.stderr).toBe('');
+      expect(res.stdout).toBe(
+        (
+          await runMigrate(UNREACHABLE_URL, {
+            printUserRole: true,
+            appRole: 'my_app_role',
+            schemaName: 'custom_schema',
+          })
+        ).out,
+      );
+
+      res = spawn('--print-user-role');
+      expect(res.status).toBe(1);
+      expect(res.stdout).toBe('');
+      expect(res.stderr).toContain('--app-role');
+
+      res = spawn('--print-migrations', 'all', '--print-user-role', '-r', 'my_app_role');
+      expect(res.status).toBe(1);
+      expect(res.stdout).toBe('');
+      expect(res.stderr).toContain('cannot be combined');
+
+      res = spawn('--print-migrations', 'nope');
+      expect(res.status).toBe(1);
+      expect(res.stdout).toBe('');
+      expect(res.stderr).toContain("expected 'all' or a migration number");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
-    }
-  }, 30000);
-
-  test('printed SQL applies end-to-end to a fresh database with a special-character schema', async () => {
-    const config = generateDBOSTestConfig();
-    const baseUrl = new URL(config.systemDatabaseUrl!);
-    baseUrl.pathname = '/postgres';
-    const dbName = 'migrate_print_sql_test_db';
-    const dbUrl = new URL(baseUrl.toString());
-    dbUrl.pathname = `/${dbName}`;
-
-    const adminClient = new Client({ connectionString: baseUrl.toString() });
-    await adminClient.connect();
-    await adminClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
-    await adminClient.query(`CREATE DATABASE ${dbName};`);
-    await adminClient.end();
-
-    const client = new Client({ connectionString: dbUrl.toString() });
-    await client.connect();
-    try {
-      // Connection OK but schema/table missing: the CLI prints the full fresh script.
-      expect(await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA)).toBe(generateMigrationSQL(FUNNY_SCHEMA) + '\n');
-
-      // Apply each printed statement in autocommit, as psql would.
-      const statements = generateMigrationStatements(FUNNY_SCHEMA);
-      for (const stmt of statements) {
-        await client.query(stmt);
-      }
-
-      const schemaExists = await client.query<{ exists: boolean }>(
-        'SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = $1)',
-        [FUNNY_SCHEMA],
-      );
-      expect(schemaExists.rows[0].exists).toBe(true);
-
-      for (const table of ['dbos_migrations', 'workflow_status', 'operation_outputs', 'notifications', 'streams']) {
-        const tableExists = await client.query<{ exists: boolean }>(
-          'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2)',
-          [FUNNY_SCHEMA, table],
-        );
-        expect(tableExists.rows[0].exists).toBe(true);
-      }
-
-      const versionRows = await client.query<{ version: string }>(
-        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
-      );
-      expect(versionRows.rows.length).toBe(1);
-      expect(Number(versionRows.rows[0].version)).toBe(allMigrations().length);
-
-      // Re-running the fail-fast guard on the now-migrated database aborts.
-      const guard = statements.find((s) => s.includes('fresh databases only'))!;
-      expect(guard).toBeDefined();
-      await expect(client.query(guard)).rejects.toThrow(
-        `DBOS schema "${FUNNY_SCHEMA}" is already at version ${allMigrations().length}; this script is for fresh databases only. Use dbos migrate instead.`,
-      );
-    } finally {
-      await client.end();
-      const cleanupClient = new Client({ connectionString: baseUrl.toString() });
-      await cleanupClient.connect();
-      await cleanupClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
-      await cleanupClient.end();
-    }
-  }, 60000);
-
-  test('delta script end-to-end: partial database, delta print, apply, latest, guard mismatch', async () => {
-    const partialVersion = 20;
-    const config = generateDBOSTestConfig();
-    const baseUrl = new URL(config.systemDatabaseUrl!);
-    baseUrl.pathname = '/postgres';
-    const dbName = 'migrate_print_delta_test_db';
-    const dbUrl = new URL(baseUrl.toString());
-    dbUrl.pathname = `/${dbName}`;
-
-    const adminClient = new Client({ connectionString: baseUrl.toString() });
-    await adminClient.connect();
-    await adminClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
-    await adminClient.query(`CREATE DATABASE ${dbName};`);
-    await adminClient.end();
-
-    const client = new Client({ connectionString: dbUrl.toString() });
-    await client.connect();
-    try {
-      // Build a genuinely partial database: run the real migration runner
-      // through migration N only.
-      await runSysMigrationsPg(client, allMigrations(FUNNY_SCHEMA).slice(0, partialVersion), FUNNY_SCHEMA, {
-        onWarn: () => {},
-      });
-      const partialRows = await client.query<{ version: string }>(
-        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
-      );
-      expect(Number(partialRows.rows[0].version)).toBe(partialVersion);
-
-      // The CLI connects, detects version N, and prints only the delta.
-      const printed = await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA);
-      expect(printed).toBe(generateMigrationSQL(FUNNY_SCHEMA, partialVersion) + '\n');
-      expect(printed).toContain(`(delta: version ${partialVersion} -> ${LATEST_VERSION})`);
-      expect(printed).toContain(`IF current_version IS DISTINCT FROM ${partialVersion} THEN`);
-      expect(printed).toContain(`-- migration ${partialVersion + 1}:`);
-      expect(printed).not.toContain('CREATE SCHEMA');
-      expect(printed).not.toContain(`-- migration ${partialVersion}:`);
-      expect(printed).not.toContain('fresh databases only');
-      expect(printed).toContain(`"${FUNNY_SCHEMA}"."dbos_migrations"`);
-
-      // Apply the delta statement by statement in autocommit, as psql would.
-      const deltaStatements = generateMigrationStatements(FUNNY_SCHEMA, partialVersion);
-      for (const stmt of deltaStatements) {
-        await client.query(stmt);
-      }
-      const versionRows = await client.query<{ version: string }>(
-        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
-      );
-      expect(versionRows.rows.length).toBe(1);
-      expect(Number(versionRows.rows[0].version)).toBe(LATEST_VERSION);
-
-      // A real migration pass treats the delta-migrated database as up-to-date.
-      await ensureSystemDatabase(dbUrl.toString(), new GlobalLogger(), undefined, FUNNY_SCHEMA);
-      const afterEnsure = await client.query<{ version: string }>(
-        `SELECT "version" FROM "${FUNNY_SCHEMA}"."dbos_migrations"`,
-      );
-      expect(afterEnsure.rows.length).toBe(1);
-      expect(Number(afterEnsure.rows[0].version)).toBe(LATEST_VERSION);
-
-      // At the latest version the CLI prints only the nothing-to-do comment.
-      expect(await printMigrationSQL(dbUrl.toString(), FUNNY_SCHEMA)).toBe(
-        `-- Database is already at the latest DBOS schema version (${LATEST_VERSION}); nothing to do.\n`,
-      );
-
-      // Guard mismatch: the version-N delta guard aborts on a database at a different version.
-      const guard = deltaStatements[0];
-      expect(guard).toContain('IS DISTINCT FROM');
-      await expect(client.query(guard)).rejects.toThrow(
-        `DBOS schema "${FUNNY_SCHEMA}" is at version ${LATEST_VERSION} but this delta script requires version ${partialVersion}. Regenerate it with dbos migrate --print-only.`,
-      );
-    } finally {
-      await client.end();
-      const cleanupClient = new Client({ connectionString: baseUrl.toString() });
-      await cleanupClient.connect();
-      await cleanupClient.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE);`);
-      await cleanupClient.end();
     }
   }, 60000);
 });


### PR DESCRIPTION
Ports the final design of dbos-inc/dbos-transact-py#780 to TypeScript. The earlier `--print-only` flag is replaced by two new, mutually exclusive flags on `dbos migrate`, which print SQL to stdout instead of executing anything and never connect to a database. Stdout stays pure SQL and `--` comments, so it can be piped straight into a `.sql` file; the commands exit 0 even if the database URL is unreachable.

## `--print-migrations <all|N>`

Prints the SQL of all DBOS system database migrations, or of migrations N (1-based) through the latest, including per-migration version bookkeeping that mirrors the migration runner — an interrupted apply can be resumed from the next migration number.

```shell
npx dbos migrate --print-migrations all > fresh.sql   # complete script for a FRESH database
npx dbos migrate --print-migrations 10 > delta.sql    # migrations 10 through the latest
```

The script contains `CREATE`/`DROP INDEX CONCURRENTLY`, so it must be run outside a transaction block (plain `psql`, not `psql --single-transaction`). The system database URL appears password-masked in a header comment. Invalid values (`--print-migrations 0`, `foo`, or a number beyond the latest migration) are rejected on stderr with a non-zero exit.

## `--print-user-role`

Prints the SQL granting an application role (`-r`/`--app-role`, newly added to `dbos migrate`) access to the DBOS system schema:

```shell
npx dbos migrate --print-user-role -r my_app_role > grants.sql
```

Passing `--print-user-role` without `--app-role`, or combining it with `--print-migrations`, is an error. Schema or role names containing quotes are rejected in both print modes.

`grantDbosSchemaPermissions` now shares the same statement list (`getDbosSchemaPermissionsSql`) so the printed and executed grants cannot drift.

## Deviations from the Python PR

- **No prelude statements.** Python emits `CREATE SCHEMA IF NOT EXISTS` and `CREATE TABLE IF NOT EXISTS dbos_migrations` before the migrations because its runner creates them outside the migration list. The TS migrations 1 and 2 create the schema and the `dbos_migrations` table themselves, so the printed script simply mirrors the runner: no bookkeeping is emitted until migration 2 has created the table, the first bookkeeping statement is `INSERT ... VALUES (2)`, and every later migration emits an `UPDATE`.
- **No skipped migration.** Python skips its migration 10 (a notifications primary-key backfill that its migration 1 already performs on fresh databases). The TS migration list has no fresh-database-hostile migration — TS creates the `notifications` table without a primary key and adds it in a later migration, so the full statement list applies cleanly to a fresh database (covered by tests) — and there is no skip logic.
- Migration comments include the migration name when one exists (`-- Migration 2: 20240123182944_dbos_migrations`), since TS migrations are named.

Tested in `tests/migrate_print.test.ts`: the printed statements applied one-by-one to a fresh database (including a quoting-hostile schema name `F8nny_sCHem@-n@m3`) produce a database the real runner considers fully migrated; a partial database truncated at version latest-1 is completed by the `--print-migrations <latest>` output; plus flag validation, quote rejection, `all`/`1` equivalence, and spawned-CLI stdout-purity/exit-code checks.
