### PR TITLE
Re-stamp workflow executor_id when successfully checkpointing a step

### DIFF
--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -4398,6 +4398,16 @@ export class SystemDatabase {
         );
         throw new DBOSWorkflowConflictError(workflowID);
       }
+      if (Number(out?.rows?.[0]?.completed_at_epoch_ms) === endTimeEpochMs) {
+        // Winning the checkpoint proves this executor is advancing the workflow:
+        // claim the executor_id marker (skips the write when already ours).
+        await client.query(
+          `UPDATE "${this.schemaName}".workflow_status
+             SET executor_id = $1
+           WHERE workflow_uuid = $2 AND executor_id IS DISTINCT FROM $1`,
+          [globalParams.executorID, workflowID],
+        );
+      }
     } catch (error) {
       const err: DatabaseError = error as DatabaseError;
       if (err.code === '40001' || err.code === '23505') {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -115,6 +115,40 @@ describe('recovery-tests', () => {
     }
   }
 
+  class RestampExecutor {
+    static stepOneDone = new Event();
+    static proceed = new Event();
+
+    @DBOS.workflow()
+    static async twoStepWorkflow() {
+      await DBOS.runStep(() => Promise.resolve(1), { name: 'stepOne' });
+      RestampExecutor.stepOneDone.set();
+      await RestampExecutor.proceed.wait();
+      return await DBOS.runStep(() => Promise.resolve(2), { name: 'stepTwo' });
+    }
+  }
+
+  test('restamp-executor-id-on-step-checkpoint', async () => {
+    const handle = await DBOS.startWorkflow(RestampExecutor).twoStepWorkflow();
+    await RestampExecutor.stepOneDone.wait();
+
+    // Simulate another executor holding the marker.
+    await systemDBClient.query(`UPDATE dbos.workflow_status SET executor_id=$1 WHERE workflow_uuid=$2`, [
+      'stale-executor',
+      handle.workflowID,
+    ]);
+
+    RestampExecutor.proceed.set();
+    await expect(handle.getResult()).resolves.toBe(2);
+
+    // Checkpointing the second step should have re-stamped executor_id to this executor.
+    const result = await systemDBClient.query<{ executor_id: string }>(
+      `SELECT executor_id FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(result.rows[0].executor_id).toBe(globalParams.executorID);
+  });
+
   test('dead-letter-queue', async () => {
     LocalRecovery.cnt = 0;
 


### PR DESCRIPTION
When an executor "wins" the checkpointing race, it should restamp the executor ID column in the status table so reporting is accurate.