### PR TITLE
Deprecate the Admin Server

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -107,7 +107,13 @@
       "properties": {
         "admin_port": {
           "type": "number",
-          "description": "The port number of the admin server (Default: 3001)"
+          "deprecated": true,
+          "description": "The port number of the admin server (Default: 3001). Deprecated: the admin server will be removed in a future version of DBOS."
+        },
+        "runAdminServer": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "Whether to run the admin server (Default: false). Deprecated: the admin server will be removed in a future version of DBOS."
         },
         "start": {
           "type": "array",

--- a/src/adminserver.ts
+++ b/src/adminserver.ts
@@ -102,6 +102,7 @@ function matchPath(pattern: string, pathname: string): Record<string, string> | 
   return params;
 }
 
+/** @deprecated The admin server is deprecated and will be removed in a future version of DBOS. */
 export class DBOSAdminServer {
   static setupAdminApp(dbosExec: DBOSExecutor): http.Server {
     const routes: Route[] = [];

--- a/src/config.ts
+++ b/src/config.ts
@@ -229,7 +229,7 @@ export function translateRuntimeConfig(
   config: Partial<DBOSRuntimeConfig & DBOSConfig> /*eww*/ = {},
 ): DBOSRuntimeConfig {
   return {
-    runAdminServer: config.runAdminServer ?? true,
+    runAdminServer: config.runAdminServer ?? false,
     admin_port: config.admin_port ?? config.adminPort ?? 3001,
     start: config.start ?? [],
     setup: config.setup ?? [],

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -137,7 +137,12 @@ export interface DBOSConfig {
    */
   otelAttributeFormat?: OtelAttributeFormat;
 
+  /** @deprecated The admin server is deprecated and will be removed in a future version of DBOS. */
   adminPort?: number;
+  /**
+   * Whether to run the admin server. Defaults to `false` outside DBOS Cloud.
+   * @deprecated The admin server is deprecated and will be removed in a future version of DBOS.
+   */
   runAdminServer?: boolean;
 
   applicationVersion?: string;
@@ -171,7 +176,9 @@ export interface DBOSConfig {
 }
 
 export interface DBOSRuntimeConfig {
+  /** @deprecated The admin server is deprecated and will be removed in a future version of DBOS. */
   admin_port: number;
+  /** @deprecated The admin server is deprecated and will be removed in a future version of DBOS. */
   runAdminServer: boolean;
   start: string[];
   setup: string[];

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -532,7 +532,7 @@ export class DBOS {
     const logger = DBOS.logger;
     if (runtimeConfig.runAdminServer) {
       // In DBOS Cloud the admin server is forced on, so there is nothing for the user to act on.
-      if (process.env.DBOS__CLOUD !== 'true') {
+      if (!globalParams.dbosCloud) {
         logger.warn('The DBOS admin server is deprecated and will be removed in a future version of DBOS.');
       }
       const adminApp = DBOSAdminServer.setupAdminApp(executor);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -523,6 +523,9 @@ export class DBOS {
     // Start the DBOS admin server
     const logger = DBOS.logger;
     if (runtimeConfig.runAdminServer) {
+      if (!globalParams.dbosCloud) {
+        logger.warn('The DBOS admin server is deprecated and will be removed in a future version of DBOS.');
+      }
       const adminApp = DBOSAdminServer.setupAdminApp(executor);
       try {
         await DBOSAdminServer.checkPortAvailabilityIPv4Ipv6(runtimeConfig.admin_port, logger as GlobalLogger);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -425,14 +425,6 @@ export class DBOS {
     let internalConfig = DBOS.#dbosConfig ? translateDbosConfig(DBOS.#dbosConfig) : getDbosConfig(configFile);
     let runtimeConfig = DBOS.#dbosConfig ? translateRuntimeConfig(DBOS.#dbosConfig) : getRuntimeConfig(configFile);
 
-    // Retained unresolved so the deprecation notice below can tell "unset" from "explicitly off".
-    const adminServerConfig = DBOS.#dbosConfig
-      ? { runAdminServer: DBOS.#dbosConfig.runAdminServer, adminPort: DBOS.#dbosConfig.adminPort }
-      : {
-          runAdminServer: configFile.runtimeConfig?.runAdminServer,
-          adminPort: configFile.runtimeConfig?.admin_port,
-        };
-
     if (process.env.DBOS__CLOUD === 'true') {
       [internalConfig, runtimeConfig] = overwriteConfigForDBOSCloud(internalConfig, runtimeConfig, configFile);
     }
@@ -551,11 +543,6 @@ export class DBOS {
       } catch (e) {
         logger.warn(`Unable to start DBOS admin server on port ${runtimeConfig.admin_port}`);
       }
-    } else if (adminServerConfig.runAdminServer === undefined && adminServerConfig.adminPort !== undefined) {
-      // These users configured a port but relied on the server starting by default, which it no longer does.
-      logger.warn(
-        'The DBOS admin server is deprecated and no longer starts by default. Set runAdminServer to true to re-enable it.',
-      );
     }
   }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -425,6 +425,14 @@ export class DBOS {
     let internalConfig = DBOS.#dbosConfig ? translateDbosConfig(DBOS.#dbosConfig) : getDbosConfig(configFile);
     let runtimeConfig = DBOS.#dbosConfig ? translateRuntimeConfig(DBOS.#dbosConfig) : getRuntimeConfig(configFile);
 
+    // Retained unresolved so the deprecation notice below can tell "unset" from "explicitly off".
+    const adminServerConfig = DBOS.#dbosConfig
+      ? { runAdminServer: DBOS.#dbosConfig.runAdminServer, adminPort: DBOS.#dbosConfig.adminPort }
+      : {
+          runAdminServer: configFile.runtimeConfig?.runAdminServer,
+          adminPort: configFile.runtimeConfig?.admin_port,
+        };
+
     if (process.env.DBOS__CLOUD === 'true') {
       [internalConfig, runtimeConfig] = overwriteConfigForDBOSCloud(internalConfig, runtimeConfig, configFile);
     }
@@ -523,7 +531,8 @@ export class DBOS {
     // Start the DBOS admin server
     const logger = DBOS.logger;
     if (runtimeConfig.runAdminServer) {
-      if (!globalParams.dbosCloud) {
+      // In DBOS Cloud the admin server is forced on, so there is nothing for the user to act on.
+      if (process.env.DBOS__CLOUD !== 'true') {
         logger.warn('The DBOS admin server is deprecated and will be removed in a future version of DBOS.');
       }
       const adminApp = DBOSAdminServer.setupAdminApp(executor);
@@ -542,6 +551,11 @@ export class DBOS {
       } catch (e) {
         logger.warn(`Unable to start DBOS admin server on port ${runtimeConfig.admin_port}`);
       }
+    } else if (adminServerConfig.runAdminServer === undefined && adminServerConfig.adminPort !== undefined) {
+      // These users configured a port but relied on the server starting by default, which it no longer does.
+      logger.warn(
+        'The DBOS admin server is deprecated and no longer starts by default. Set runAdminServer to true to re-enable it.',
+      );
     }
   }
 

--- a/tests/adminserver.test.ts
+++ b/tests/adminserver.test.ts
@@ -36,9 +36,24 @@ describe('not-running-admin-server', () => {
     await DBOS.shutdown();
   });
 
+  test('test-admin-server-off-by-default', async () => {
+    config = generateDBOSTestConfig();
+    DBOS.setConfig({ ...config });
+    await setUpDBOSTestSysDb(config);
+    await DBOS.launch();
+
+    await expect(async () => {
+      await fetch(`http://localhost:3001${HealthUrl}`, {
+        method: 'GET',
+      });
+    }).rejects.toThrow();
+
+    await DBOS.shutdown();
+  });
+
   test('test-admin-server-set-port', async () => {
     config = generateDBOSTestConfig();
-    DBOS.setConfig({ ...config, adminPort: 4444 });
+    DBOS.setConfig({ ...config, runAdminServer: true, adminPort: 4444 });
     await setUpDBOSTestSysDb(config);
     await DBOS.launch();
 

--- a/tests/adminserver.test.ts
+++ b/tests/adminserver.test.ts
@@ -51,6 +51,21 @@ describe('not-running-admin-server', () => {
     await DBOS.shutdown();
   });
 
+  test('test-admin-port-alone-does-not-start-server', async () => {
+    config = generateDBOSTestConfig();
+    DBOS.setConfig({ ...config, adminPort: 4444 });
+    await setUpDBOSTestSysDb(config);
+    await DBOS.launch();
+
+    await expect(async () => {
+      await fetch(`http://localhost:4444${HealthUrl}`, {
+        method: 'GET',
+      });
+    }).rejects.toThrow();
+
+    await DBOS.shutdown();
+  });
+
   test('test-admin-server-set-port', async () => {
     config = generateDBOSTestConfig();
     DBOS.setConfig({ ...config, runAdminServer: true, adminPort: 4444 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -2,15 +2,9 @@ import { spawn, execSync, ChildProcess } from 'child_process';
 import { Writable } from 'stream';
 import { Client } from 'pg';
 import { generateDBOSTestConfig } from './helpers';
-import { HealthUrl } from '../src/adminserver';
 import { sleepms } from '../src/utils';
 
-async function waitForMessageTest(
-  command: ChildProcess,
-  port: string,
-  adminPort?: string,
-  checkResponse: boolean = true,
-) {
+async function waitForMessageTest(command: ChildProcess, port: string, checkResponse: boolean = true) {
   const stdout = command.stdout as unknown as Writable;
   const stdin = command.stdin as unknown as Writable;
   const stderr = command.stderr as unknown as Writable;
@@ -24,10 +18,6 @@ async function waitForMessageTest(
     process.stderr.write(`[child stderr]: ${data}`);
   });
 
-  if (!adminPort) {
-    adminPort = (Number(port) + 1).toString();
-  }
-
   try {
     const maxAttempts = 10;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -36,8 +26,6 @@ async function waitForMessageTest(
           const response = await fetch(`http://127.0.0.1:${port}/greeting/dbos`);
           expect(response.status).toBe(200);
         }
-        const healthRes = await fetch(`http://127.0.0.1:${adminPort}${HealthUrl}`);
-        expect(healthRes.status).toBe(200);
       } catch (error) {
         if (attempt < maxAttempts - 1) {
           await sleepms(1000);


### PR DESCRIPTION
The admin server is not part of the documented public interface of DBOS. This PR formally deprecates it and switches it off by default. It will be removed in a future release.