### PR TITLE
Update workflow status with a final result only when status is PENDING

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -739,7 +739,10 @@ export class DBOSExecutor {
     };
 
     const eserializer = this.serializer;
-    async function handleWorkflowError(err: Error, exec: DBOSExecutor): Promise<{ recorded: boolean; error: Error }> {
+    async function handleWorkflowError(
+      err: Error,
+      exec: DBOSExecutor,
+    ): Promise<{ recorded: boolean; reviveError: () => Promise<Error> }> {
       // Record the error.
       const e = err as Error & { dbos_already_logged?: boolean };
       const sererr = await serializeResErrorWithSerializer(e, eserializer, ires.serialization ?? null);
@@ -756,7 +759,9 @@ export class DBOSExecutor {
       span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
       return {
         recorded,
-        error: await deserializeResError(sererr.serializedValue, sererr.serialization, eserializer),
+        // deserializeResError can throw directly if the serialized error represents a portable workflow error.
+        // Defer this until we check whether the error has been recorded.
+        reviveError: () => deserializeResError(sererr.serializedValue, sererr.serialization, eserializer),
       };
     }
 
@@ -872,12 +877,15 @@ export class DBOSExecutor {
               pendingAdopt = notRecordedWarning;
             }
           } else {
-            const { recorded, error } = await handleWorkflowError(err as Error, this);
+            const { recorded, reviveError } = await handleWorkflowError(err as Error, this);
             if (recorded) {
               // If we want to be consistent about what is thrown (stored result vs live)
               //  we would have to do this.  It is a breaking change in the sense that it
               //  is a behavior change, but it would "break" things that are already broken
-              throw serializationType === 'portable' ? error : err;
+              if (serializationType === 'portable') {
+                throw await reviveError();
+              }
+              throw err;
             }
             pendingAdopt = notRecordedWarning;
           }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -763,9 +763,19 @@ export class DBOSExecutor {
     // final status overrides anything a caller stamped before parking.
     const adoptRecordedOutcome = async (warning: string): Promise<R> => {
       this.logger.warn(warning);
-      const recordedResult = (await this.systemDatabase.awaitWorkflowResult(workflowID))!;
-      span.setAttribute('cached', true);
       try {
+        // The workflow's row is known to have existed (this run was dispatched
+        // from it), so fail fast if it is missing: a missing row means it was
+        // deleted, not that it has yet to be inserted.
+        const recordedResult = (await this.systemDatabase.awaitWorkflowResult(
+          workflowID,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          /* failIfMissing */ true,
+        ))!;
+        span.setAttribute('cached', true);
         if (recordedResult.cancelled) {
           // awaitWorkflowResult reports a CANCELLED row from an awaiter's point
           // of view, but this outcome is delivered to the workflow's own handle:

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -756,16 +756,11 @@ export class DBOSExecutor {
       };
     }
 
-    // The terminal-outcome write applies only while the workflow's row is
-    // PENDING. When the write does not land, this run no longer owns the
-    // workflow's outcome (cancelled, dead-lettered, completed by a concurrent
-    // execution, or handed back to the queue by a resume): park the run and
-    // deliver the recorded outcome through its own handle instead of the
-    // locally computed one.
-    const adoptRecordedOutcome = async (): Promise<R> => {
-      this.logger.warn(
-        `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`,
-      );
+    // This run does not own the workflow's outcome: park the run and deliver
+    // the recorded outcome through its own handle instead of the locally
+    // computed one.
+    const adoptRecordedOutcome = async (warning: string): Promise<R> => {
+      this.logger.warn(warning);
       const recordedResult = (await this.systemDatabase.awaitWorkflowResult(workflowID))!;
       if (recordedResult.cancelled) {
         // awaitWorkflowResult reports a CANCELLED row from an awaiter's point
@@ -778,6 +773,8 @@ export class DBOSExecutor {
       }
       return await DBOSExecutor.reviveResultOrError<R>(recordedResult, this.serializer);
     };
+
+    const notRecordedWarning = `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`;
 
     const runWorkflow = async () => {
       let result: R;
@@ -822,30 +819,31 @@ export class DBOSExecutor {
         releaseRunningWorkflow();
         const recorded = await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
         if (!recorded) {
-          result = await adoptRecordedOutcome();
+          result = await adoptRecordedOutcome(notRecordedWarning);
         }
         span.setStatus({ code: SpanStatusCode.OK });
       } catch (err) {
         if (err instanceof DBOSWorkflowConflictError) {
-          // Retrieve the handle and wait for the result.
-          const retrievedHandle = this.retrieveWorkflow<R>(workflowID);
-          result = await retrievedHandle.getResult();
+          // Another execution owns this workflow's step checkpoints. Release
+          // before parking so a resume re-dispatched here is not blocked.
+          releaseRunningWorkflow();
+          result = await adoptRecordedOutcome(`Aborting duplicate execution of workflow ${workflowID}.`);
           span.setAttribute('cached', true);
           span.setStatus({ code: SpanStatusCode.OK });
         } else if (err instanceof DBOSWorkflowCancelledError) {
           span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           internalStatus.error = err.message;
           if (err.workflowID === workflowID) {
-            // The row is already durably CANCELLED (resumable): release now so
-            // a resume re-dispatched here is not blocked during async unwind.
+            // The run observed its own cancellation. Park the execution.
             releaseRunningWorkflow();
-            internalStatus.status = StatusString.CANCELLED;
-            throw err;
+            result = await adoptRecordedOutcome(
+              `Workflow ${workflowID} was cancelled during execution. Waiting for the recorded outcome`,
+            );
           } else {
             const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
             const { recorded } = await handleWorkflowError(e as Error, this);
             if (!recorded) {
-              result = await adoptRecordedOutcome();
+              result = await adoptRecordedOutcome(notRecordedWarning);
             } else {
               throw e;
             }
@@ -853,7 +851,7 @@ export class DBOSExecutor {
         } else {
           const { recorded, error } = await handleWorkflowError(err as Error, this);
           if (!recorded) {
-            result = await adoptRecordedOutcome();
+            result = await adoptRecordedOutcome(notRecordedWarning);
           } else if (serializationType === 'portable') {
             // If we want to be consistent about what is thrown (stored result vs live)
             //  we would have to do this.  It is a breaking change in the sense that it

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -797,7 +797,13 @@ export class DBOSExecutor {
     const notRecordedWarning = `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`;
 
     const runWorkflow = async () => {
-      let result: R;
+      let result!: R;
+      // Set when the SUCCESS write is refused: the park runs after the
+      // try/catch below, so an error rethrown while adopting the recorded
+      // outcome propagates to the handle instead of re-entering the workflow
+      // error-handling path (which would attempt a second, doomed outcome
+      // write and park again).
+      let adoptOutcomeOfRefusedSuccess = false;
 
       // Execute the workflow.
       try {
@@ -839,9 +845,10 @@ export class DBOSExecutor {
         releaseRunningWorkflow();
         const recorded = await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
         if (!recorded) {
-          result = await adoptRecordedOutcome(notRecordedWarning);
+          adoptOutcomeOfRefusedSuccess = true;
+        } else {
+          span.setStatus({ code: SpanStatusCode.OK });
         }
-        span.setStatus({ code: SpanStatusCode.OK });
       } catch (err) {
         if (err instanceof DBOSWorkflowConflictError) {
           // Another execution owns this workflow's step checkpoints. Release
@@ -878,7 +885,18 @@ export class DBOSExecutor {
           }
         }
       } finally {
-        this.tracer.endSpan(span);
+        // The refused-success park below still needs the span (it stamps the
+        // adopted outcome on it), so it ends the span itself.
+        if (!adoptOutcomeOfRefusedSuccess) {
+          this.tracer.endSpan(span);
+        }
+      }
+      if (adoptOutcomeOfRefusedSuccess) {
+        try {
+          result = await adoptRecordedOutcome(notRecordedWarning);
+        } finally {
+          this.tracer.endSpan(span);
+        }
       }
       return result;
     };

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -758,20 +758,30 @@ export class DBOSExecutor {
 
     // This run does not own the workflow's outcome: park the run and deliver
     // the recorded outcome through its own handle instead of the locally
-    // computed one.
+    // computed one. The span reflects the adopted outcome — `cached` marks a
+    // result served from the store rather than computed by this run, and the
+    // final status overrides anything a caller stamped before parking.
     const adoptRecordedOutcome = async (warning: string): Promise<R> => {
       this.logger.warn(warning);
       const recordedResult = (await this.systemDatabase.awaitWorkflowResult(workflowID))!;
-      if (recordedResult.cancelled) {
-        // awaitWorkflowResult reports a CANCELLED row from an awaiter's point
-        // of view, but this outcome is delivered to the workflow's own handle:
-        // report the workflow's cancellation.
-        throw new DBOSWorkflowCancelledError(workflowID);
+      span.setAttribute('cached', true);
+      try {
+        if (recordedResult.cancelled) {
+          // awaitWorkflowResult reports a CANCELLED row from an awaiter's point
+          // of view, but this outcome is delivered to the workflow's own handle:
+          // report the workflow's cancellation.
+          throw new DBOSWorkflowCancelledError(workflowID);
+        }
+        if (recordedResult.maxRecoveryAttemptsExceeded) {
+          throw new DBOSMaxRecoveryAttemptsExceededError(workflowID, maxRecoveryAttempts);
+        }
+        const adopted = await DBOSExecutor.reviveResultOrError<R>(recordedResult, this.serializer);
+        span.setStatus({ code: SpanStatusCode.OK });
+        return adopted;
+      } catch (e) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (e as Error).message });
+        throw e;
       }
-      if (recordedResult.maxRecoveryAttemptsExceeded) {
-        throw new DBOSMaxRecoveryAttemptsExceededError(workflowID, maxRecoveryAttempts);
-      }
-      return await DBOSExecutor.reviveResultOrError<R>(recordedResult, this.serializer);
     };
 
     const notRecordedWarning = `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`;
@@ -828,11 +838,7 @@ export class DBOSExecutor {
           // before parking so a resume re-dispatched here is not blocked.
           releaseRunningWorkflow();
           result = await adoptRecordedOutcome(`Aborting duplicate execution of workflow ${workflowID}.`);
-          span.setAttribute('cached', true);
-          span.setStatus({ code: SpanStatusCode.OK });
         } else if (err instanceof DBOSWorkflowCancelledError) {
-          span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-          internalStatus.error = err.message;
           if (err.workflowID === workflowID) {
             // The run observed its own cancellation. Park the execution.
             releaseRunningWorkflow();

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -4,6 +4,7 @@ import {
   DBOSWorkflowConflictError,
   DBOSNotRegisteredError,
   DBOSMaxStepRetriesError,
+  DBOSMaxRecoveryAttemptsExceededError,
   DBOSWorkflowCancelledError,
   DBOSUnexpectedStepError,
   DBOSAwaitedWorkflowCancelledError,
@@ -738,7 +739,7 @@ export class DBOSExecutor {
     };
 
     const eserializer = this.serializer;
-    async function handleWorkflowError(err: Error, exec: DBOSExecutor) {
+    async function handleWorkflowError(err: Error, exec: DBOSExecutor): Promise<{ recorded: boolean; error: Error }> {
       // Record the error.
       const e = err as Error & { dbos_already_logged?: boolean };
       exec.logger.error(e);
@@ -747,10 +748,36 @@ export class DBOSExecutor {
       internalStatus.error = sererr.serializedValue;
       internalStatus.status = StatusString.ERROR;
       releaseRunningWorkflow();
-      await exec.systemDatabase.recordWorkflowError(workflowID, internalStatus);
+      const recorded = await exec.systemDatabase.recordWorkflowError(workflowID, internalStatus);
       span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
-      return await deserializeResError(sererr.serializedValue, sererr.serialization, eserializer);
+      return {
+        recorded,
+        error: await deserializeResError(sererr.serializedValue, sererr.serialization, eserializer),
+      };
     }
+
+    // The terminal-outcome write applies only while the workflow's row is
+    // PENDING. When the write does not land, this run no longer owns the
+    // workflow's outcome (cancelled, dead-lettered, completed by a concurrent
+    // execution, or handed back to the queue by a resume): park the run and
+    // deliver the recorded outcome through its own handle instead of the
+    // locally computed one.
+    const adoptRecordedOutcome = async (): Promise<R> => {
+      this.logger.warn(
+        `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`,
+      );
+      const recordedResult = (await this.systemDatabase.awaitWorkflowResult(workflowID))!;
+      if (recordedResult.cancelled) {
+        // awaitWorkflowResult reports a CANCELLED row from an awaiter's point
+        // of view, but this outcome is delivered to the workflow's own handle:
+        // report the workflow's cancellation.
+        throw new DBOSWorkflowCancelledError(workflowID);
+      }
+      if (recordedResult.maxRecoveryAttemptsExceeded) {
+        throw new DBOSMaxRecoveryAttemptsExceededError(workflowID, maxRecoveryAttempts);
+      }
+      return await DBOSExecutor.reviveResultOrError<R>(recordedResult, this.serializer);
+    };
 
     const runWorkflow = async () => {
       let result: R;
@@ -793,7 +820,10 @@ export class DBOSExecutor {
         internalStatus.output = funcResult.stringified;
         internalStatus.status = StatusString.SUCCESS;
         releaseRunningWorkflow();
-        await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
+        const recorded = await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
+        if (!recorded) {
+          result = await adoptRecordedOutcome();
+        }
         span.setStatus({ code: SpanStatusCode.OK });
       } catch (err) {
         if (err instanceof DBOSWorkflowConflictError) {
@@ -813,18 +843,25 @@ export class DBOSExecutor {
             throw err;
           } else {
             const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
-            await handleWorkflowError(e as Error, this);
-            throw e;
+            const { recorded } = await handleWorkflowError(e as Error, this);
+            if (!recorded) {
+              result = await adoptRecordedOutcome();
+            } else {
+              throw e;
+            }
           }
         } else {
-          // If we want to be consistent about what is thrown (stored result vs live)
-          //  we would have to do this.  It is a breaking change in the sense that it
-          //  is a behavior change, but it would "break" things that are already broken
-          if (serializationType === 'portable') {
-            throw await handleWorkflowError(err as Error, this);
+          const { recorded, error } = await handleWorkflowError(err as Error, this);
+          if (!recorded) {
+            result = await adoptRecordedOutcome();
+          } else if (serializationType === 'portable') {
+            // If we want to be consistent about what is thrown (stored result vs live)
+            //  we would have to do this.  It is a breaking change in the sense that it
+            //  is a behavior change, but it would "break" things that are already broken
+            throw error;
+          } else {
+            throw err;
           }
-          await handleWorkflowError(err as Error, this);
-          throw err;
         }
       } finally {
         this.tracer.endSpan(span);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -742,13 +742,17 @@ export class DBOSExecutor {
     async function handleWorkflowError(err: Error, exec: DBOSExecutor): Promise<{ recorded: boolean; error: Error }> {
       // Record the error.
       const e = err as Error & { dbos_already_logged?: boolean };
-      exec.logger.error(e);
-      e.dbos_already_logged = true;
       const sererr = await serializeResErrorWithSerializer(e, eserializer, ires.serialization ?? null);
       internalStatus.error = sererr.serializedValue;
       internalStatus.status = StatusString.ERROR;
       releaseRunningWorkflow();
       const recorded = await exec.systemDatabase.recordWorkflowError(workflowID, internalStatus);
+      if (recorded) {
+        exec.logger.error(e);
+        e.dbos_already_logged = true;
+      } else {
+        exec.logger.debug(e);
+      }
       span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
       return {
         recorded,
@@ -797,7 +801,7 @@ export class DBOSExecutor {
     const notRecordedWarning = `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`;
 
     const runWorkflow = async () => {
-      let result!: R;
+      let result: R;
       // Set when the SUCCESS write is refused: the park runs after the
       // try/catch below, so an error rethrown while adopting the recorded
       // outcome propagates to the handle instead of re-entering the workflow
@@ -858,6 +862,7 @@ export class DBOSExecutor {
         } else if (err instanceof DBOSWorkflowCancelledError) {
           if (err.workflowID === workflowID) {
             // The run observed its own cancellation. Park the execution.
+            // Of course this relies on the user not abusing DBOSWorkflowCancelledError to not hang.
             releaseRunningWorkflow();
             result = await adoptRecordedOutcome(
               `Workflow ${workflowID} was cancelled during execution. Waiting for the recorded outcome`,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -801,109 +801,93 @@ export class DBOSExecutor {
     const notRecordedWarning = `Workflow ${workflowID} outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome`;
 
     const runWorkflow = async () => {
-      let result: R;
-      // Set when the SUCCESS write is refused: the park runs after the
-      // try/catch below, so an error rethrown while adopting the recorded
-      // outcome propagates to the handle instead of re-entering the workflow
-      // error-handling path (which would attempt a second, doomed outcome
-      // write and park again).
-      let adoptOutcomeOfRefusedSuccess = false;
-
-      // Execute the workflow.
       try {
-        const callResult = await runWithTrace(span, async () => {
-          return await runWithParentContext(
-            pctx,
-            {
-              presetID,
-              workflowTimeoutMS: undefined, // Becomes deadline
-              deadlineEpochMS,
-              workflowId: workflowID,
-              logger: this.ctxLogger,
-              curWFFunctionId: undefined,
-              serializationType,
-            },
-            () => {
-              const callPromise = wf.call(params.configuredInstance, ...args);
+        let result: R;
+        // The warning to park under, set by whichever site found that this run
+        // does not own the workflow's outcome.
+        let pendingAdopt: string;
 
-              if ($deadlineEpochMS === undefined) {
-                return callPromise;
-              } else {
-                return callPromiseWithTimeout(callPromise, $deadlineEpochMS, this.systemDatabase);
-              }
-            },
-          );
-        });
-
-        result = callResult!;
-
-        const funcResult = await serializeFunctionInputOutputWithSerializer(
-          result,
-          [wfname, '<result>'],
-          this.serializer,
-          ires.serialization,
-        );
-        result = funcResult.deserialized;
-        internalStatus.output = funcResult.stringified;
-        internalStatus.status = StatusString.SUCCESS;
-        releaseRunningWorkflow();
-        const recorded = await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
-        if (!recorded) {
-          adoptOutcomeOfRefusedSuccess = true;
-        } else {
-          span.setStatus({ code: SpanStatusCode.OK });
-        }
-      } catch (err) {
-        if (err instanceof DBOSWorkflowConflictError) {
-          // Another execution owns this workflow's step checkpoints. Release
-          // before parking so a resume re-dispatched here is not blocked.
-          releaseRunningWorkflow();
-          result = await adoptRecordedOutcome(`Aborting duplicate execution of workflow ${workflowID}.`);
-        } else if (err instanceof DBOSWorkflowCancelledError) {
-          if (err.workflowID === workflowID) {
-            // The run observed its own cancellation. Park the execution.
-            // Of course this relies on the user not abusing DBOSWorkflowCancelledError to not hang.
-            releaseRunningWorkflow();
-            result = await adoptRecordedOutcome(
-              `Workflow ${workflowID} was cancelled during execution. Waiting for the recorded outcome`,
-            );
-          } else {
-            const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
-            const { recorded } = await handleWorkflowError(e as Error, this);
-            if (!recorded) {
-              result = await adoptRecordedOutcome(notRecordedWarning);
-            } else {
-              throw e;
-            }
-          }
-        } else {
-          const { recorded, error } = await handleWorkflowError(err as Error, this);
-          if (!recorded) {
-            result = await adoptRecordedOutcome(notRecordedWarning);
-          } else if (serializationType === 'portable') {
-            // If we want to be consistent about what is thrown (stored result vs live)
-            //  we would have to do this.  It is a breaking change in the sense that it
-            //  is a behavior change, but it would "break" things that are already broken
-            throw error;
-          } else {
-            throw err;
-          }
-        }
-      } finally {
-        // The refused-success park below still needs the span (it stamps the
-        // adopted outcome on it), so it ends the span itself.
-        if (!adoptOutcomeOfRefusedSuccess) {
-          this.tracer.endSpan(span);
-        }
-      }
-      if (adoptOutcomeOfRefusedSuccess) {
+        // Execute the workflow.
         try {
-          result = await adoptRecordedOutcome(notRecordedWarning);
-        } finally {
-          this.tracer.endSpan(span);
+          const callResult = await runWithTrace(span, async () => {
+            return await runWithParentContext(
+              pctx,
+              {
+                presetID,
+                workflowTimeoutMS: undefined, // Becomes deadline
+                deadlineEpochMS,
+                workflowId: workflowID,
+                logger: this.ctxLogger,
+                curWFFunctionId: undefined,
+                serializationType,
+              },
+              () => {
+                const callPromise = wf.call(params.configuredInstance, ...args);
+
+                if ($deadlineEpochMS === undefined) {
+                  return callPromise;
+                } else {
+                  return callPromiseWithTimeout(callPromise, $deadlineEpochMS, this.systemDatabase);
+                }
+              },
+            );
+          });
+
+          result = callResult!;
+
+          const funcResult = await serializeFunctionInputOutputWithSerializer(
+            result,
+            [wfname, '<result>'],
+            this.serializer,
+            ires.serialization,
+          );
+          result = funcResult.deserialized;
+          internalStatus.output = funcResult.stringified;
+          internalStatus.status = StatusString.SUCCESS;
+          releaseRunningWorkflow();
+          const recorded = await this.systemDatabase.recordWorkflowOutput(workflowID, internalStatus);
+          if (recorded) {
+            span.setStatus({ code: SpanStatusCode.OK });
+            return result;
+          }
+          pendingAdopt = notRecordedWarning;
+        } catch (err) {
+          if (err instanceof DBOSWorkflowConflictError) {
+            // Another execution owns this workflow's step checkpoints. Release
+            // before parking so a resume re-dispatched here is not blocked.
+            releaseRunningWorkflow();
+            pendingAdopt = `Aborting duplicate execution of workflow ${workflowID}.`;
+          } else if (err instanceof DBOSWorkflowCancelledError) {
+            if (err.workflowID === workflowID) {
+              // The run observed its own cancellation. Park the execution.
+              // Of course this relies on the user not abusing DBOSWorkflowCancelledError to not hang.
+              releaseRunningWorkflow();
+              pendingAdopt = `Workflow ${workflowID} was cancelled during execution. Waiting for the recorded outcome`;
+            } else {
+              const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
+              const { recorded } = await handleWorkflowError(e as Error, this);
+              if (recorded) {
+                throw e;
+              }
+              pendingAdopt = notRecordedWarning;
+            }
+          } else {
+            const { recorded, error } = await handleWorkflowError(err as Error, this);
+            if (recorded) {
+              // If we want to be consistent about what is thrown (stored result vs live)
+              //  we would have to do this.  It is a breaking change in the sense that it
+              //  is a behavior change, but it would "break" things that are already broken
+              throw serializationType === 'portable' ? error : err;
+            }
+            pendingAdopt = notRecordedWarning;
+          }
         }
+
+        // Reached only when a refusal above set pendingAdopt.
+        return await adoptRecordedOutcome(pendingAdopt);
+      } finally {
+        this.tracer.endSpan(span);
       }
-      return result;
     };
 
     if (

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1080,53 +1080,57 @@ export class SystemDatabase {
   }
 
   @dbRetry()
-  async recordWorkflowOutput(workflowID: string, status: WorkflowStatusInternal): Promise<void> {
+  async recordWorkflowOutput(workflowID: string, status: WorkflowStatusInternal): Promise<boolean> {
     const client = await this.pool.connect();
     try {
-      await this.#recordWorkflowOutcome(client, workflowID, StatusString.SUCCESS, { output: status.output });
+      return await this.#recordWorkflowOutcome(client, workflowID, StatusString.SUCCESS, { output: status.output });
     } finally {
       client.release();
     }
   }
 
   @dbRetry()
-  async recordWorkflowError(workflowID: string, status: WorkflowStatusInternal): Promise<void> {
+  async recordWorkflowError(workflowID: string, status: WorkflowStatusInternal): Promise<boolean> {
     const client = await this.pool.connect();
     try {
-      await this.#recordWorkflowOutcome(client, workflowID, StatusString.ERROR, { error: status.error });
+      return await this.#recordWorkflowOutcome(client, workflowID, StatusString.ERROR, { error: status.error });
     } finally {
       client.release();
     }
   }
 
-  // Record a workflow's terminal outcome (SUCCESS or ERROR), but never overwrite
-  // the terminal CANCELLED status: a workflow can be cancelled during its final
-  // step, and if so it must not be able to subsequently complete. If the
-  // workflow is cancelled, abort the function so it does not complete. This
-  // mirrors the cancellation check done before each step.
+  // Record a workflow's terminal outcome (SUCCESS or ERROR), reporting whether
+  // the write landed. The write applies only to a PENDING row: a run owns its
+  // workflow's outcome exactly as long as the row says that run is what the
+  // workflow is doing. (Note: this does not prevent a write when another
+  // concurrent execution is already running and the status is PENDING. However,
+  // both executions should be deterministic and idempotent.)
+  //
+  // Returning false means the row was CANCELLED, dead-lettered, already
+  // terminal, or handed to another execution (ENQUEUED/DELAYED, e.g. by a
+  // concurrent resume). If the row does not exist at all, a
+  // DBOSNonExistentWorkflowError is thrown.
   async #recordWorkflowOutcome(
     client: PoolClient,
     workflowID: string,
     status: (typeof StatusString)[keyof typeof StatusString],
     outcome: { output?: string | null; error?: string | null },
-  ): Promise<void> {
-    let cancelled = false;
-    try {
-      await client.query('BEGIN');
-      await this.updateWorkflowStatus(client, workflowID, status, {
-        update: { ...outcome, resetDeduplicationID: true, setCompletedAt: true },
-        where: { notStatus: StatusString.CANCELLED },
-        throwOnFailure: false,
-      });
-      cancelled = (await this.getWorkflowStatusValue(client, workflowID)) === StatusString.CANCELLED;
-      await client.query('COMMIT');
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
+  ): Promise<boolean> {
+    const rowCount = await this.updateWorkflowStatus(client, workflowID, status, {
+      update: { ...outcome, resetDeduplicationID: true, setCompletedAt: true },
+      where: { status: StatusString.PENDING },
+      throwOnFailure: false,
+    });
+    if (rowCount > 0) {
+      return true;
     }
-    if (cancelled) {
-      throw new DBOSWorkflowCancelledError(workflowID);
+    // The guarded UPDATE matched no rows. Re-read (only on this rare no-op path)
+    // to distinguish a row this run no longer owns from a row that is gone.
+    const currentStatus = await this.getWorkflowStatusValue(client, workflowID);
+    if (currentStatus === undefined) {
+      throw new DBOSNonExistentWorkflowError(`Workflow ${workflowID} does not exist`);
     }
+    return false;
   }
 
   async getPendingWorkflows(executorID: string, appVersion: string): Promise<GetPendingWorkflowsOutput[]> {
@@ -4433,7 +4437,7 @@ export class SystemDatabase {
       };
       throwOnFailure?: boolean;
     } = {},
-  ): Promise<void> {
+  ): Promise<number> {
     // Use SQL now() so updated_at and completed_at (when set together) are
     // computed in the same statement against the same clock.
     const nowMsExpr = `(EXTRACT(EPOCH FROM now()) * 1000)::bigint`;
@@ -4508,6 +4512,7 @@ export class SystemDatabase {
     if (throwOnFailure && result.rowCount !== 1) {
       throw new DBOSWorkflowConflictError(`Attempt to record transition of nonexistent workflow ${workflowID}`);
     }
+    return result.rowCount ?? 0;
   }
 
   private async recordOperationResultInternal(

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1107,9 +1107,9 @@ export class SystemDatabase {
   // both executions should be deterministic and idempotent.)
   //
   // Returning false means the row was CANCELLED, dead-lettered, already
-  // terminal, or handed to another execution (ENQUEUED/DELAYED, e.g. by a
-  // concurrent resume). If the row does not exist at all, a
-  // DBOSNonExistentWorkflowError is thrown.
+  // terminal, handed to another execution (ENQUEUED/DELAYED, e.g. by a
+  // concurrent resume), or deleted; the caller resolves which by awaiting the
+  // recorded outcome.
   async #recordWorkflowOutcome(
     client: PoolClient,
     workflowID: string,
@@ -1121,16 +1121,7 @@ export class SystemDatabase {
       where: { status: StatusString.PENDING },
       throwOnFailure: false,
     });
-    if (rowCount > 0) {
-      return true;
-    }
-    // The guarded UPDATE matched no rows. Re-read (only on this rare no-op path)
-    // to distinguish a row this run no longer owns from a row that is gone.
-    const currentStatus = await this.getWorkflowStatusValue(client, workflowID);
-    if (currentStatus === undefined) {
-      throw new DBOSNonExistentWorkflowError(`Workflow ${workflowID} does not exist`);
-    }
-    return false;
+    return rowCount > 0;
   }
 
   async getPendingWorkflows(executorID: string, appVersion: string): Promise<GetPendingWorkflowsOutput[]> {
@@ -2151,12 +2142,18 @@ export class SystemDatabase {
   }
 
   @dbRetry()
+  // A missing row normally means the workflow has not been inserted yet, so
+  // polling for it is correct. Callers that know the row must already exist
+  // (e.g. a run parking on an outcome it just failed to write) pass
+  // `failIfMissing` to fail fast with DBOSNonExistentWorkflowError instead of
+  // polling forever.
   async awaitWorkflowResult(
     workflowID: string,
     timeoutSeconds?: number,
     callerID?: string,
     timerFuncID?: number,
     pollingIntervalMs?: number,
+    failIfMissing?: boolean,
   ): Promise<SystemDatabaseStoredResult | undefined> {
     const timeoutms = timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined;
     let finishTime = timeoutms !== undefined ? Date.now() + timeoutms : undefined;
@@ -2170,32 +2167,35 @@ export class SystemDatabase {
 
     while (true) {
       if (callerID) await this.#checkIfCanceledLimited(callerID);
+      let rows: workflow_status[];
       try {
-        const { rows } = await this.#pollWithLimiter(() =>
+        ({ rows } = await this.#pollWithLimiter(() =>
           this.pool.query<workflow_status>(
             `SELECT status, output, error, serialization FROM "${this.schemaName}".workflow_status
              WHERE workflow_uuid=$1`,
             [workflowID],
           ),
-        );
-        if (rows.length > 0) {
-          const status = rows[0].status;
-          if (status === StatusString.SUCCESS) {
-            return { output: rows[0].output, serialization: rows[0].serialization };
-          } else if (status === StatusString.ERROR) {
-            return { error: rows[0].error, serialization: rows[0].serialization };
-          } else if (status === StatusString.CANCELLED) {
-            return { cancelled: true };
-          } else if (status === StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED) {
-            return { maxRecoveryAttemptsExceeded: true };
-          } else {
-            // Status is not actionable
-          }
-        }
+        ));
       } catch (e) {
         const err = e as Error;
         this.logger.error(`Exception from system database: ${err}`, err);
         throw err;
+      }
+      if (rows.length > 0) {
+        const status = rows[0].status;
+        if (status === StatusString.SUCCESS) {
+          return { output: rows[0].output, serialization: rows[0].serialization };
+        } else if (status === StatusString.ERROR) {
+          return { error: rows[0].error, serialization: rows[0].serialization };
+        } else if (status === StatusString.CANCELLED) {
+          return { cancelled: true };
+        } else if (status === StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED) {
+          return { maxRecoveryAttemptsExceeded: true };
+        } else {
+          // Status is not actionable
+        }
+      } else if (failIfMissing) {
+        throw new DBOSNonExistentWorkflowError(`Workflow ${workflowID} does not exist`);
       }
 
       const ct = Date.now();

--- a/tests/outcome_ownership.test.ts
+++ b/tests/outcome_ownership.test.ts
@@ -7,6 +7,7 @@ import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import { DBOS, StatusString } from '../src';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
 import {
+  DBOSAwaitedWorkflowCancelledError,
   DBOSMaxRecoveryAttemptsExceededError,
   DBOSNonExistentWorkflowError,
   DBOSWorkflowCancelledError,
@@ -18,15 +19,25 @@ import { NodeTracerProvider } from './nodetraceprovider';
 
 // Each run blocks until the test has rewritten its row, then returns a
 // result the test can tell apart from anything recorded out-of-band.
-const controls = new Map<string, { started: Event; release: Event }>();
+// `workflowID`/`stepID` are published by the run itself, for the cases where
+// the test has to address a workflow (or a step checkpoint) whose identity it
+// does not choose.
+type Control = { started: Event; release: Event; workflowID?: string; stepID?: number };
+const controls = new Map<string, Control>();
+
+function control(id: string): Control {
+  const ctrl = controls.get(id);
+  if (!ctrl) {
+    throw new Error(`no control registered for workflow ${id}`);
+  }
+  return ctrl;
+}
 
 class OutcomeOwnership {
   @DBOS.workflow()
   static async blockedWorkflow(id: string): Promise<string> {
-    const ctrl = controls.get(id);
-    if (!ctrl) {
-      throw new Error(`no control registered for workflow ${id}`);
-    }
+    const ctrl = control(id);
+    ctrl.workflowID = DBOS.workflowID;
     ctrl.started.set();
     await ctrl.release.wait();
     return 'own-result';
@@ -36,21 +47,60 @@ class OutcomeOwnership {
   // cancellation is thrown only after the test has rewritten the row.
   @DBOS.workflow()
   static async selfCancellingWorkflow(id: string): Promise<string> {
-    const ctrl = controls.get(id);
-    if (!ctrl) {
-      throw new Error(`no control registered for workflow ${id}`);
-    }
+    const ctrl = control(id);
+    ctrl.workflowID = DBOS.workflowID;
     ctrl.started.set();
     await ctrl.release.wait();
     throw new DBOSWorkflowCancelledError(id);
   }
+
+  // A run that fails on its own terms: it computes an error, not a result.
+  @DBOS.workflow()
+  static async throwingWorkflow(id: string): Promise<string> {
+    const ctrl = control(id);
+    ctrl.workflowID = DBOS.workflowID;
+    ctrl.started.set();
+    await ctrl.release.wait();
+    throw new Error('own failure');
+  }
+
+  // Blocks inside a step, after the step's function ID is knowable but before
+  // its checkpoint is written, so the test can plant a conflicting checkpoint.
+  @DBOS.workflow()
+  static async blockedStepWorkflow(id: string): Promise<string> {
+    const ctrl = control(id);
+    ctrl.workflowID = DBOS.workflowID;
+    return await DBOS.runStep(
+      async () => {
+        ctrl.stepID = DBOS.stepID;
+        ctrl.started.set();
+        await ctrl.release.wait();
+        return 'own-result';
+      },
+      { name: 'blockedStep' },
+    );
+  }
+
+  // Awaits a child workflow directly, so the child's own cancellation error
+  // propagates into this run unwrapped.
+  @DBOS.workflow()
+  static async parentOfBlockedWorkflow(id: string): Promise<string> {
+    return await OutcomeOwnership.blockedWorkflow(id);
+  }
 }
+
+type BlockingWorkflow =
+  | 'blockedWorkflow'
+  | 'selfCancellingWorkflow'
+  | 'throwingWorkflow'
+  | 'blockedStepWorkflow'
+  | 'parentOfBlockedWorkflow';
 
 // Start a run and return once it is blocked inside the workflow function,
 // with its row PENDING.
-async function startBlockedRun(workflow: 'blockedWorkflow' | 'selfCancellingWorkflow' = 'blockedWorkflow') {
+async function startBlockedRun(workflow: BlockingWorkflow = 'blockedWorkflow') {
   const id = `outcome-ownership-${randomUUID()}`;
-  const ctrl = { started: new Event(), release: new Event() };
+  const ctrl: Control = { started: new Event(), release: new Event() };
   controls.set(id, ctrl);
   const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id })[workflow](id);
   await ctrl.started.wait();
@@ -78,6 +128,19 @@ async function rewriteRowWith(
      SET status=$1, output=$2, error=$3, serialization=COALESCE($4, serialization)
      WHERE workflow_uuid=$5`,
     [status, fields.output ?? null, fields.error ?? null, fields.serialization ?? null, workflowID],
+  );
+}
+
+// Plant the checkpoint the blocked step is about to write, with a different
+// completion time so the step's own write is refused as a conflict. Stands in
+// for the concurrent execution that would have written it in production.
+async function plantConflictingCheckpoint(client: Client, workflowID: string, stepID: number | undefined) {
+  expect(stepID).toBeDefined();
+  await client.query(
+    `INSERT INTO dbos.operation_outputs
+       (workflow_uuid, function_id, function_name, started_at_epoch_ms, completed_at_epoch_ms)
+     VALUES ($1, $2, 'blockedStep', 1, 1)`,
+    [workflowID, stepID],
   );
 }
 
@@ -239,6 +302,127 @@ describe('workflow-outcome-ownership', () => {
 
     await expect(handle.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
+
+  test('failed-run-adopts-the-recorded-outcome-instead-of-its-own-error', async () => {
+    // The ownership rule applies to a run that fails as much as to one that
+    // succeeds: a run whose error write is refused must deliver the recorded
+    // outcome, not the error it computed locally.
+    const { handle, ctrl } = await startBlockedRun('throwingWorkflow');
+    const recorded = await encodeOutput('recorded-elsewhere');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+
+    // The run's own failure must not surface, and must not be recorded.
+    await expect(handle.getResult()).resolves.toBe('recorded-elsewhere');
+    const { rows } = await systemDBClient.query<{ status: string; output: string; error: string | null }>(
+      `SELECT status, output, error FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+    expect(rows[0].output).toBe(recorded.serializedValue);
+    expect(rows[0].error).toBeNull();
+  });
+
+  test('duplicate-execution-releases-the-running-entry-before-parking', async () => {
+    // A conflicting step checkpoint means another execution owns this
+    // workflow's progress. The run must release its running-workflow entry
+    // before parking, so a resume re-dispatched to this executor is not
+    // blocked by the parked run, and then adopt the recorded outcome.
+    const { handle, ctrl } = await startBlockedRun('blockedStepWorkflow');
+    await plantConflictingCheckpoint(systemDBClient, handle.workflowID, ctrl.stepID);
+    // ENQUEUED with no queue name: nothing dequeues it, so the run stays
+    // parked until this test records the outcome itself.
+    await rewriteRow(handle.workflowID, StatusString.ENQUEUED);
+    ctrl.release.set();
+
+    const resultPromise: Promise<{ result?: string; error?: Error }> = handle.getResult().then(
+      (result) => ({ result }),
+      (error: Error) => ({ error }),
+    );
+
+    // The parked run must not hold the running-workflow entry.
+    await retryUntilSuccess(() => {
+      expect(DBOSExecutor.globalInstance!.systemDatabase.checkForRunningWorkflow(handle.workflowID)).toBe(false);
+    }, 30000);
+    const parked = await Promise.race([resultPromise.then(() => false), sleepms(2000).then(() => true)]);
+    expect(parked).toBe(true);
+
+    const recorded = await encodeOutput('recorded-by-owner');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    await expect(resultPromise).resolves.toEqual({ result: 'recorded-by-owner' });
+  }, 60000);
+
+  test('awaited-cancellation-adopts-the-recorded-outcome', async () => {
+    // The parent fails because its child was cancelled, but its row was taken
+    // away while it waited: the recorded outcome wins over the awaited-
+    // cancellation error the parent computed.
+    const { handle, ctrl } = await startBlockedRun('parentOfBlockedWorkflow');
+    const childID = ctrl.workflowID!;
+    expect(childID).not.toBe(handle.workflowID);
+
+    const recorded = await encodeOutput('recorded-elsewhere');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    // Cancel only the child: the parent's outcome comes from its rewritten row.
+    await DBOS.cancelWorkflow(childID);
+    ctrl.release.set();
+
+    await expect(handle.getResult()).resolves.toBe('recorded-elsewhere');
+    const { rows } = await systemDBClient.query<{ status: string; error: string | null }>(
+      `SELECT status, error FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+    expect(rows[0].error).toBeNull();
+  });
+
+  test('failed-run-fails-fast-when-its-row-is-deleted', async () => {
+    // Same fail-fast as the success path, reached through the error path: the
+    // refused error write leaves the run parking on a row it knows existed, so
+    // a missing row must not be read as "not inserted yet" and polled forever.
+    const { handle, ctrl } = await startBlockedRun('throwingWorkflow');
+    await systemDBClient.query(`DELETE FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.workflowID]);
+    ctrl.release.set();
+
+    await expect(handle.getResult()).rejects.toThrow(DBOSNonExistentWorkflowError);
+  });
+
+  test('duplicate-execution-reports-the-workflows-own-cancellation', async () => {
+    // The duplicate-execution outcome is delivered to the workflow's own
+    // handle, so a CANCELLED row must surface as the workflow's cancellation —
+    // not as DBOSAwaitedWorkflowCancelledError, which is what an awaiter of
+    // some other workflow would see.
+    const { handle, ctrl } = await startBlockedRun('blockedStepWorkflow');
+    await plantConflictingCheckpoint(systemDBClient, handle.workflowID, ctrl.stepID);
+    await rewriteRow(handle.workflowID, StatusString.CANCELLED);
+    ctrl.release.set();
+
+    const error = await handle.getResult().then(
+      () => undefined,
+      (e: Error) => e,
+    );
+    expect(error).toBeInstanceOf(DBOSWorkflowCancelledError);
+    expect(error).not.toBeInstanceOf(DBOSAwaitedWorkflowCancelledError);
+  });
+
+  test('duplicate-execution-reports-the-dead-letter-error', async () => {
+    // Same perspective for a dead-lettered row: the duplicate execution must
+    // report the dead-letter error rather than a completion.
+    const { handle, ctrl } = await startBlockedRun('blockedStepWorkflow');
+    await plantConflictingCheckpoint(systemDBClient, handle.workflowID, ctrl.stepID);
+    await rewriteRow(handle.workflowID, StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
+    ctrl.release.set();
+
+    await expect(handle.getResult()).rejects.toThrow(DBOSMaxRecoveryAttemptsExceededError);
+  });
 });
 
 // The workflow span reflects the adopted outcome: `cached` marks a result
@@ -250,13 +434,15 @@ describe('workflow-outcome-ownership-spans', () => {
   let systemDBClient: Client;
   const memoryExporter = new InMemorySpanExporter();
 
-  beforeAll(async () => {
+  beforeAll(() => {
     const provider = new NodeTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
     });
     provider.register();
+    // Same system database as the suite above, already migrated by its
+    // beforeAll. Re-running setUpDBOSTestSysDb here would drop it, which races
+    // with connections that suite has not finished closing.
     config = { ...generateDBOSTestConfig(), tracingEnabled: true };
-    await setUpDBOSTestSysDb(config);
     DBOS.setConfig(config);
   });
 
@@ -327,5 +513,26 @@ describe('workflow-outcome-ownership-spans', () => {
     expect(span).toBeDefined();
     expect(span!.attributes['cached']).toBe(true);
     expect(span!.status.code).toBe(SpanStatusCode.OK);
+  });
+
+  test('adopted-error-on-the-duplicate-execution-path-sets-span-error-and-cached', async () => {
+    // The duplicate-execution path stamps no status up front, so the adopted
+    // error is what must set it: an adopted failure here previously left the
+    // span status unset.
+    const { handle, ctrl } = await startBlockedRun('blockedStepWorkflow');
+    await plantConflictingCheckpoint(systemDBClient, handle.workflowID, ctrl.stepID);
+    const recorded = await encodeError('recorded failure');
+    await rewriteRowWith(systemDBClient, handle.workflowID, StatusString.ERROR, {
+      error: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+    await expect(handle.getResult()).rejects.toThrow('recorded failure');
+
+    const span = workflowSpan(handle.workflowID);
+    expect(span).toBeDefined();
+    expect(span!.attributes['cached']).toBe(true);
+    expect(span!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span!.status.message).toContain('recorded failure');
   });
 });

--- a/tests/outcome_ownership.test.ts
+++ b/tests/outcome_ownership.test.ts
@@ -64,6 +64,18 @@ class OutcomeOwnership {
     throw new Error('own failure');
   }
 
+  // Same as throwingWorkflow, but portable-serialized: reviving a portable
+  // error throws the revived PortableWorkflowError rather than returning it, so
+  // this run's error must not be revived before the ownership decision.
+  @DBOS.workflow({ serialization: 'portable' })
+  static async throwingPortableWorkflow(id: string): Promise<string> {
+    const ctrl = control(id);
+    ctrl.workflowID = DBOS.workflowID;
+    ctrl.started.set();
+    await ctrl.release.wait();
+    throw new Error('portable own failure');
+  }
+
   // Blocks inside a step, after the step's function ID is knowable but before
   // its checkpoint is written, so the test can plant a conflicting checkpoint.
   @DBOS.workflow()
@@ -93,6 +105,7 @@ type BlockingWorkflow =
   | 'blockedWorkflow'
   | 'selfCancellingWorkflow'
   | 'throwingWorkflow'
+  | 'throwingPortableWorkflow'
   | 'blockedStepWorkflow'
   | 'parentOfBlockedWorkflow';
 
@@ -381,6 +394,29 @@ describe('workflow-outcome-ownership', () => {
       [handle.workflowID],
     );
     expect(rows[0].status).toBe(StatusString.SUCCESS);
+    expect(rows[0].error).toBeNull();
+  });
+
+  test('portable-failed-run-adopts-the-recorded-outcome', async () => {
+    // A portable-serialized run reaches the same ownership decision as any
+    // other. Its error is revived only where the revived error is used, because
+    // reviving a portable error throws it: reviving before the decision would
+    // deliver this run's own failure while the row says the workflow succeeded.
+    const { handle, ctrl } = await startBlockedRun('throwingPortableWorkflow');
+    const recorded = await encodeOutput('recorded-elsewhere');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+
+    await expect(handle.getResult()).resolves.toBe('recorded-elsewhere');
+    const { rows } = await systemDBClient.query<{ status: string; output: string; error: string | null }>(
+      `SELECT status, output, error FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+    expect(rows[0].output).toBe(recorded.serializedValue);
     expect(rows[0].error).toBeNull();
   });
 

--- a/tests/outcome_ownership.test.ts
+++ b/tests/outcome_ownership.test.ts
@@ -3,7 +3,11 @@ import { Client } from 'pg';
 
 import { DBOS, StatusString } from '../src';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
-import { DBOSMaxRecoveryAttemptsExceededError, DBOSNonExistentWorkflowError } from '../src/error';
+import {
+  DBOSMaxRecoveryAttemptsExceededError,
+  DBOSNonExistentWorkflowError,
+  DBOSWorkflowCancelledError,
+} from '../src/error';
 import { serializeResError, serializeValue } from '../src/serialization';
 import { sleepms } from '../src/utils';
 import { Event, generateDBOSTestConfig, retryUntilSuccess, setUpDBOSTestSysDb } from './helpers';
@@ -33,6 +37,19 @@ describe('workflow-outcome-ownership', () => {
       await ctrl.release.wait();
       return 'own-result';
     }
+
+    // Stands in for a run that observes its own cancellation mid-flight: the
+    // cancellation is thrown only after the test has rewritten the row.
+    @DBOS.workflow()
+    static async selfCancellingWorkflow(id: string): Promise<string> {
+      const ctrl = controls.get(id);
+      if (!ctrl) {
+        throw new Error(`no control registered for workflow ${id}`);
+      }
+      ctrl.started.set();
+      await ctrl.release.wait();
+      throw new DBOSWorkflowCancelledError(id);
+    }
   }
 
   beforeAll(async () => {
@@ -54,11 +71,11 @@ describe('workflow-outcome-ownership', () => {
 
   // Start a run and return once it is blocked inside the workflow function,
   // with its row PENDING.
-  async function startBlockedRun() {
+  async function startBlockedRun(workflow: 'blockedWorkflow' | 'selfCancellingWorkflow' = 'blockedWorkflow') {
     const id = `outcome-ownership-${randomUUID()}`;
     const ctrl = { started: new Event(), release: new Event() };
     controls.set(id, ctrl);
-    const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id }).blockedWorkflow(id);
+    const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id })[workflow](id);
     await ctrl.started.wait();
     return { handle, ctrl };
   }
@@ -184,5 +201,29 @@ describe('workflow-outcome-ownership', () => {
 
     // A run whose row vanished must not report a completion.
     await expect(handle.getResult()).rejects.toThrow(DBOSNonExistentWorkflowError);
+  });
+
+  test('cancelled-run-adopts-a-recorded-outcome', async () => {
+    // A run that observes its own cancellation adopts the recorded outcome
+    // rather than trusting its local view: here a concurrent "resume" already
+    // rewrote the row to SUCCESS, so the handle reports that outcome instead
+    // of a cancellation that is no longer the workflow's state.
+    const { handle, ctrl } = await startBlockedRun('selfCancellingWorkflow');
+    const recorded = await encodeOutput('recorded-after-cancel');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+
+    await expect(handle.getResult()).resolves.toBe('recorded-after-cancel');
+  });
+
+  test('cancelled-run-still-reports-cancellation-for-a-cancelled-row', async () => {
+    const { handle, ctrl } = await startBlockedRun('selfCancellingWorkflow');
+    await rewriteRow(handle.workflowID, StatusString.CANCELLED);
+    ctrl.release.set();
+
+    await expect(handle.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
 });

--- a/tests/outcome_ownership.test.ts
+++ b/tests/outcome_ownership.test.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from 'node:crypto';
+import { Client } from 'pg';
+
+import { DBOS, StatusString } from '../src';
+import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSMaxRecoveryAttemptsExceededError, DBOSNonExistentWorkflowError } from '../src/error';
+import { serializeResError, serializeValue } from '../src/serialization';
+import { sleepms } from '../src/utils';
+import { Event, generateDBOSTestConfig, retryUntilSuccess, setUpDBOSTestSysDb } from './helpers';
+
+// A run may record its outcome only while its workflow_status row is still
+// PENDING: that row is what says "this run is what the workflow is doing".
+// Every other status means the run lost ownership (a concurrent resume
+// re-enqueued it, a recovery raced it, it was cancelled or dead-lettered) and
+// the recorded outcome, not the one the run computed, is the workflow's
+// outcome.
+describe('workflow-outcome-ownership', () => {
+  let config: DBOSConfig;
+  let systemDBClient: Client;
+
+  // Each run blocks until the test has rewritten its row, then returns a
+  // result the test can tell apart from anything recorded out-of-band.
+  const controls = new Map<string, { started: Event; release: Event }>();
+
+  class OutcomeOwnership {
+    @DBOS.workflow()
+    static async blockedWorkflow(id: string): Promise<string> {
+      const ctrl = controls.get(id);
+      if (!ctrl) {
+        throw new Error(`no control registered for workflow ${id}`);
+      }
+      ctrl.started.set();
+      await ctrl.release.wait();
+      return 'own-result';
+    }
+  }
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestSysDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    await DBOS.launch();
+    systemDBClient = new Client({ connectionString: config.systemDatabaseUrl });
+    await systemDBClient.connect();
+  });
+
+  afterEach(async () => {
+    await systemDBClient.end();
+    await DBOS.shutdown();
+  });
+
+  // Start a run and return once it is blocked inside the workflow function,
+  // with its row PENDING.
+  async function startBlockedRun() {
+    const id = `outcome-ownership-${randomUUID()}`;
+    const ctrl = { started: new Event(), release: new Event() };
+    controls.set(id, ctrl);
+    const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id }).blockedWorkflow(id);
+    await ctrl.started.wait();
+    return { handle, ctrl };
+  }
+
+  // Encode a value/error the way the workflow's outcome would be recorded.
+  async function encodeOutput(value: string) {
+    return await serializeValue(value, DBOSExecutor.globalInstance!.serializer, undefined);
+  }
+  async function encodeError(message: string) {
+    return await serializeResError(new Error(message), DBOSExecutor.globalInstance!.serializer, undefined);
+  }
+
+  // Take the row away from the blocked run, standing in for the concurrent
+  // resume/recovery/cancel that would do it in production.
+  async function rewriteRow(
+    workflowID: string,
+    status: (typeof StatusString)[keyof typeof StatusString],
+    fields: { output?: string | null; error?: string | null; serialization?: string | null } = {},
+  ) {
+    await systemDBClient.query(
+      `UPDATE dbos.workflow_status
+       SET status=$1, output=$2, error=$3, serialization=COALESCE($4, serialization)
+       WHERE workflow_uuid=$5`,
+      [status, fields.output ?? null, fields.error ?? null, fields.serialization ?? null, workflowID],
+    );
+  }
+
+  test('recorded-success-supersedes-the-run-result', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    const recorded = await encodeOutput('recorded-elsewhere');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+
+    // The run must report the recorded output, not its own.
+    await expect(handle.getResult()).resolves.toBe('recorded-elsewhere');
+
+    // The recorded output must not be overwritten.
+    const { rows } = await systemDBClient.query<{ status: string; output: string }>(
+      `SELECT status, output FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+    expect(rows[0].output).toBe(recorded.serializedValue);
+  });
+
+  test('recorded-error-supersedes-the-run-result', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    const recorded = await encodeError('recorded failure');
+    await rewriteRow(handle.workflowID, StatusString.ERROR, {
+      error: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+
+    // The recorded error must be adopted.
+    await expect(handle.getResult()).rejects.toThrow('recorded failure');
+    await expect(DBOS.getWorkflowStatus(handle.workflowID)).resolves.toMatchObject({ status: StatusString.ERROR });
+  });
+
+  test('non-terminal-row-parks-the-run-until-an-outcome-is-recorded', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    // ENQUEUED with no queue name: nothing dequeues it, so the run stays
+    // parked until this test records the outcome itself.
+    await rewriteRow(handle.workflowID, StatusString.ENQUEUED);
+    ctrl.release.set();
+
+    const resultPromise: Promise<{ result?: string; error?: Error }> = handle.getResult().then(
+      (result) => ({ result }),
+      (error: Error) => ({ error }),
+    );
+
+    // The run releases its running-workflow entry immediately before it tries
+    // to record its outcome. Waiting for that makes the check below assert
+    // that the run parked, rather than merely that it had not gotten around to
+    // the write yet.
+    await retryUntilSuccess(() => {
+      expect(DBOSExecutor.globalInstance!.systemDatabase.checkForRunningWorkflow(handle.workflowID)).toBe(false);
+    }, 30000);
+
+    // The run must wait for the owning execution.
+    const parked = await Promise.race([resultPromise.then(() => false), sleepms(2000).then(() => true)]);
+    expect(parked).toBe(true);
+
+    const recorded = await encodeOutput('recorded-by-owner');
+    await rewriteRow(handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+
+    // The parked run must adopt the recorded outcome, not its own.
+    await expect(resultPromise).resolves.toEqual({ result: 'recorded-by-owner' });
+  }, 60000);
+
+  test('dead-lettered-row-fails-the-run', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    await rewriteRow(handle.workflowID, StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
+    // A dead-lettered row carries an exhausted retry budget.
+    await systemDBClient.query(`UPDATE dbos.workflow_status SET recovery_attempts=$1 WHERE workflow_uuid=$2`, [
+      100,
+      handle.workflowID,
+    ]);
+    ctrl.release.set();
+
+    // A dead-lettered workflow must not report a completion.
+    await expect(handle.getResult()).rejects.toThrow(DBOSMaxRecoveryAttemptsExceededError);
+
+    // The refused outcome must not have recorded an output.
+    const { rows } = await systemDBClient.query<{ status: string; output: string | null }>(
+      `SELECT status, output FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [handle.workflowID],
+    );
+    expect(rows[0].status).toBe(StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
+    expect(rows[0].output).toBeNull();
+  });
+
+  test('deleted-row-fails-the-run-with-non-existent-workflow', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    await systemDBClient.query(`DELETE FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.workflowID]);
+    ctrl.release.set();
+
+    // A run whose row vanished must not report a completion.
+    await expect(handle.getResult()).rejects.toThrow(DBOSNonExistentWorkflowError);
+  });
+});

--- a/tests/outcome_ownership.test.ts
+++ b/tests/outcome_ownership.test.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { Client } from 'pg';
 
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+
 import { DBOS, StatusString } from '../src';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
 import {
@@ -11,6 +14,72 @@ import {
 import { serializeResError, serializeValue } from '../src/serialization';
 import { sleepms } from '../src/utils';
 import { Event, generateDBOSTestConfig, retryUntilSuccess, setUpDBOSTestSysDb } from './helpers';
+import { NodeTracerProvider } from './nodetraceprovider';
+
+// Each run blocks until the test has rewritten its row, then returns a
+// result the test can tell apart from anything recorded out-of-band.
+const controls = new Map<string, { started: Event; release: Event }>();
+
+class OutcomeOwnership {
+  @DBOS.workflow()
+  static async blockedWorkflow(id: string): Promise<string> {
+    const ctrl = controls.get(id);
+    if (!ctrl) {
+      throw new Error(`no control registered for workflow ${id}`);
+    }
+    ctrl.started.set();
+    await ctrl.release.wait();
+    return 'own-result';
+  }
+
+  // Stands in for a run that observes its own cancellation mid-flight: the
+  // cancellation is thrown only after the test has rewritten the row.
+  @DBOS.workflow()
+  static async selfCancellingWorkflow(id: string): Promise<string> {
+    const ctrl = controls.get(id);
+    if (!ctrl) {
+      throw new Error(`no control registered for workflow ${id}`);
+    }
+    ctrl.started.set();
+    await ctrl.release.wait();
+    throw new DBOSWorkflowCancelledError(id);
+  }
+}
+
+// Start a run and return once it is blocked inside the workflow function,
+// with its row PENDING.
+async function startBlockedRun(workflow: 'blockedWorkflow' | 'selfCancellingWorkflow' = 'blockedWorkflow') {
+  const id = `outcome-ownership-${randomUUID()}`;
+  const ctrl = { started: new Event(), release: new Event() };
+  controls.set(id, ctrl);
+  const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id })[workflow](id);
+  await ctrl.started.wait();
+  return { handle, ctrl };
+}
+
+// Encode a value/error the way the workflow's outcome would be recorded.
+async function encodeOutput(value: string) {
+  return await serializeValue(value, DBOSExecutor.globalInstance!.serializer, undefined);
+}
+async function encodeError(message: string) {
+  return await serializeResError(new Error(message), DBOSExecutor.globalInstance!.serializer, undefined);
+}
+
+// Take the row away from the blocked run, standing in for the concurrent
+// resume/recovery/cancel that would do it in production.
+async function rewriteRowWith(
+  client: Client,
+  workflowID: string,
+  status: (typeof StatusString)[keyof typeof StatusString],
+  fields: { output?: string | null; error?: string | null; serialization?: string | null } = {},
+) {
+  await client.query(
+    `UPDATE dbos.workflow_status
+     SET status=$1, output=$2, error=$3, serialization=COALESCE($4, serialization)
+     WHERE workflow_uuid=$5`,
+    [status, fields.output ?? null, fields.error ?? null, fields.serialization ?? null, workflowID],
+  );
+}
 
 // A run may record its outcome only while its workflow_status row is still
 // PENDING: that row is what says "this run is what the workflow is doing".
@@ -21,36 +90,6 @@ import { Event, generateDBOSTestConfig, retryUntilSuccess, setUpDBOSTestSysDb } 
 describe('workflow-outcome-ownership', () => {
   let config: DBOSConfig;
   let systemDBClient: Client;
-
-  // Each run blocks until the test has rewritten its row, then returns a
-  // result the test can tell apart from anything recorded out-of-band.
-  const controls = new Map<string, { started: Event; release: Event }>();
-
-  class OutcomeOwnership {
-    @DBOS.workflow()
-    static async blockedWorkflow(id: string): Promise<string> {
-      const ctrl = controls.get(id);
-      if (!ctrl) {
-        throw new Error(`no control registered for workflow ${id}`);
-      }
-      ctrl.started.set();
-      await ctrl.release.wait();
-      return 'own-result';
-    }
-
-    // Stands in for a run that observes its own cancellation mid-flight: the
-    // cancellation is thrown only after the test has rewritten the row.
-    @DBOS.workflow()
-    static async selfCancellingWorkflow(id: string): Promise<string> {
-      const ctrl = controls.get(id);
-      if (!ctrl) {
-        throw new Error(`no control registered for workflow ${id}`);
-      }
-      ctrl.started.set();
-      await ctrl.release.wait();
-      throw new DBOSWorkflowCancelledError(id);
-    }
-  }
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
@@ -69,38 +108,12 @@ describe('workflow-outcome-ownership', () => {
     await DBOS.shutdown();
   });
 
-  // Start a run and return once it is blocked inside the workflow function,
-  // with its row PENDING.
-  async function startBlockedRun(workflow: 'blockedWorkflow' | 'selfCancellingWorkflow' = 'blockedWorkflow') {
-    const id = `outcome-ownership-${randomUUID()}`;
-    const ctrl = { started: new Event(), release: new Event() };
-    controls.set(id, ctrl);
-    const handle = await DBOS.startWorkflow(OutcomeOwnership, { workflowID: id })[workflow](id);
-    await ctrl.started.wait();
-    return { handle, ctrl };
-  }
-
-  // Encode a value/error the way the workflow's outcome would be recorded.
-  async function encodeOutput(value: string) {
-    return await serializeValue(value, DBOSExecutor.globalInstance!.serializer, undefined);
-  }
-  async function encodeError(message: string) {
-    return await serializeResError(new Error(message), DBOSExecutor.globalInstance!.serializer, undefined);
-  }
-
-  // Take the row away from the blocked run, standing in for the concurrent
-  // resume/recovery/cancel that would do it in production.
-  async function rewriteRow(
+  function rewriteRow(
     workflowID: string,
     status: (typeof StatusString)[keyof typeof StatusString],
     fields: { output?: string | null; error?: string | null; serialization?: string | null } = {},
   ) {
-    await systemDBClient.query(
-      `UPDATE dbos.workflow_status
-       SET status=$1, output=$2, error=$3, serialization=COALESCE($4, serialization)
-       WHERE workflow_uuid=$5`,
-      [status, fields.output ?? null, fields.error ?? null, fields.serialization ?? null, workflowID],
-    );
+    return rewriteRowWith(systemDBClient, workflowID, status, fields);
   }
 
   test('recorded-success-supersedes-the-run-result', async () => {
@@ -225,5 +238,94 @@ describe('workflow-outcome-ownership', () => {
     ctrl.release.set();
 
     await expect(handle.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
+  });
+});
+
+// The workflow span reflects the adopted outcome: `cached` marks a result
+// served from the store rather than computed by this run, and the final span
+// status follows the adopted result, overriding anything stamped before
+// parking.
+describe('workflow-outcome-ownership-spans', () => {
+  let config: DBOSConfig;
+  let systemDBClient: Client;
+  const memoryExporter = new InMemorySpanExporter();
+
+  beforeAll(async () => {
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
+    provider.register();
+    config = { ...generateDBOSTestConfig(), tracingEnabled: true };
+    await setUpDBOSTestSysDb(config);
+    DBOS.setConfig(config);
+  });
+
+  afterAll(() => {
+    trace.disable();
+    context.disable();
+  });
+
+  beforeEach(async () => {
+    memoryExporter.reset();
+    await DBOS.launch();
+    systemDBClient = new Client({ connectionString: config.systemDatabaseUrl });
+    await systemDBClient.connect();
+  });
+
+  afterEach(async () => {
+    await systemDBClient.end();
+    await DBOS.shutdown();
+  });
+
+  function workflowSpan(workflowID: string) {
+    return memoryExporter.getFinishedSpans().find((s) => s.attributes['operationUUID'] === workflowID);
+  }
+
+  test('adopted-success-sets-span-ok-and-cached', async () => {
+    const { handle, ctrl } = await startBlockedRun();
+    const recorded = await encodeOutput('recorded-elsewhere');
+    await rewriteRowWith(systemDBClient, handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+    await expect(handle.getResult()).resolves.toBe('recorded-elsewhere');
+
+    const span = workflowSpan(handle.workflowID);
+    expect(span).toBeDefined();
+    expect(span!.attributes['cached']).toBe(true);
+    expect(span!.status.code).toBe(SpanStatusCode.OK);
+  });
+
+  test('adopted-cancellation-sets-span-error-and-cached', async () => {
+    const { handle, ctrl } = await startBlockedRun('selfCancellingWorkflow');
+    await rewriteRowWith(systemDBClient, handle.workflowID, StatusString.CANCELLED);
+    ctrl.release.set();
+    await expect(handle.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
+
+    const span = workflowSpan(handle.workflowID);
+    expect(span).toBeDefined();
+    expect(span!.attributes['cached']).toBe(true);
+    expect(span!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span!.status.message).toContain('cancelled');
+  });
+
+  test('cancelled-run-adopting-a-recorded-success-sets-span-ok', async () => {
+    // The cancellation branch stamps no ERROR up front: when the adopted
+    // outcome is a success (a resume raced the cancellation), the span must
+    // report OK.
+    const { handle, ctrl } = await startBlockedRun('selfCancellingWorkflow');
+    const recorded = await encodeOutput('recorded-after-cancel');
+    await rewriteRowWith(systemDBClient, handle.workflowID, StatusString.SUCCESS, {
+      output: recorded.serializedValue,
+      serialization: recorded.serialization,
+    });
+    ctrl.release.set();
+    await expect(handle.getResult()).resolves.toBe('recorded-after-cancel');
+
+    const span = workflowSpan(handle.workflowID);
+    expect(span).toBeDefined();
+    expect(span!.attributes['cached']).toBe(true);
+    expect(span!.status.code).toBe(SpanStatusCode.OK);
   });
 });


### PR DESCRIPTION
Update the workflow's terminal-outcome write (`recordWorkflowOutput`/`recordWorkflowError`) to apply only while the workflow's row is still PENDING.

Recording the workflow outcome can result either in actually recording the  outcome (the common path), or parking and returning the result / rethrowing the error from the database.

If, during the outcome update attempt, it turns out the workflow doesn't exist anymore, throw a `DBOSNonExistentWorkflowError`

This does not solve the race if another execution has resumed and the workflow is PENDING -- but in this case the outcome should be deterministic and idempotent.

Port of dbos-inc/dbos-transact-golang#417.
